### PR TITLE
collision free hashing for ChunkID

### DIFF
--- a/chunkcache.cpp
+++ b/chunkcache.cpp
@@ -37,7 +37,8 @@ bool ChunkID::operator==(const ChunkID &other) const
 }
 uint qHash(const ChunkID &c)
 {
-	return c.x^c.z;	//quick way to hash a pair of integers
+//	return c.x^c.z;	//quick way to hash a pair of integers
+	return qHash(c.x) ^ qHash(c.z); //safe way to hash a pair of integers
 }
 
 ChunkCache::ChunkCache()


### PR DESCRIPTION
The "quick way to hash a pair of integers" can also generate collisions. As it is a simple XOR for X and Z coordinate, several collisions are generated with typical coordinates. Some examples:
x=0 z=1 -> 1 / x=1 z=0 -> 1
x=2 z=0 -> 2 / x=0 z=2 -> 2 / x=6 z=4 -> 2
...
At my tests Qt was adding some seed, so it worked anyway. But it should be safer to use non-colliding hashes so it will work even when Qt changes the internal implementation.
