### PR TITLE
fix Entity rendering depth

### DIFF
--- a/entity.cpp
+++ b/entity.cpp
@@ -51,14 +51,14 @@ QSharedPointer<OverlayItem> Entity::TryParse(Tag* tag)
 bool Entity::intersects(const Point& min, const Point& max) const
 {
 	return min.x <= pos.x && max.x >= pos.x &&
-		   min.y <= pos.y && max.y >= pos.y &&
-		   min.z <= pos.z && max.z >= pos.z;
+	       min.y <= pos.y && max.y >= pos.y &&
+	       min.z <= pos.z && max.z >= pos.z;
 }
 
 void Entity::draw(double offsetX, double offsetZ, double scale, QPainter& canvas) const
 {
 	QPoint center((pos.x - offsetX) * scale,
-				  (pos.z - offsetZ) * scale);
+	              (pos.z - offsetZ) * scale);
 
 	QColor penColor = extraColor;
 	penColor.setAlpha(192);
@@ -66,7 +66,7 @@ void Entity::draw(double offsetX, double offsetZ, double scale, QPainter& canvas
 	pen.setColor(penColor);
 	pen.setWidth(2);
 	canvas.setPen(pen);
-	
+
 	QColor brushColor = color();
 	brushColor.setAlpha(128);
 	canvas.setBrush(brushColor);

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -337,14 +337,14 @@ void MapView::redraw()
 					{
 						//don't show entities above our depth
 						int entityY = (*it)->midpoint().y;
-						if (entityY < depth)
+						if (entityY < depth+1) // everything below the current block, but also inside the current block
 						{
 							int entityX = ((int)(*it)->midpoint().x) & 0x0f;
 							int entityZ = ((int)(*it)->midpoint().z) & 0x0f ;
 							int index = entityX + (entityZ<<4);
 							int highY = chunk->depth[index];
 							if ( (entityY+10 >= highY) ||
-								 (entityY+10 >= depth) )
+							     (entityY+10 >= depth) )
 								(*it)->draw(x1, z1, zoom, canvas);
 						}
 					}


### PR DESCRIPTION
Now render correctly Entities inside the current depth layer. Before this change, some Mobs may be invisible when the depth slider is at the same level.
(also done some TAB vs. spaces fixes)