### PR TITLE
added default suffix for world save to PNG

### DIFF
--- a/minutor.cpp
+++ b/minutor.cpp
@@ -127,7 +127,9 @@ void Minutor::reload()
 
 void Minutor::save()
 {
-	QString filename = QFileDialog::getSaveFileName(this,tr("Save PNG"),QString(),"*.png");
+	QFileDialog fileDialog(this);
+	fileDialog.setDefaultSuffix("png");
+	QString filename = fileDialog.getSaveFileName(this,tr("Save world as PNG"),QString(),"*.png");
 	if (!filename.isEmpty())
 	{
 		WorldSave *ws=new WorldSave(filename,mapview);


### PR DESCRIPTION
fix #34: now a default suffix ".png" is added when a filename without a
suffix was given.
