### PR TITLE
Changed Depth shading to produce a more visible shade.

### DIFF
--- a/mapview.cpp
+++ b/mapview.cpp
@@ -503,9 +503,13 @@ void MapView::renderChunk(Chunk *chunk)
 				quint32 colb = color & 0xff;
 				if (flags & flgDepthShading)
 				{
-					colr = colr * (256 - (depth - y)) / 256;
-					colg = colg * (256 - (depth - y)) / 256;
-					colb = colb * (256 - (depth - y)) / 256;
+					// Use a table to define depth-relative shade:
+					static const quint32 shadeTable[] = {0, 12, 18, 22, 24, 26, 28, 29, 30, 31, 32};
+					size_t idx = std::min(static_cast<size_t>(depth - y), sizeof(shadeTable) / sizeof(*shadeTable) - 1);
+					quint32 shade = shadeTable[idx];
+					colr = colr - std::min(shade, colr);
+					colg = colg - std::min(shade, colg);
+					colb = colb - std::min(shade, colb);
 				}
 				if (flags & flgMobSpawn)
 				{


### PR DESCRIPTION
The first step down Y-wise is the biggest difference, additional steps have less impact on the shade.

Visual comparison for the same area of a world:
before:
![minutor depth shading before](https://cloud.githubusercontent.com/assets/4388386/10059125/7bb3021e-6249-11e5-96f4-363e9dd1eb41.png)

this PR:
![minutor depth shading after](https://cloud.githubusercontent.com/assets/4388386/10059133/898f93ac-6249-11e5-87a7-6b8d8d15ca41.png)
