### PR TITLE
added detection for EndCity structures

### DIFF
--- a/generatedstructure.cpp
+++ b/generatedstructure.cpp
@@ -51,6 +51,10 @@ QList<QSharedPointer<GeneratedStructure> > GeneratedStructure::tryParse(Tag* dat
 								{
 									structure->setDimension("nether");
 								}
+								else if (structure->type() == "Structure.EndCity")
+								{
+									structure->setDimension("end");
+								}
 								else
 								{
 									structure->setDimension("overworld");


### PR DESCRIPTION
All new structures have to be linked to the correct dimension (if not Overworld).