### PR TITLE
fix for unknown Entities are not shown as Overlay

### DIFF
--- a/entity.cpp
+++ b/entity.cpp
@@ -28,7 +28,10 @@ QSharedPointer<OverlayItem> Entity::TryParse(const Tag* tag) {
         QString itemtype = itemId->toString();
         entity->setDisplay(itemtype.mid(itemtype.indexOf(':') + 1));
       } else {  // or just use the Entity's name
-        entity->setDisplay(info.name);
+        if (info.name == "Name unknown")
+          entity->setDisplay(type);       // use Minecraft internal name if not found
+        else
+          entity->setDisplay(info.name);  // use name as defined in JSON
       }
       entity->setType("Entity." + info.category);
       entity->setColor(info.brushColor);

--- a/entityidentifier.cpp
+++ b/entityidentifier.cpp
@@ -8,8 +8,9 @@ EntityInfo::EntityInfo(QString name, QString category, QColor brushColor,
                        QColor penColor) : name(name), category(category),
   brushColor(brushColor), penColor(penColor) {}
 
-static EntityInfo entityDummy("Name unknown", "Entity.Unknown", Qt::black,
-                              Qt::black);
+// dummy for entities not found in *_entity.json
+static EntityInfo entityDummy("Name unknown", "Others",  // Name Category
+                              Qt::black, Qt::black);     // Black circle with Black border
 
 EntityIdentifier::EntityIdentifier() {}
 EntityIdentifier::~EntityIdentifier() {}


### PR DESCRIPTION
In case an Entity is not defined in *_entity.json it was not shown in any of the Entity Overlays.
Now unknown Entities are placed in the Others category and therefore can be made visible.