### PR TITLE
fix for missing .png suffix

### DIFF
--- a/minutor.cpp
+++ b/minutor.cpp
@@ -116,11 +116,24 @@ void Minutor::reload() {
 }
 
 void Minutor::save() {
+  // get filname to save to
   QFileDialog fileDialog(this);
   fileDialog.setDefaultSuffix("png");
   QString filename = fileDialog.getSaveFileName(this, tr("Save world as PNG"),
-                                                QString(), "*.png");
+                                                QString(), "PNG Images (*.png)");
 
+  // check if filename was given
+  if (filename.isEmpty())
+    return;
+
+  // add .png suffix if not present
+  QFile file(filename);
+  QFileInfo fileinfo(file);
+  if (fileinfo.suffix().isEmpty()) {
+    filename.append(".png");
+  }
+
+  // save world to PNG image
   savePNG(filename, false, false, false);
 }
 


### PR DESCRIPTION
This fixes issue #83. Intentionally it should already have been fixed with commit 87c9af5, as this problem is a duplicate of #34. 

The problem seems to be Operation System or Qt version dependand, therefore I added much more check code to handle this problem in any case