### PR TITLE
automatic chunk cache size based on available memory

### DIFF
--- a/chunkcache.cpp
+++ b/chunkcache.cpp
@@ -58,7 +58,7 @@ ChunkCache::ChunkCache()
 	MEMORYSTATUSEX status;
 	status.dwLength = sizeof(status);
 	GlobalMemoryStatusEx(&status);
-	DWORDLONG available = std::min(status.ullAvailPhys, status.ullAvailVirtual);
+    DWORDLONG available = std::min<DWORDLONG>(status.ullAvailPhys, status.ullAvailVirtual);
 	chunks = available / (sizeof(Chunk) + 16*sizeof(ChunkSection));
 #endif
 	cache.setMaxCost(chunks);
@@ -115,7 +115,7 @@ void ChunkCache::gotChunk(int x,int z)
 	emit chunkLoaded(x,z);
 }
 
-void ChunkCache::apaptCacheToWindow(int x,int y)
+void ChunkCache::adaptCacheToWindow(int x,int y)
 {
 	int chunks=((x+15)>>4)*((y+15)>>4); // number of chunks visible in window
 	chunks *= 1.10; // add 10%

--- a/chunkcache.h
+++ b/chunkcache.h
@@ -59,7 +59,7 @@ signals:
 	void chunkLoaded(int x,int z);
 
 public slots:
-	void apaptCacheToWindow(int x,int y);
+    void adaptCacheToWindow(int x,int y);
 
 private slots:
 	void gotChunk(int x,int z);


### PR DESCRIPTION
As I always have problems with too small chunk cache on larger monitors,
I added an automatic calculation of the maximum size based on the
available memory. There is also a new slot alowing to change the cache
size based on a given window/desktop/monitor size.

For Windows x32 and x64 builds have to be handled separately, as this
changes the memory available to a process.
The Linux code is not fully tested, but should work in principle. It
would be great if someone could do deeper tests here.
