### PR TITLE
Update 1.11

### DIFF
--- a/definitions/readme_entity.txt
+++ b/definitions/readme_entity.txt
@@ -30,6 +30,10 @@ the category if omitted. The highlight color (unique for each entity) is given
 by "color". If omitted a pseudo random color is calculated based on the hashed id.
 The "name" is automatically copied from the "id", but can also be set individually.
 
+As of version 1.11 the "id" was completely reworked by Mojang. Some code has been
+implemented to detect lower case changes automatically. But in case there is a
+renamed "id" it has to be given as "id1" to maintain backwards compatibility.
+
 
 All colors can be defined in a syntax readable by Qt::QColor::setNamedColor( QString )
  http://qt-project.org/doc/qt-4.8/qcolor.html#setNamedColor

--- a/definitions/vanilla_entity.json
+++ b/definitions/vanilla_entity.json
@@ -147,6 +147,10 @@
           "color": "#000080"
         },
         {
+          "id": "llama",
+          "color": "Khaki"
+        },
+        {
           "id": "Pig",
           "color": "#ff00ff"
         },
@@ -188,6 +192,20 @@
         },
         {
           "id": "Villager",
+          "color": "#800080"
+        },
+        {
+          "id": "vindication_illager",
+          "name": "Vindicator",
+          "color": "#800080"
+        },
+        {
+          "id": "evocation_illager",
+          "name": "Evoker",
+          "color": "#800080"
+        },
+        {
+          "id": "vex",
           "color": "#800080"
         },
         {

--- a/definitions/vanilla_entity.json
+++ b/definitions/vanilla_entity.json
@@ -1,7 +1,7 @@
 {
   "name": "Vanilla",
   "type": "entity",
-  "version": "1.11.16w32a",
+  "version": "1.11.16w39a",
   "data": [
     {
       "category": "Hostile",

--- a/definitions/vanilla_entity.json
+++ b/definitions/vanilla_entity.json
@@ -1,7 +1,7 @@
 {
   "name": "Vanilla",
   "type": "entity",
-  "version": "1.10.16w20a",
+  "version": "1.11.16w32a",
   "data": [
     {
       "category": "Hostile",
@@ -13,6 +13,7 @@
         },
         {
           "id": "CaveSpider",
+          "id1": "cave_spider",
           "color": "#808000"
         },
         {
@@ -21,6 +22,7 @@
         },
         {
           "id": "EnderDragon",
+          "id1": "ender_dragon",
           "color": "#ff00ff"
         },
         {
@@ -40,13 +42,13 @@
           "color": "#000080"
         },
         {
-          "id": "LavaSlime",
-          "color": "#00ffff"
+          "id": "elder_guardian",
+          "color": "#000080"
         },
         {
-          "id": "PigZombie",
-          "name": "Zombie Pigman",
-          "color": "#008000"
+          "id": "LavaSlime",
+          "id1": "magma_cube",
+          "color": "#00ffff"
         },
         {
           "id": "Shulker",
@@ -58,6 +60,14 @@
         },
         {
           "id": "Skeleton",
+          "color": "#c0c0c0"
+        },
+        {
+          "id": "stray",
+          "color": "#c0c0c0"
+        },
+        {
+          "id": "wither_skeleton",
           "color": "#c0c0c0"
         },
         {
@@ -74,11 +84,26 @@
         },
         {
           "id": "WitherBoss",
+          "id1": "wither",
           "name": "Wither",
           "color": "#808080"
         },
         {
           "id": "Zombie",
+          "color": "#008000"
+        },
+        {
+          "id": "zombie_villager",
+          "color": "#008000"
+        },
+        {
+          "id": "husk",
+          "color": "#008000"
+        },
+        {
+          "id": "PigZombie",
+          "id1": "zombie_pigman",
+          "name": "Zombie Pigman",
           "color": "#008000"
         }
       ]
@@ -101,7 +126,24 @@
         },
         {
           "id": "EntityHorse",
+          "id1": "horse",
           "name": "Horse",
+          "color": "#000080"
+        },
+        {
+          "id": "donkey",
+          "color": "#000080"
+        },
+        {
+          "id": "mule",
+          "color": "#000080"
+        },
+        {
+          "id": "skeleton_horse",
+          "color": "#000080"
+        },
+        {
+          "id": "zombie_horse",
           "color": "#000080"
         },
         {
@@ -110,6 +152,8 @@
         },
         {
           "id": "MushroomCow",
+          "id1": "mooshroom",
+          "name": "Mooshroom",
           "color": "#ff0000"
         },
         {
@@ -118,6 +162,7 @@
         },
         {
           "id": "PolarBear",
+          "id1": "polar_bear",
           "color": "#404040"
         },
         {
@@ -130,6 +175,7 @@
         },
         {
           "id": "SnowMan",
+          "id1": "snow_man",
           "color": "#ffffff"
         },
         {
@@ -146,6 +192,7 @@
         },
         {
           "id": "VillagerGolem",
+          "id1": "villager_golem",
           "name": "Iron Golem",
           "color": "#00ffff"
         }
@@ -157,16 +204,20 @@
       "entity": [
         {
           "id": "XPOrb",
+          "id1": "xp_orb",
+          "name": "XP Orb",
           "catcolor": "GreenYellow",
           "color": "Gold"
         },
         {
           "id": "LeashKnot",
+          "id1": "leash_knot",
           "catcolor": "GreenYellow",
           "color": "SandyBrown"
         },
         {
           "id": "EnderCrystal",
+          "id1": "ender_crystal",
           "catcolor": "Plum",
           "color": "SkyBlue"
         },
@@ -177,36 +228,50 @@
         },
         {
           "id": "MinecartCommandBlock",
+          "id1": "commandblock_minecart",
+          "name": "CommandBlock Minecart",
           "catcolor": "DarkOrange",
           "color": "HotPink"
         },
         {
           "id": "MinecartRideable",
+          "id1": "minecart",
+          "name": "Minecart",
           "catcolor": "DarkOrange",
           "color": "#a0a0a0"
         },
         {
           "id": "MinecartChest",
+          "id1": "chest_minecart",
+          "name": "Chest Minecart",
           "catcolor": "DarkOrange",
           "color": "SaddleBrown"
         },
         {
           "id": "MinecartFurnace",
+          "id1": "furnace_minecart",
+          "name": "Furnace Minecart",
           "catcolor": "DarkOrange",
           "color": "#202020"
         },
         {
           "id": "MinecartTNT",
+          "id1": "tnt_minecart",
+          "name": "TNT Minecart",
           "catcolor": "DarkOrange",
           "color": "#ff0000"
         },
         {
           "id": "MinecartHopper",
+          "id1": "hopper_minecart",
+          "name": "Hopper Minecart",
           "catcolor": "DarkOrange",
           "color": "#808080"
         },
         {
           "id": "MinecartSpawner",
+          "id1": "spawner_minecart",
+          "name": "Spawner Minecart",
           "catcolor": "DarkOrange",
           "color": "Plum"
         },
@@ -217,11 +282,13 @@
         },
         {
           "id": "ItemFrame",
+          "id1": "item_frame",
           "catcolor": "Violet",
           "color": "Seashell"
         },
         {
           "id": "ArmorStand",
+          "id1": "armor_stand",
           "catcolor": "Violet",
           "color": "Aquamarine"
         }

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -2512,6 +2512,91 @@
       "color": "cec9b2"
     },
     {
+      "id": 218,
+      "name": "Observer",
+      "color": "535353"
+    },
+    {
+      "id": 219,
+      "name": "White Shulker Box",
+      "color": "dedbdb"
+    },
+    {
+      "id": 220,
+      "name": "Orange Shulker Box",
+      "color": "ce7438"
+    },
+    {
+      "id": 221,
+      "name": "Magenta Shulker Box",
+      "color": "ba64c2"
+    },
+    {
+      "id": 222,
+      "name": "Light Blue Shulker Box",
+      "color": "658ecb"
+    },
+    {
+      "id": 223,
+      "name": "Yellow Shulker Box",
+      "color": "c1b73d"
+    },
+    {
+      "id": 224,
+      "name": "Lime Shulker Box",
+      "color": "47b73b"
+    },
+    {
+      "id": 225,
+      "name": "Pink Shulker Box",
+      "color": "d08ca1"
+    },
+    {
+      "id": 226,
+      "name": "Gray Shulker Box",
+      "color": "535151"
+    },
+    {
+      "id": 227,
+      "name": "Light Gray Shulker Box",
+      "color": "a4a2a2"
+    },
+    {
+      "id": 228,
+      "name": "Cyan Shulker Box",
+      "color": "4488a4"
+    },
+    {
+      "id": 229,
+      "name": "Purple Shulker Box",
+      "color": "976797"
+    },
+    {
+      "id": 230,
+      "name": "Blue Shulker Box",
+      "color": "6571c9"
+    },
+    {
+      "id": 231,
+      "name": "Brown Shulker Box",
+      "color": "8d705d"
+    },
+    {
+      "id": 232,
+      "name": "Green Shulker Box",
+      "color": "6f8254"
+    },
+    {
+      "id": 233,
+      "name": "Red Shulker Box",
+      "color": "c25855"
+    },
+    {
+      "id": 234,
+      "name": "Black Shulker Box",
+      "color": "383737"
+    },
+    {
       "id": 255,
       "name": "Structure Block",
       "color": "000000"

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -1,7 +1,7 @@
 {
   "name": "Vanilla",
   "type": "block",
-  "version": "1.10.16w20a",
+  "version": "1.11.16w39a",
   "data": [
     {
       "id": 0,


### PR DESCRIPTION
**16w32a:**
Entity names were completely renamed by Mojang. Therefore some backwards compatible code and definition was implemented. Lower case version are handled automatically, but renamed Entities have to be specified with "id1" tag.
* Horse split into entity IDs horse, donkey, mule, skeleton_horse and zombie_horse
* Skeleton split into entity IDs skeleton, stray and wither_skeleton
* Zombie split into entity IDs zombie, zombie_villager and husk
* Guardian split into entity IDs guardian and elder_guardian

**16w39a:**
+ Block: Observer
+ Block: (16 colored) Shulker Boxe(s)
+ Entity: Llama
+ Entity: Vindicator
+ Entity: Evoker
+ Entity: Vex