### PR TITLE
final block ID update for upcomming 1.8

### DIFF
--- a/blockidentifier.cpp
+++ b/blockidentifier.cpp
@@ -305,10 +305,13 @@ void BlockIdentifier::parseDefinition(JSONObject *b, BlockInfo *parent, int pack
 	}
 	else
 		block->alpha=0.0;
+
 	if (b->has("mask"))
 		block->mask=b->at("mask")->asNumber();
-	else
+	else if (b->has("variants"))
 		block->mask=0x0f;
+	else
+		block->mask=0x00;
 
 	if (b->has("variants"))
 	{

--- a/definitions/readme.txt
+++ b/definitions/readme.txt
@@ -51,9 +51,22 @@ to be flagged with
   "spawninside": true
 
 
-All this information is gathered directly from the 1.6.4 source code or special
-test setup per block in 1.8 snapshots. As at the moment deobfuscated 1.7.x or
-1.8.x code is not available.
+All this information is gathered directly from the 1.6.4 - 1.7.10 source code
+or special test setup per block in development snapshots. As at the moment
+deobfuscated 1.8.x code is not available.
+
+
+
+Other special attribute value pairs in this file:
+
+"mask": number
+
+In case a block has variants a mask can be given to blend out bits in the data
+field that are not used to define the block itself. These bits are mostely used
+to define block orientation.
+ if a block has no variants defined,   "mask":  0 is predefined
+ if a block has some variants defined, "mask": 15 is predefined
+
 
 
 [EtlamGit]

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -75,32 +75,32 @@
     },
     {
       "id": 5,
-      "name": "Oak Plank",
+      "name": "Oak Wood Plank",
       "color": "b4905a",
       "variants": [
         {
           "data": 1,
-          "name": "Spruce Plank",
+          "name": "Spruce Wood Plank",
           "color": "805e36"
         },
         {
           "data": 2,
-          "name": "Birch Plank",
+          "name": "Birch Wood Plank",
           "color": "c8b77a"
         },
         {
           "data": 3,
-          "name": "Jungle Plank",
+          "name": "Jungle Wood Plank",
           "color": "b1805c"
         },
         {
           "data": 4,
-          "name": "Acacia Plank",
+          "name": "Acacia Wood Plank",
           "color": "ba6337"
         },
         {
           "data": 5,
-          "name": "Dark Oak Plank",
+          "name": "Dark Oak Wood Plank",
           "color": "462d15"
         }
       ]
@@ -542,12 +542,12 @@
     },
     {
       "id": 41,
-      "name": "Gold Block",
+      "name": "Block of Gold",
       "color": "fdfb4f"
     },
     {
       "id": 42,
-      "name": "Iron Block",
+      "name": "Block of Iron",
       "color": "e6e6e6"
     },
     {
@@ -716,7 +716,7 @@
     },
     {
       "id": 57,
-      "name": "Diamond Block",
+      "name": "Block of Diamond",
       "color": "91e8e4"
     },
     {
@@ -940,12 +940,12 @@
     },
     {
       "id": 91,
-      "name": "Jack o' Lantern",
+      "name": "Jack o'Lantern",
       "color": "e9b416"
     },
     {
       "id": 92,
-      "name": "Cake Block",
+      "name": "Cake",
       "color": "eae9eb",
       "transparent": true
     },
@@ -1055,16 +1055,33 @@
     },
     {
       "id": 97,
-      "name": "Monster Egg",
-      "color": "767676",
+      "name": "Stone Monster Egg",
+      "color": "7a7a7a",
       "variants": [
         {
           "data": 1,
-          "color": "919191"
+          "name": "Cobblestone Monster Egg",
+          "color": "787878"
         },
         {
           "data": 2,
-          "color": "7b7b7b"
+          "name": "Stone Brick Monster Egg",
+          "color": "777777"
+        },
+        {
+          "data": 3,
+          "name": "Mossy Stone Brick Monster Egg",
+          "color": "707467"
+        },
+        {
+          "data": 4,
+          "name": "Cracked Stone Brick Monster Egg",
+          "color": "747474"
+        },
+        {
+          "data": 5,
+          "name": "Chiseled Stone Brick Monster Egg",
+          "color": "747474"
         }
       ]
     },
@@ -1130,6 +1147,18 @@
         {
           "data": 9,
           "color": "8f6b53"
+        },
+        {
+          "data": 10,
+          "color": "d2b17d"
+        },
+        {
+          "data": 14,
+          "color": "8f6b53"
+        },
+        {
+          "data": 15,
+          "color": "cdc9bf"
         }
       ]
     },
@@ -1173,6 +1202,18 @@
         {
           "data": 9,
           "color": "b51d1b"
+        },
+        {
+          "data": 10,
+          "color": "d2b17d"
+        },
+        {
+          "data": 14,
+          "color": "b51d1b"
+        },
+        {
+          "data": 15,
+          "color": "cdc9bf"
         }
       ]
     },
@@ -1335,66 +1376,66 @@
     },
     {
       "id": 125,
-      "name": "Double Oak Slab",
+      "name": "Double Oak Wood Slab",
       "color": "b4905a",
       "variants": [
         {
           "data": 1,
-          "name": "Double Spruce Slab",
+          "name": "Double Spruce Wood Slab",
           "color": "664f2f"
         },
         {
           "data": 2,
-          "name": "Double Birch Slab",
+          "name": "Double Birch Wood Slab",
           "color": "d7cb8d"
         },
         {
           "data": 3,
-          "name": "Double Jungle Slab",
+          "name": "Double Jungle Wood Slab",
           "color": "b1805c"
         },
         {
           "data": 4,
-          "name": "Double Acacia Slab",
+          "name": "Double Acacia Wood Slab",
           "color": "ad5d32"
         },
         {
           "data": 5,
-          "name": "Double Dark Oak Slab",
+          "name": "Double Dark Oak Wood Slab",
           "color": "462d15"
         }
       ]
     },
     {
       "id": 126,
-      "name": "Oak Slab",
+      "name": "Oak Wood Slab",
       "color": "b4905a",
       "mask": 7,
       "transparent": true,
       "variants": [
         {
           "data": 1,
-          "name": "Spruce Slab",
+          "name": "Spruce Wood Slab",
           "color": "664f2f"
         },
         {
           "data": 2,
-          "name": "Birch Slab",
+          "name": "Birch Wood Slab",
           "color": "d7cb8d"
         },
         {
           "data": 3,
-          "name": "Jungle Slab",
+          "name": "Jungle Wood Slab",
           "color": "b1805c"
         },
         {
           "data": 4,
-          "name": "Acacia Slab",
+          "name": "Acacia Wood Slab",
           "color": "ba6337"
         },
         {
           "data": 5,
-          "name": "Dark Oak Slab",
+          "name": "Dark Oak Wood Slab",
           "color": "462d15"
         }
       ]
@@ -1447,7 +1488,7 @@
     },
     {
       "id": 133,
-      "name": "Emerald Block",
+      "name": "Block of Emerald",
       "color": "64ea8a"
     },
     {
@@ -1544,6 +1585,16 @@
           "data": 11,
           "name": "Flower Pot (fern)",
           "color": "315e05"
+        },
+        {
+          "data": 12,
+          "name": "Flower Pot (acacia)",
+          "color": "946428"
+        },
+        {
+          "data": 13,
+          "name": "Flower Pot (dark oak)",
+          "color": "315e05"
         }
       ]
     },
@@ -1591,7 +1642,18 @@
       "id": 145,
       "name": "Anvil",
       "color": "474747",
-      "transparent": true
+      "transparent": true,
+      "mask": 12,
+      "variants": [
+        {
+          "data": 4,
+          "name": "Slightly Damaged Anvil"
+        },
+        {
+          "data": 8,
+          "name": "Very Damaged Anvil"
+        }
+      ]
     },
     {
       "id": 146,
@@ -1639,7 +1701,7 @@
     },
     {
       "id": 152,
-      "name": "Redstone Block",
+      "name": "Block of Redstone",
       "color": "bb1c0a",
       "transparent": true,
       "canProvidePower": true
@@ -1657,7 +1719,7 @@
     },
     {
       "id": 155,
-      "name": "Quartz Block",
+      "name": "Block of Quartz",
       "color": "edebe5",
       "variants": [
         {
@@ -2040,7 +2102,7 @@
     },
     {
       "id": 173,
-      "name": "Coal Block",
+      "name": "Block of Coal",
       "color": "2b2b2b"
     },
     {


### PR DESCRIPTION
I finished checking for missing blocks and other errors.
As Minecraft 1.8 is announced for tomorrow, I would assume, that the number of players asking for an updated version of Minutor will increase significantly. So it is probably a good idea to provide an update before they flood the issue tracker...
On short term, I will not be able to work on the other open topics located in branches. So these may have to wait for the next update (Christmas?). But I will work on them in the following order: widget focus changes, Windows 64bit builds and dynamic chunk cache size for larger monitors.
