### PR TITLE
fix for double tall flowers

### DIFF
--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -2153,6 +2153,13 @@
           "color": "ffffff",
           "alpha": 0.0
         }
+,
+        {
+          "data": 10,
+          "name": "Large Flower (top part)",
+          "color": "ffffff",
+          "alpha": 0.0
+        }
       ]
     },
     {


### PR DESCRIPTION
it seems that the data value can have 8 and 10 for the upper part of
tall flowers/grass

(no idea what caused the double commit)