### PR TITLE
Fix color name usage

### DIFF
--- a/biomeidentifier.cpp
+++ b/biomeidentifier.cpp
@@ -1,5 +1,7 @@
 /** Copyright (c) 2013, Sean Kasun */
 
+#include <assert.h>
+
 #include "./biomeidentifier.h"
 #include "./json.h"
 
@@ -58,47 +60,31 @@ int BiomeIdentifier::addDefinitions(JSONArray *defs, int pack) {
     else
       biome->name = "Unknown";
 
+    // check for "alpha" (0: transparent / 1: saturated)
+    // probably never used
+    if (b->has("alpha"))
+      biome->alpha = b->at("alpha")->asNumber();
+    else
+      biome->alpha = 1.0;
+
+    // get color definition
+    QColor biomecolor;
     if (b->has("color")) {
-      QString color = b->at("color")->asString();
-      quint32 col = 0;
-      for (int h = 0; h < color.length(); h++) {
-        ushort c = color.at(h).unicode();
-        col <<= 4;
-        if (c >= '0' && c <= '9')
-          col |= c - '0';
-        else if (c >= 'A' && c <= 'F')
-          col |= c - 'A' + 10;
-        else if (c >= 'a' && c <= 'f')
-          col |= c - 'a' + 10;
-      }
-      int rd = col >> 16;
-      int gn = (col >> 8) & 0xff;
-      int bl = col & 0xff;
-
-      if (b->has("alpha"))
-        biome->alpha = b->at("alpha")->asNumber();
-      else
-        biome->alpha = 1.0;
-
-      // pre multiply alphas
-      rd *= biome->alpha;
-      gn *= biome->alpha;
-      bl *= biome->alpha;
-
-      // pre-calculate light spectrum
-      double y = 0.299 * rd + 0.587 * gn + 0.114 * bl;
-      double u = (bl - y) * 0.565;
-      double v = (rd - y) * 0.713;
-      double delta = y / 15;
-      for (int i = 0; i < 16; i++) {
-        y = i * delta;
-        rd = (unsigned int)clamp(y + 1.403 * v, 0, 255);
-        gn = (unsigned int)clamp(y - 0.344 * u - 0.714 * v, 0, 255);
-        bl = (unsigned int)clamp(y + 1.770 * u, 0, 255);
-        biome->colors[i] = (rd << 16) | (gn << 8) | bl;
-      }
+      QString colorname = b->at("color")->asString();
+      biomecolor.setNamedColor(colorname);
+      assert(biomecolor.isValid());
     } else {
-      biome->alpha = 0.0;
+      // use hashed by name instead
+      quint32 hue = qHash(biome->name);
+      biomecolor.setHsv(hue % 360, 255, 255);
+    }
+
+    // pre-calculate light spectrum
+    for (int i = 0; i < 16; i++) {
+      biome->colors[i].setHsv( biomecolor.hue(),
+                               biomecolor.saturation(),
+                               biomecolor.value()*(i/16.0),
+                               255*biome->alpha );
     }
 
     biomes[id].append(biome);

--- a/biomeidentifier.cpp
+++ b/biomeidentifier.cpp
@@ -71,6 +71,13 @@ int BiomeIdentifier::addDefinitions(JSONArray *defs, int pack) {
     QColor biomecolor;
     if (b->has("color")) {
       QString colorname = b->at("color")->asString();
+      if (colorname.length() == 6) {
+        // check if this is an old color definition with missing '#'
+        bool ok;
+        colorname.toInt(&ok,16);
+        if (ok)
+          colorname.push_front('#');
+      }
       biomecolor.setNamedColor(colorname);
       assert(biomecolor.isValid());
     } else {

--- a/biomeidentifier.cpp
+++ b/biomeidentifier.cpp
@@ -88,10 +88,13 @@ int BiomeIdentifier::addDefinitions(JSONArray *defs, int pack) {
 
     // pre-calculate light spectrum
     for (int i = 0; i < 16; i++) {
-      biome->colors[i].setHsv( biomecolor.hue(),
-                               biomecolor.saturation(),
-                               biomecolor.value()*(i/16.0),
-                               255*biome->alpha );
+      // calculate light attenuation similar to Minecraft
+      // except base 90% here, were Minecraft is using 80% per level
+      double light_factor = pow(0.90,15-i);
+      biome->colors[i].setRgb(light_factor*biomecolor.red(),
+                              light_factor*biomecolor.green(),
+                              light_factor*biomecolor.blue(),
+                              255*biome->alpha );
     }
 
     biomes[id].append(biome);

--- a/biomeidentifier.h
+++ b/biomeidentifier.h
@@ -5,6 +5,7 @@
 #include <QHash>
 #include <QList>
 #include <QString>
+#include <QColor>
 class JSONArray;
 
 class BiomeInfo {
@@ -12,7 +13,7 @@ class BiomeInfo {
   BiomeInfo() {}
   QString name;
   bool enabled;
-  quint32 colors[16];
+  QColor colors[16];
   double alpha;
 };
 

--- a/blockidentifier.cpp
+++ b/blockidentifier.cpp
@@ -219,6 +219,13 @@ void BlockIdentifier::parseDefinition(JSONObject *b, BlockInfo *parent,
   QColor blockcolor;
   if (b->has("color")) {
     QString colorname = b->at("color")->asString();
+    if (colorname.length() == 6) {
+      // check if this is an old color definition with missing '#'
+      bool ok;
+      colorname.toInt(&ok,16);
+      if (ok)
+        colorname.push_front('#');
+    }
     blockcolor.setNamedColor(colorname);
     assert(blockcolor.isValid());
   } else if (parent != NULL) {

--- a/blockidentifier.cpp
+++ b/blockidentifier.cpp
@@ -248,9 +248,15 @@ void BlockIdentifier::parseDefinition(JSONObject *b, BlockInfo *parent,
 
   // pre-calculate light spectrum
   for (int i = 0; i < 16; i++) {
+
+    // calculate light attenuation similar to Minecraft
+    // except base 90% here, were Minecraft is using 80% per level
+    double light_factor = pow(0.90,15-i);
+
     block->colors[i].setHsv( blockcolor.hue(),
                              blockcolor.saturation(),
-                             blockcolor.value()*(i/15.0),
+                             blockcolor.value()*light_factor,
+//                           blockcolor.value()*(i/15.0),
 //                           blockcolor.value()*(i/15.0)*block->alpha, // with pre-multiply alpha
                              255*block->alpha );
   }

--- a/blockidentifier.cpp
+++ b/blockidentifier.cpp
@@ -1,6 +1,8 @@
 /** Copyright (c) 2013, Sean Kasun */
 
 #include <QDebug>
+#include <assert.h>
+
 #include "./blockidentifier.h"
 #include "./json.h"
 
@@ -207,53 +209,38 @@ void BlockIdentifier::parseDefinition(JSONObject *b, BlockInfo *parent,
   else
     block->providepower = false;
 
-  if (b->has("color")) {
-    QString color = b->at("color")->asString();
-    quint32 col = 0;
-    for (int h = 0; h < color.length(); h++) {
-      ushort c = color.at(h).unicode();
-      col <<= 4;
-      if (c >= '0' && c <= '9')
-        col |= c - '0';
-      else if (c >= 'A' && c <= 'F')
-        col |= c - 'A' + 10;
-      else if (c >= 'a' && c <= 'f')
-        col |= c - 'a' + 10;
-    }
-    int rd = col >> 16;
-    int gn = (col >> 8) & 0xff;
-    int bl = col & 0xff;
-
-    if (b->has("alpha"))
-      block->alpha = b->at("alpha")->asNumber();
-    else if (parent != NULL)
-      block->alpha = parent->alpha;
-    else
-      block->alpha = 1.0;
-
-    // pre multiply alphas
-    rd *= block->alpha;
-    gn *= block->alpha;
-    bl *= block->alpha;
-
-    // pre-calculate light spectrum
-    double y = 0.299 * rd + 0.587 * gn + 0.114 * bl;
-    double u = (bl - y) * 0.565;
-    double v = (rd - y) * 0.713;
-    double delta = y / 15;
-    for (int i = 0; i < 16; i++) {
-      y = i * delta;
-      rd = (unsigned int)clamp(y + 1.403 * v, 0, 255);
-      gn = (unsigned int)clamp(y - 0.344 * u - 0.714 * v, 0, 255);
-      bl = (unsigned int)clamp(y + 1.770 * u, 0, 255);
-      block->colors[i] = (rd << 16) | (gn << 8) | bl;
-    }
-  } else if (parent != NULL) {
-    for (int i = 0; i < 16; i++)
-      block->colors[i] = parent->colors[i];
+  if (b->has("alpha"))
+    block->alpha = b->at("alpha")->asNumber();
+  else if (parent != NULL)
     block->alpha = parent->alpha;
+  else
+    block->alpha = 1.0;
+
+  QColor blockcolor;
+  if (b->has("color")) {
+    QString colorname = b->at("color")->asString();
+    blockcolor.setNamedColor(colorname);
+    assert(blockcolor.isValid());
+  } else if (parent != NULL) {
+    // copy brightest color from parent
+    blockcolor = parent->colors[15];
   } else {
-    block->alpha = 0.0;
+    // use hashed by name instead
+    quint32 hue = qHash(block->getName());
+    blockcolor.setHsv(hue % 360, 255, 255);
+  }
+
+  // pre multiply alphas
+//    rd *= block->alpha;
+//    gn *= block->alpha;
+//    bl *= block->alpha;
+
+  // pre-calculate light spectrum
+  for (int i = 0; i < 16; i++) {
+    block->colors[i].setHsv( blockcolor.hue(),
+                             blockcolor.saturation(),
+                             blockcolor.value()*(i/15.0),
+                             255*block->alpha );
   }
 
   if (b->has("mask"))

--- a/blockidentifier.cpp
+++ b/blockidentifier.cpp
@@ -237,28 +237,15 @@ void BlockIdentifier::parseDefinition(JSONObject *b, BlockInfo *parent,
     blockcolor.setHsv(hue % 360, 255, 255);
   }
 
-  // pre multiply alphas
-//rd *= block->alpha;
-//gn *= block->alpha;
-//bl *= block->alpha;
-  // ??? why should do we do this ???
-  // a transparent block is "blended" correctly in mapview.cpp
-  // if we change anything to the color here, we just change it...
-  // for this special case: we make all transparent blocks darker
-
   // pre-calculate light spectrum
   for (int i = 0; i < 16; i++) {
-
     // calculate light attenuation similar to Minecraft
     // except base 90% here, were Minecraft is using 80% per level
     double light_factor = pow(0.90,15-i);
-
-    block->colors[i].setHsv( blockcolor.hue(),
-                             blockcolor.saturation(),
-                             blockcolor.value()*light_factor,
-//                           blockcolor.value()*(i/15.0),
-//                           blockcolor.value()*(i/15.0)*block->alpha, // with pre-multiply alpha
-                             255*block->alpha );
+    block->colors[i].setRgb(light_factor*blockcolor.red(),
+                            light_factor*blockcolor.green(),
+                            light_factor*blockcolor.blue(),
+                            255*block->alpha );
   }
 
   if (b->has("mask"))

--- a/blockidentifier.cpp
+++ b/blockidentifier.cpp
@@ -238,15 +238,20 @@ void BlockIdentifier::parseDefinition(JSONObject *b, BlockInfo *parent,
   }
 
   // pre multiply alphas
-//    rd *= block->alpha;
-//    gn *= block->alpha;
-//    bl *= block->alpha;
+//rd *= block->alpha;
+//gn *= block->alpha;
+//bl *= block->alpha;
+  // ??? why should do we do this ???
+  // a transparent block is "blended" correctly in mapview.cpp
+  // if we change anything to the color here, we just change it...
+  // for this special case: we make all transparent blocks darker
 
   // pre-calculate light spectrum
   for (int i = 0; i < 16; i++) {
     block->colors[i].setHsv( blockcolor.hue(),
                              blockcolor.saturation(),
                              blockcolor.value()*(i/15.0),
+//                           blockcolor.value()*(i/15.0)*block->alpha, // with pre-multiply alpha
                              255*block->alpha );
   }
 

--- a/blockidentifier.h
+++ b/blockidentifier.h
@@ -6,6 +6,7 @@
 #include <QMap>
 #include <QHash>
 #include <QList>
+#include <QColor>
 
 class JSONArray;
 class JSONObject;
@@ -47,7 +48,7 @@ class BlockInfo {
   bool rendernormal;
   bool providepower;
   bool spawninside;
-  quint32 colors[16];
+  QColor colors[16];
 
  private:
   QString name;

--- a/definitions/vanilla_biomes.json
+++ b/definitions/vanilla_biomes.json
@@ -6,312 +6,312 @@
     {
       "id": 0,
       "name": "Ocean",
-      "color": "000070"
+      "color": "#000070"
     },
     {
       "id": 1,
       "name": "Plains",
-      "color": "8db360"
+      "color": "#8db360"
     },
     {
       "id": 2,
       "name": "Desert",
-      "color": "fa9418"
+      "color": "#fa9418"
     },
     {
       "id": 3,
       "name": "Extreme Hills",
-      "color": "606060"
+      "color": "#606060"
     },
     {
       "id": 4,
       "name": "Forest",
-      "color": "056621"
+      "color": "#056621"
     },
     {
       "id": 5,
       "name": "Taiga",
-      "color": "0b6659"
+      "color": "#0b6659"
     },
     {
       "id": 6,
       "name": "Swampland",
-      "color": "07f9b2"
+      "color": "#07f9b2"
     },
     {
       "id": 7,
       "name": "River",
-      "color": "0000ff"
+      "color": "#0000ff"
     },
     {
       "id": 8,
       "name": "Hell",
-      "color": "ff0000"
+      "color": "#ff0000"
     },
     {
       "id": 9,
       "name": "Sky",
-      "color": "8080ff"
+      "color": "#8080ff"
     },
     {
       "id": 10,
       "name": "Frozen Ocean",
-      "color": "9090a0"
+      "color": "#9090a0"
     },
     {
       "id": 11,
       "name": "Frozen River",
-      "color": "a0a0ff"
+      "color": "#a0a0ff"
     },
     {
       "id": 12,
       "name": "Ice Plains",
-      "color": "ffffff"
+      "color": "#ffffff"
     },
     {
       "id": 13,
       "name": "Ice Mountains",
-      "color": "a0a0a0"
+      "color": "#a0a0a0"
     },
     {
       "id": 14,
       "name": "Mushroom Island",
-      "color": "ff00ff"
+      "color": "#ff00ff"
     },
     {
       "id": 15,
       "name": "Mushroom Island Shore",
-      "color": "a000ff"
+      "color": "#a000ff"
     },
     {
       "id": 16,
       "name": "Beach",
-      "color": "fade55"
+      "color": "#fade55"
     },
     {
       "id": 17,
       "name": "Desert Hills",
-      "color": "d25f12"
+      "color": "#d25f12"
     },
     {
       "id": 18,
       "name": "Forest Hills",
-      "color": "22551c"
+      "color": "#22551c"
     },
     {
       "id": 19,
       "name": "Taiga Hills",
-      "color": "163933"
+      "color": "#163933"
     },
     {
       "id": 20,
       "name": "Extreme Hills Edge",
-      "color": "72789a"
+      "color": "#72789a"
     },
     {
       "id": 21,
       "name": "Jungle",
-      "color": "537b09"
+      "color": "#537b09"
     },
     {
       "id": 22,
       "name": "Jungle Hills",
-      "color": "2c4205"
+      "color": "#2c4205"
     },
     {
       "id": 23,
       "name": "Jungle Edge",
-      "color": "628b17"
+      "color": "#628b17"
     },
     {
       "id": 24,
       "name": "Deep Ocean",
-      "color": "000030"
+      "color": "#000030"
     },
     {
       "id": 25,
       "name": "Stone Beach",
-      "color": "a2a284"
+      "color": "#a2a284"
     },
     {
       "id": 26,
       "name": "Cold Beach",
-      "color": "faf0c0"
+      "color": "#faf0c0"
     },
     {
       "id": 27,
       "name": "Birch Forest",
-      "color": "307444"
+      "color": "#307444"
     },
     {
       "id": 28,
       "name": "Birch Forest Hills",
-      "color": "1f5f32"
+      "color": "#1f5f32"
     },
     {
       "id": 29,
       "name": "Roofed Forest",
-      "color": "40511a"
+      "color": "#40511a"
     },
     {
       "id": 30,
       "name": "Cold Taiga",
-      "color": "31554a"
+      "color": "#31554a"
     },
     {
       "id": 31,
       "name": "Cold Taiga Hills",
-      "color": "243f36"
+      "color": "#243f36"
     },
     {
       "id": 32,
       "name": "Mega Taiga",
-      "color": "596651"
+      "color": "#596651"
     },
     {
       "id": 33,
       "name": "Mega Taiga Hills",
-      "color": "454f3e"
+      "color": "#454f3e"
     },
     {
       "id": 34,
       "name": "Extreme Hills+",
-      "color": "507050"
+      "color": "#507050"
     },
     {
       "id": 35,
       "name": "Savanna",
-      "color": "bdb25f"
+      "color": "#bdb25f"
     },
     {
       "id": 36,
       "name": "Savanna Plateau",
-      "color": "a79d64"
+      "color": "#a79d64"
     },
     {
       "id": 37,
       "name": "Mesa",
-      "color": "d94515"
+      "color": "#d94515"
     },
     {
       "id": 38,
       "name": "Mesa Plateau F",
-      "color": "b09765"
+      "color": "#b09765"
     },
     {
       "id": 39,
       "name": "Mesa Plateau",
-      "color": "ca8c65"
+      "color": "#ca8c65"
     },
     {
       "id": 127,
       "name": "The Void",
-      "color": "282898"
+      "color": "#282898"
     },
     {
       "id": 129,
       "name": "Sunflower Plains",
-      "color": "b5db88"
+      "color": "#b5db88"
     },
     {
       "id": 130,
       "name": "Desert M",
-      "color": "ffbc40"
+      "color": "#ffbc40"
     },
     {
       "id": 131,
       "name": "Extreme Hills M",
-      "color": "888888"
+      "color": "#888888"
     },
     {
       "id": 132,
       "name": "Flower Forest",
-      "color": "2d8e49"
+      "color": "#2d8e49"
     },
     {
       "id": 133,
       "name": "Taiga M",
-      "color": "338e81"
+      "color": "#338e81"
     },
     {
       "id": 134,
       "name": "Swampland M",
-      "color": "2fffda"
+      "color": "#2fffda"
     },
     {
       "id": 140,
       "name": "Ice Plains Spikes",
-      "color": "b4dcdc"
+      "color": "#b4dcdc"
     },
     {
       "id": 149,
       "name": "Jungle M",
-      "color": "7ba331"
+      "color": "#7ba331"
     },
     {
       "id": 151,
       "name": "Jungle Edge M",
-      "color": "8ab33f"
+      "color": "#8ab33f"
     },
     {
       "id": 155,
       "name": "Birch Forest M",
-      "color": "589c6c"
+      "color": "#589c6c"
     },
     {
       "id": 156,
       "name": "Birch Forest Hills M",
-      "color": "47875a"
+      "color": "#47875a"
     },
     {
       "id": 157,
       "name": "Roofed Forest M",
-      "color": "687942"
+      "color": "#687942"
     },
     {
       "id": 158,
       "name": "Cold Taiga M",
-      "color": "597d72"
+      "color": "#597d72"
     },
     {
       "id": 160,
       "name": "Mega Spruce Taiga",
-      "color": "818e79"
+      "color": "#818e79"
     },
     {
       "id": 161,
       "name": "Mega Spruce Taiga Hills",
-      "color": "6d7766"
+      "color": "#6d7766"
     },
     {
       "id": 162,
       "name": "Extreme Hills+ M",
-      "color": "789878"
+      "color": "#789878"
     },
     {
       "id": 163,
       "name": "Savanna M",
-      "color": "e5da87"
+      "color": "#e5da87"
     },
     {
       "id": 164,
       "name": "Savanna Plateau M",
-      "color": "cfc58c"
+      "color": "#cfc58c"
     },
     {
       "id": 165,
       "name": "Mesa (Bryce)",
-      "color": "ff6d3d"
+      "color": "#ff6d3d"
     },
     {
       "id": 166,
       "name": "Mesa Plateau F M",
-      "color": "d8bf8d"
+      "color": "#d8bf8d"
     },
     {
       "id": 167,
       "name": "Mesa Plateau M",
-      "color": "f2b48d"
+      "color": "#f2b48d"
     }
   ]
 }

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -6,109 +6,111 @@
     {
       "id": 0,
       "name": "Air",
+      "color": "#ffffff",
+      "alpha": 0.0,
       "transparent": true,
       "spawninside": true
     },
     {
       "id": 1,
       "name": "Stone",
-      "color": "747474",
+      "color": "#747474",
       "variants": [
         {
           "data": 1,
           "name": "Granite",
-          "color": "977061"
+          "color": "#977061"
         },
         {
           "data": 2,
           "name": "Polished Granite",
-          "color": "9d7160"
+          "color": "#9d7160"
         },
         {
           "data": 3,
           "name": "Diorite",
-          "color": "b2b2b5"
+          "color": "#b2b2b5"
         },
         {
           "data": 4,
           "name": "Polished Diorite",
-          "color": "b9b9bc"
+          "color": "#b9b9bc"
         },
         {
           "data": 5,
           "name": "Andesite",
-          "color": "818181"
+          "color": "#818181"
         },
         {
           "data": 6,
           "name": "Polished Andesite",
-          "color": "838385"
+          "color": "#838385"
         }
       ]
     },
     {
       "id": 2,
       "name": "Grass",
-      "color": "78bf64"
+      "color": "#78bf64"
     },
     {
       "id": 3,
       "name": "Dirt",
-      "color": "835d40",
+      "color": "#835d40",
       "variants": [
         {
           "data": 1,
           "name": "Coarse Dirt",
-          "color": "76543a"
+          "color": "#76543a"
         },
         {
           "data": 2,
           "name": "Podzol",
-          "color": "573c1a"
+          "color": "#573c1a"
         }
       ]
     },
     {
       "id": 4,
       "name": "Cobblestone",
-      "color": "8f8f8f"
+      "color": "#8f8f8f"
     },
     {
       "id": 5,
       "name": "Oak Wood Plank",
-      "color": "b4905a",
+      "color": "#b4905a",
       "variants": [
         {
           "data": 1,
           "name": "Spruce Wood Plank",
-          "color": "805e36"
+          "color": "#805e36"
         },
         {
           "data": 2,
           "name": "Birch Wood Plank",
-          "color": "c8b77a"
+          "color": "#c8b77a"
         },
         {
           "data": 3,
           "name": "Jungle Wood Plank",
-          "color": "b1805c"
+          "color": "#b1805c"
         },
         {
           "data": 4,
           "name": "Acacia Wood Plank",
-          "color": "ba6337"
+          "color": "#ba6337"
         },
         {
           "data": 5,
           "name": "Dark Oak Wood Plank",
-          "color": "462d15"
+          "color": "#462d15"
         }
       ]
     },
     {
       "id": 6,
       "name": "Oak Sapling",
-      "color": "1f6519",
+      "color": "#1f6519",
       "alpha": 0.3,
       "mask": 7,
       "transparent": true,
@@ -117,39 +119,39 @@
         {
           "data": 1,
           "name": "Spruce Sapling",
-          "color": "395a39"
+          "color": "#395a39"
         },
         {
           "data": 2,
           "name": "Birch Sapling",
-          "color": "51742d"
+          "color": "#51742d"
         },
         {
           "data": 3,
           "name": "Jungle Sapling",
-          "color": "2c6c18"
+          "color": "#2c6c18"
         },
         {
           "data": 4,
           "name": "Acacia Sapling",
-          "color": "677e17"
+          "color": "#677e17"
         },
         {
           "data": 5,
           "name": "Dark Oak Sapling",
-          "color": "105210"
+          "color": "#105210"
         }
       ]
     },
     {
       "id": 7,
       "name": "Bedrock",
-      "color": "333333"
+      "color": "#333333"
     },
     {
       "id": 8,
       "name": "Water (flowing)",
-      "color": "1f55ff",
+      "color": "#1f55ff",
       "alpha": 0.53,
       "transparent": true,
       "liquid": true
@@ -157,7 +159,7 @@
     {
       "id": 9,
       "name": "Water",
-      "color": "1f55ff",
+      "color": "#1f55ff",
       "alpha": 0.53,
       "transparent": true,
       "liquid": true
@@ -165,76 +167,76 @@
     {
       "id": 10,
       "name": "Lava (flowing)",
-      "color": "fc5700",
+      "color": "#fc5700",
       "transparent": true,
       "liquid": true
     },
     {
       "id": 11,
       "name": "Lava",
-      "color": "fc5700",
+      "color": "#fc5700",
       "transparent": true,
       "liquid": true
     },
     {
       "id": 12,
       "name": "Sand",
-      "color": "d6cf97",
+      "color": "#d6cf97",
       "variants": [
         {
           "data": 1,
           "name": "Red Sand",
-          "color": "a6551e"
+          "color": "#a6551e"
         }
       ]
     },
     {
       "id": 13,
       "name": "Gravel",
-      "color": "817f7f"
+      "color": "#817f7f"
     },
     {
       "id": 14,
       "name": "Gold Ore",
-      "color": "fcee4b"
+      "color": "#fcee4b"
     },
     {
       "id": 15,
       "name": "Iron Ore",
-      "color": "af8e77"
+      "color": "#af8e77"
     },
     {
       "id": 16,
       "name": "Coal Ore",
-      "color": "454545"
+      "color": "#454545"
     },
     {
       "id": 17,
       "name": "Oak Wood",
-      "color": "665130",
+      "color": "#665130",
       "mask": 3,
       "variants": [
         {
           "data": 1,
           "name": "Spruce Wood",
-          "color": "2e1d0a"
+          "color": "#2e1d0a"
         },
         {
           "data": 2,
           "name": "Birch Wood",
-          "color": "d6dad6"
+          "color": "#d6dad6"
         },
         {
           "data": 3,
           "name": "Jungle Wood",
-          "color": "584219"
+          "color": "#584219"
         }
       ]
     },
     {
       "id": 18,
       "name": "Oak Leaves",
-      "color": "3d9b3d",
+      "color": "#3d9b3d",
       "transparent": true,
       "rendercube": true,
       "mask": 3,
@@ -242,93 +244,93 @@
         {
           "data": 1,
           "name": "Spruce Leaves",
-          "color": "519b5a"
+          "color": "#519b5a"
         },
         {
           "data": 2,
           "name": "Birch Leaves",
-          "color": "6faa3b"
+          "color": "#6faa3b"
         },
         {
           "data": 3,
           "name": "Jungle Leaves",
-          "color": "649642"
+          "color": "#649642"
         }
       ]
     },
     {
       "id": 19,
       "name": "Sponge",
-      "color": "c3c455",
+      "color": "#c3c455",
       "variants": [
         {
           "data": 1,
           "name": "Wet Sponge",
-          "color": "a09f3f"
+          "color": "#a09f3f"
         }
       ]
     },
     {
       "id": 20,
       "name": "Glass",
-      "color": "c0f5fe",
+      "color": "#c0f5fe",
       "alpha": 0.5,
       "transparent": true
     },
     {
       "id": 21,
       "name": "Lapis Lazuli Ore",
-      "color": "1b43ad"
+      "color": "#1b43ad"
     },
     {
       "id": 22,
       "name": "Lapis Lazuli Block",
-      "color": "0f26b8"
+      "color": "#0f26b8"
     },
     {
       "id": 23,
       "name": "Dispenser",
-      "color": "848484"
+      "color": "#848484"
     },
     {
       "id": 24,
       "name": "Sandstone",
-      "color": "dfd7a5",
+      "color": "#dfd7a5",
       "variants": [
         {
           "data": 1,
           "name": "Chiseled Sandstone",
-          "color": "ddd8ab"
+          "color": "#ddd8ab"
         },
         {
           "data": 2,
           "name": "Smooth Sandstone",
-          "color": "d9d29a"
+          "color": "#d9d29a"
         }
       ]
     },
     {
       "id": 25,
       "name": "Note Block",
-      "color": "915840"
+      "color": "#915840"
     },
     {
       "id": 26,
       "name": "Bed",
-      "color": "8c1616",
+      "color": "#8c1616",
       "transparent": true
     },
     {
       "id": 27,
       "name": "Powered Rail",
-      "color": "ab0301",
+      "color": "#ab0301",
       "transparent": true,
       "spawninside": true
     },
     {
       "id": 28,
       "name": "Detector Rail",
-      "color": "7d7171",
+      "color": "#7d7171",
       "transparent": true,
       "spawninside": true,
       "canProvidePower": true
@@ -336,19 +338,19 @@
     {
       "id": 29,
       "name": "Sticky Piston",
-      "color": "7bc070",
+      "color": "#7bc070",
       "transparent": true
     },
     {
       "id": 30,
       "name": "Cobweb",
-      "color": "ededed",
+      "color": "#ededed",
       "transparent": true
     },
     {
       "id": 31,
       "name": "Dead Shrub",
-      "color": "946428",
+      "color": "#946428",
       "alpha": 0.3,
       "transparent": true,
       "spawninside": true,
@@ -356,19 +358,19 @@
         {
           "data": 1,
           "name": "Tall Grass",
-          "color": "83bf54"
+          "color": "#83bf54"
         },
         {
           "data": 2,
           "name": "Fern",
-          "color": "8fbb64"
+          "color": "#8fbb64"
         }
       ]
     },
     {
       "id": 32,
       "name": "Dead Bush",
-      "color": "946428",
+      "color": "#946428",
       "transparent": true,
       "spawninside": true,
       "alpha": 0.3
@@ -376,105 +378,105 @@
     {
       "id": 33,
       "name": "Piston",
-      "color": "9f844d",
+      "color": "#9f844d",
       "transparent": true
     },
     {
       "id": 34,
       "name": "Piston Head",
-      "color": "b4905a"
+      "color": "#b4905a"
     },
     {
       "id": 35,
       "name": "White Wool",
-      "color": "eaeaea",
+      "color": "#eaeaea",
       "variants": [
         {
           "data": 1,
           "name": "Orange Wool",
-          "color": "db7b3b"
+          "color": "#db7b3b"
         },
         {
           "data": 2,
           "name": "Magenta Wool",
-          "color": "af44b8"
+          "color": "#af44b8"
         },
         {
           "data": 3,
           "name": "Light Blue Wool",
-          "color": "7e99d0"
+          "color": "#7e99d0"
         },
         {
           "data": 4,
           "name": "Yellow Wool",
-          "color": "bcb02a"
+          "color": "#bcb02a"
         },
         {
           "data": 5,
           "name": "Lime Wool",
-          "color": "44b93b"
+          "color": "#44b93b"
         },
         {
           "data": 6,
           "name": "Pink Wool",
-          "color": "d28a9e"
+          "color": "#d28a9e"
         },
         {
           "data": 7,
           "name": "Gray Wool",
-          "color": "454545"
+          "color": "#454545"
         },
         {
           "data": 8,
           "name": "Light Gray Wool",
-          "color": "909898"
+          "color": "#909898"
         },
         {
           "data": 9,
           "name": "Cyan Wool",
-          "color": "30728e"
+          "color": "#30728e"
         },
         {
           "data": 10,
           "name": "Purple Wool",
-          "color": "7737ad"
+          "color": "#7737ad"
         },
         {
           "data": 11,
           "name": "Blue Wool",
-          "color": "2b3585"
+          "color": "#2b3585"
         },
         {
           "data": 12,
           "name": "Brown Wool",
-          "color": "563822"
+          "color": "#563822"
         },
         {
           "data": 13,
           "name": "Green Wool",
-          "color": "314119"
+          "color": "#314119"
         },
         {
           "data": 14,
           "name": "Red Wool",
-          "color": "91312f"
+          "color": "#91312f"
         },
         {
           "data": 15,
           "name": "Black Wool",
-          "color": "1d1b1b"
+          "color": "#1d1b1b"
         }
       ]
     },
     {
       "id": 36,
       "name": "Piston Extension",
-      "color": "b4905a"
+      "color": "#b4905a"
     },
     {
       "id": 37,
       "name": "Dandelion",
-      "color": "f1f902",
+      "color": "#f1f902",
       "transparent": true,
       "spawninside": true,
       "alpha": 0.3
@@ -482,7 +484,7 @@
     {
       "id": 38,
       "name": "Poppy",
-      "color": "ba050b",
+      "color": "#ba050b",
       "transparent": true,
       "spawninside": true,
       "alpha": 0.3,
@@ -490,49 +492,49 @@
         {
           "data": 1,
           "name": "Blue Orchid",
-          "color": "29aefb"
+          "color": "#29aefb"
         },
         {
           "data": 2,
           "name": "Allium",
-          "color": "b865fb"
+          "color": "#b865fb"
         },
         {
           "data": 3,
           "name": "Azure Bluet",
-          "color": "e4eaf2"
+          "color": "#e4eaf2"
         },
         {
           "data": 4,
           "name": "Red Tulip",
-          "color": "d33a17"
+          "color": "#d33a17"
         },
         {
           "data": 5,
           "name": "Orange Tulip",
-          "color": "de731f"
+          "color": "#de731f"
         },
         {
           "data": 6,
           "name": "White Tulip",
-          "color": "e7e7e7"
+          "color": "#e7e7e7"
         },
         {
           "data": 7,
           "name": "Pink Tulip",
-          "color": "eabeea"
+          "color": "#eabeea"
         },
         {
           "data": 8,
           "name": "Oxeye Daisy",
-          "color": "eae6ad"
+          "color": "#eae6ad"
         }
       ]
     },
     {
       "id": 39,
       "name": "Brown Mushroom",
-      "color": "916d55",
+      "color": "#916d55",
       "transparent": true,
       "spawninside": true,
       "alpha": 0.3
@@ -540,7 +542,7 @@
     {
       "id": 40,
       "name": "Red Mushroom",
-      "color": "e21212",
+      "color": "#e21212",
       "transparent": true,
       "spawninside": true,
       "alpha": 0.3
@@ -548,306 +550,306 @@
     {
       "id": 41,
       "name": "Block of Gold",
-      "color": "fdfb4f"
+      "color": "#fdfb4f"
     },
     {
       "id": 42,
       "name": "Block of Iron",
-      "color": "e6e6e6"
+      "color": "#e6e6e6"
     },
     {
       "id": 43,
       "name": "Double Stone Slab",
-      "color": "a3a3a3",
+      "color": "#a3a3a3",
       "variants": [
         {
           "data": 1,
           "name": "Double Sandstone Slab",
-          "color": "d7ce95"
+          "color": "#d7ce95"
         },
         {
           "data": 2,
           "name": "Double Wooden Slab",
-          "color": "b4905a"
+          "color": "#b4905a"
         },
         {
           "data": 3,
           "name": "Double Cobblestone Slab",
-          "color": "8f8f8f"
+          "color": "#8f8f8f"
         },
         {
           "data": 4,
           "name": "Double Bricks Slab",
-          "color": "7c4536"
+          "color": "#7c4536"
         },
         {
           "data": 5,
           "name": "Double Stone Brick Slab",
-          "color": "797979"
+          "color": "#797979"
         },
         {
           "data": 6,
           "name": "Double Nether Brick Slab",
-          "color": "30181c"
+          "color": "#30181c"
         },
         {
           "data": 7,
           "name": "Double Quartz Slab",
-          "color": "f0eee8"
+          "color": "#f0eee8"
         },
         {
           "data": 8,
           "name": "Full Stone Slab",
-          "color": "9c9c9c"
+          "color": "#9c9c9c"
         },
         {
           "data": 9,
           "name": "Full Sandstone Slab",
-          "color": "d7cf9c"
+          "color": "#d7cf9c"
         }
       ]
     },
     {
       "id": 44,
       "name": "Stone Slab",
-      "color": "a3a3a3",
+      "color": "#a3a3a3",
       "transparent": true,
       "variants": [
         {
           "data": 1,
           "name": "Sandstone Slab",
-          "color": "d7ce95"
+          "color": "#d7ce95"
         },
         {
           "data": 2,
           "name": "Wooden Slab",
-          "color": "b4905a"
+          "color": "#b4905a"
         },
         {
           "data": 3,
           "name": "Cobblestone Slab",
-          "color": "8f8f8f"
+          "color": "#8f8f8f"
         },
         {
           "data": 4,
           "name": "Brick Slab",
-          "color": "7c4536"
+          "color": "#7c4536"
         },
         {
           "data": 5,
           "name": "Stone Brick Slab",
-          "color": "797979"
+          "color": "#797979"
         },
         {
           "data": 6,
           "name": "Nether Brick Slab",
-          "color": "30181c"
+          "color": "#30181c"
         },
         {
           "data": 7,
           "name": "Quartz Slab",
-          "color": "f0eee8"
+          "color": "#f0eee8"
         },
         {
           "data": 8,
           "name": "Upper Stone Slab",
-          "color": "a3a3a3"
+          "color": "#a3a3a3"
         },
         {
           "data": 9,
           "name": "Upper Sandstone Slab",
-          "color": "d7ce95"
+          "color": "#d7ce95"
         },
         {
           "data": 10,
           "name": "Upper Wooden Slab",
-          "color": "b4905a"
+          "color": "#b4905a"
         },
         {
           "data": 11,
           "name": "Upper Cobblestone Slab",
-          "color": "8f8f8f"
+          "color": "#8f8f8f"
         },
         {
           "data": 12,
           "name": "Upper Brick Slab",
-          "color": "7c4536"
+          "color": "#7c4536"
         },
         {
           "data": 13,
           "name": "Upper Stone Brick Slab",
-          "color": "797979"
+          "color": "#797979"
         },
         {
           "data": 14,
           "name": "Upper Nether Brick Slab",
-          "color": "30181c"
+          "color": "#30181c"
         },
         {
           "data": 15,
           "name": "Upper Quartz Slab",
-          "color": "f0eee8"
+          "color": "#f0eee8"
         }
       ]
     },
     {
       "id": 45,
       "name": "Bricks",
-      "color": "6a3b2e"
+      "color": "#6a3b2e"
     },
     {
       "id": 46,
       "name": "TNT",
-      "color": "a83414",
+      "color": "#a83414",
       "transparent": true
     },
     {
       "id": 47,
       "name": "Bookshelf",
-      "color": "9f844d"
+      "color": "#9f844d"
     },
     {
       "id": 48,
       "name": "Moss Stone",
-      "color": "3a623a"
+      "color": "#3a623a"
     },
     {
       "id": 49,
       "name": "Obsidian",
-      "color": "0e0e16"
+      "color": "#0e0e16"
     },
     {
       "id": 50,
       "name": "Torch",
-      "color": "ffd800",
+      "color": "#ffd800",
       "transparent": true
     },
     {
       "id": 51,
       "name": "Fire",
-      "color": "ff8f00",
+      "color": "#ff8f00",
       "transparent": true
     },
     {
       "id": 52,
       "name": "Monster Spawner",
-      "color": "1b2a35",
+      "color": "#1b2a35",
       "transparent": true,
       "rendercube": true
     },
     {
       "id": 53,
       "name": "Oak Wood Stairs",
-      "color": "9f844d",
+      "color": "#9f844d",
       "transparent": true
     },
     {
       "id": 54,
       "name": "Chest",
-      "color": "976b20",
+      "color": "#976b20",
       "transparent": true
     },
     {
       "id": 55,
       "name": "Redstone Wire",
-      "color": "d60000",
+      "color": "#d60000",
       "transparent": true
     },
     {
       "id": 56,
       "name": "Diamond Ore",
-      "color": "5decf5"
+      "color": "#5decf5"
     },
     {
       "id": 57,
       "name": "Block of Diamond",
-      "color": "91e8e4"
+      "color": "#91e8e4"
     },
     {
       "id": 58,
       "name": "Crafting Table",
-      "color": "a0693c"
+      "color": "#a0693c"
     },
     {
       "id": 59,
       "name": "Immature Wheat",
-      "color": "8ba803",
+      "color": "#8ba803",
       "transparent": true,
       "variants": [
         {
           "data": 7,
           "name": "Grown Wheat",
-          "color": "8e7c10"
+          "color": "#8e7c10"
         }
       ]
     },
     {
       "id": 60,
       "name": "Wet Farmland",
-      "color": "43240b",
+      "color": "#43240b",
       "transparent": true,
       "variants": [
         {
           "data": 0,
           "name": "Dry Farmland",
-          "color": "633f24"
+          "color": "#633f24"
         }
       ]
     },
     {
       "id": 61,
       "name": "Furnace",
-      "color": "535353"
+      "color": "#535353"
     },
     {
       "id": 62,
       "name": "Burning Furnace",
-      "color": "535353"
+      "color": "#535353"
     },
     {
       "id": 63,
       "name": "Sign Post",
-      "color": "9f844d",
+      "color": "#9f844d",
       "transparent": true,
       "spawninside": true
     },
     {
       "id": 64,
       "name": "Oak Door",
-      "color": "b0572a",
+      "color": "#b0572a",
       "transparent": true
     },
     {
       "id": 65,
       "name": "Ladder",
-      "color": "8e733c",
+      "color": "#8e733c",
       "transparent": true,
       "spawninside": true
     },
     {
       "id": 66,
       "name": "Rail",
-      "color": "a4a4a4",
+      "color": "#a4a4a4",
       "transparent": true,
       "spawninside": true
     },
     {
       "id": 67,
       "name": "Cobblestone Stairs",
-      "color": "565656",
+      "color": "#565656",
       "transparent": true
     },
     {
       "id": 68,
       "name": "Wall Sign",
-      "color": "b4905a",
+      "color": "#b4905a",
       "transparent": true,
       "spawninside": true
     },
     {
       "id": 69,
       "name": "Lever",
-      "color": "735e39",
+      "color": "#735e39",
       "transparent": true,
       "spawninside": true,
       "canProvidePower": true
@@ -855,7 +857,7 @@
     {
       "id": 70,
       "name": "Stone Pressure Plate",
-      "color": "8f8f8f",
+      "color": "#8f8f8f",
       "transparent": true,
       "spawninside": true,
       "canProvidePower": true
@@ -863,13 +865,13 @@
     {
       "id": 71,
       "name": "Iron Door",
-      "color": "b6b6b6",
+      "color": "#b6b6b6",
       "transparent": true
     },
     {
       "id": 72,
       "name": "Wooden Pressure Plate",
-      "color": "bc9862",
+      "color": "#bc9862",
       "transparent": true,
       "spawninside": true,
       "canProvidePower": true
@@ -877,31 +879,31 @@
     {
       "id": 73,
       "name": "Redstone Ore",
-      "color": "8f0303"
+      "color": "#8f0303"
     },
     {
       "id": 74,
       "name": "Redstone Ore (glowing)",
-      "color": "8f0303"
+      "color": "#8f0303"
     },
     {
       "id": 75,
       "name": "Redstone Torch (off)",
-      "color": "480000",
+      "color": "#480000",
       "transparent": true,
       "canProvidePower": true
     },
     {
       "id": 76,
       "name": "Redstone Torch (on)",
-      "color": "fd0000",
+      "color": "#fd0000",
       "transparent": true,
       "canProvidePower": true
     },
     {
       "id": 77,
       "name": "Stone Button",
-      "color": "a8a8a8",
+      "color": "#a8a8a8",
       "transparent": true,
       "spawninside": true,
       "canProvidePower": true
@@ -909,14 +911,14 @@
     {
       "id": 78,
       "name": "Snow",
-      "color": "eeffff",
+      "color": "#eeffff",
       "spawninside": true,
       "transparent": true
     },
     {
       "id": 79,
       "name": "Ice",
-      "color": "77a9ff",
+      "color": "#77a9ff",
       "alpha": 0.62,
       "transparent": true,
       "rendercube": true
@@ -924,468 +926,468 @@
     {
       "id": 80,
       "name": "Snow Block",
-      "color": "eeffff"
+      "color": "#eeffff"
     },
     {
       "id": 81,
       "name": "Cactus",
-      "color": "107e1d",
+      "color": "#107e1d",
       "transparent": true
     },
     {
       "id": 82,
       "name": "Clay Block",
-      "color": "9da3ae"
+      "color": "#9da3ae"
     },
     {
       "id": 83,
       "name": "Sugar Cane",
-      "color": "aadb74",
+      "color": "#aadb74",
       "spawninside": true,
       "transparent": true
     },
     {
       "id": 84,
       "name": "Jukebox",
-      "color": "945f44"
+      "color": "#945f44"
     },
     {
       "id": 85,
       "name": "Oak Fence",
-      "color": "b4905a",
+      "color": "#b4905a",
       "alpha": 0.75,
       "transparent": true
     },
     {
       "id": 86,
       "name": "Pumpkin",
-      "color": "e3901d"
+      "color": "#e3901d"
     },
     {
       "id": 87,
       "name": "Netherrack",
-      "color": "955744"
+      "color": "#955744"
     },
     {
       "id": 88,
       "name": "Soul Sand",
-      "color": "554134"
+      "color": "#554134"
     },
     {
       "id": 89,
       "name": "Glowstone Block",
-      "color": "f9d49c"
+      "color": "#f9d49c"
     },
     {
       "id": 90,
       "name": "Nether Portal",
-      "color": "d67fff",
+      "color": "#d67fff",
       "transparent": true
     },
     {
       "id": 91,
       "name": "Jack o'Lantern",
-      "color": "e9b416"
+      "color": "#e9b416"
     },
     {
       "id": 92,
       "name": "Cake",
-      "color": "eae9eb",
+      "color": "#eae9eb",
       "transparent": true
     },
     {
       "id": 93,
       "name": "Redstone Repeater (off)",
-      "color": "2a0002",
+      "color": "#2a0002",
       "transparent": true,
       "canProvidePower": true
     },
     {
       "id": 94,
       "name": "Redstone Repeater (on)",
-      "color": "fd0101",
+      "color": "#fd0101",
       "transparent": true,
       "canProvidePower": true
     },
     {
       "id": 95,
       "name": "White Stained Glass",
-      "color": "ffffff",
+      "color": "#ffffff",
       "transparent": true,
       "alpha": 0.5,
       "variants": [
         {
           "data": 1,
           "name": "Orange Stained Glass",
-          "color": "d87f33"
+          "color": "#d87f33"
         },
         {
           "data": 2,
           "name": "Magenta Stained Glass",
-          "color": "b24cd8"
+          "color": "#b24cd8"
         },
         {
           "data": 3,
           "name": "Light Blue Stained Glass",
-          "color": "6699d8"
+          "color": "#6699d8"
         },
         {
           "data": 4,
           "name": "Yellow Stained Glass",
-          "color": "e5e533"
+          "color": "#e5e533"
         },
         {
           "data": 5,
           "name": "Lime Stained Glass",
-          "color": "7fcc19"
+          "color": "#7fcc19"
         },
         {
           "data": 6,
           "name": "Pink Stained Glass",
-          "color": "f27fa5"
+          "color": "#f27fa5"
         },
         {
           "data": 7,
           "name": "Gray Stained Glass",
-          "color": "4c4c4c"
+          "color": "#4c4c4c"
         },
         {
           "data": 8,
           "name": "Silver Stained Glass",
-          "color": "999999"
+          "color": "#999999"
         },
         {
           "data": 9,
           "name": "Cyan Stained Glass",
-          "color": "4c7f99"
+          "color": "#4c7f99"
         },
         {
           "data": 10,
           "name": "Purple Stained Glass",
-          "color": "7f3fb2"
+          "color": "#7f3fb2"
         },
         {
           "data": 11,
           "name": "Blue Stained Glass",
-          "color": "334cb2"
+          "color": "#334cb2"
         },
         {
           "data": 12,
           "name": "Brown Stained Glass",
-          "color": "664c33"
+          "color": "#664c33"
         },
         {
           "data": 13,
           "name": "Green Stained Glass",
-          "color": "667f33"
+          "color": "#667f33"
         },
         {
           "data": 14,
           "name": "Red Stained Glass",
-          "color": "993333"
+          "color": "#993333"
         },
         {
           "data": 15,
           "name": "Black Stained Glass",
-          "color": "191919"
+          "color": "#191919"
         }
       ]
     },
     {
       "id": 96,
       "name": "Wooden Trapdoor",
-      "color": "7c5a2a",
+      "color": "#7c5a2a",
       "transparent": true
     },
     {
       "id": 97,
       "name": "Stone Monster Egg",
-      "color": "7a7a7a",
+      "color": "#7a7a7a",
       "variants": [
         {
           "data": 1,
           "name": "Cobblestone Monster Egg",
-          "color": "787878"
+          "color": "#787878"
         },
         {
           "data": 2,
           "name": "Stone Brick Monster Egg",
-          "color": "777777"
+          "color": "#777777"
         },
         {
           "data": 3,
           "name": "Mossy Stone Brick Monster Egg",
-          "color": "707467"
+          "color": "#707467"
         },
         {
           "data": 4,
           "name": "Cracked Stone Brick Monster Egg",
-          "color": "747474"
+          "color": "#747474"
         },
         {
           "data": 5,
           "name": "Chiseled Stone Brick Monster Egg",
-          "color": "747474"
+          "color": "#747474"
         }
       ]
     },
     {
       "id": 98,
       "name": "Stone Brick",
-      "color": "797979",
+      "color": "#797979",
       "variants": [
         {
           "data": 1,
           "name": "Mossy Stone Brick",
-          "color": "637049"
+          "color": "#637049"
         },
         {
           "data": 2,
           "name": "Cracked Stone Brick",
-          "color": "656565"
+          "color": "#656565"
         },
         {
           "data": 3,
           "name": "Chiseled Stone Brick",
-          "color": "9c9c9c"
+          "color": "#9c9c9c"
         }
       ]
     },
     {
       "id": 99,
       "name": "Huge Brown Mushroom",
-      "color": "d2b17d",
+      "color": "#d2b17d",
       "variants": [
         {
           "data": 1,
-          "color": "8f6b53"
+          "color": "#8f6b53"
         },
         {
           "data": 2,
-          "color": "8f6b53"
+          "color": "#8f6b53"
         },
         {
           "data": 3,
-          "color": "8f6b53"
+          "color": "#8f6b53"
         },
         {
           "data": 4,
-          "color": "8f6b53"
+          "color": "#8f6b53"
         },
         {
           "data": 5,
-          "color": "8f6b53"
+          "color": "#8f6b53"
         },
         {
           "data": 6,
-          "color": "8f6b53"
+          "color": "#8f6b53"
         },
         {
           "data": 7,
-          "color": "8f6b53"
+          "color": "#8f6b53"
         },
         {
           "data": 8,
-          "color": "8f6b53"
+          "color": "#8f6b53"
         },
         {
           "data": 9,
-          "color": "8f6b53"
+          "color": "#8f6b53"
         },
         {
           "data": 10,
-          "color": "d2b17d"
+          "color": "#d2b17d"
         },
         {
           "data": 14,
-          "color": "8f6b53"
+          "color": "#8f6b53"
         },
         {
           "data": 15,
-          "color": "cdc9bf"
+          "color": "#cdc9bf"
         }
       ]
     },
     {
       "id": 100,
       "name": "Huge Red Mushroom",
-      "color": "d2b17d",
+      "color": "#d2b17d",
       "variants": [
         {
           "data": 1,
-          "color": "b51d1b"
+          "color": "#b51d1b"
         },
         {
           "data": 2,
-          "color": "b51d1b"
+          "color": "#b51d1b"
         },
         {
           "data": 3,
-          "color": "b51d1b"
+          "color": "#b51d1b"
         },
         {
           "data": 4,
-          "color": "b51d1b"
+          "color": "#b51d1b"
         },
         {
           "data": 5,
-          "color": "b51d1b"
+          "color": "#b51d1b"
         },
         {
           "data": 6,
-          "color": "b51d1b"
+          "color": "#b51d1b"
         },
         {
           "data": 7,
-          "color": "b51d1b"
+          "color": "#b51d1b"
         },
         {
           "data": 8,
-          "color": "b51d1b"
+          "color": "#b51d1b"
         },
         {
           "data": 9,
-          "color": "b51d1b"
+          "color": "#b51d1b"
         },
         {
           "data": 10,
-          "color": "d2b17d"
+          "color": "#d2b17d"
         },
         {
           "data": 14,
-          "color": "b51d1b"
+          "color": "#b51d1b"
         },
         {
           "data": 15,
-          "color": "cdc9bf"
+          "color": "#cdc9bf"
         }
       ]
     },
     {
       "id": 101,
       "name": "Iron Bars",
-      "color": "6d6e6e",
+      "color": "#6d6e6e",
       "transparent": true
     },
     {
       "id": 102,
       "name": "Glass Pane",
-      "color": "c0f5fe",
+      "color": "#c0f5fe",
       "alpha": 0.5,
       "transparent": true
     },
     {
       "id": 103,
       "name": "Melon",
-      "color": "adb82c"
+      "color": "#adb82c"
     },
     {
       "id": 104,
       "name": "Pumpkin Stem",
-      "color": "6b6b0b",
+      "color": "#6b6b0b",
       "transparent": true
     },
     {
       "id": 105,
       "name": "Melon Stem",
-      "color": "6b6b0b",
+      "color": "#6b6b0b",
       "transparent": true
     },
     {
       "id": 106,
       "name": "Vines",
-      "color": "6cc44a",
+      "color": "#6cc44a",
       "transparent": true,
       "spawninside": true
     },
     {
       "id": 107,
       "name": "Oak Fence Gate",
-      "color": "b4905a",
+      "color": "#b4905a",
       "alpha": 0.75,
       "transparent": true
     },
     {
       "id": 108,
       "name": "Brick Stairs",
-      "color": "7c4536",
+      "color": "#7c4536",
       "transparent": true
     },
     {
       "id": 109,
       "name": "Stone Brick Stairs",
-      "color": "727272",
+      "color": "#727272",
       "transparent": true
     },
     {
       "id": 110,
       "name": "Mycelium",
-      "color": "806b6f"
+      "color": "#806b6f"
     },
     {
       "id": 111,
       "name": "Lily Pad",
-      "color": "88bf54",
+      "color": "#88bf54",
       "transparent": true
     },
     {
       "id": 112,
       "name": "Nether Brick",
-      "color": "30181c"
+      "color": "#30181c"
     },
     {
       "id": 113,
       "name": "Nether Brick Fence",
-      "color": "1c0e10",
+      "color": "#1c0e10",
       "transparent": true
     },
     {
       "id": 114,
       "name": "Nether Brick Stairs",
-      "color": "381a1f",
+      "color": "#381a1f",
       "transparent": true
     },
     {
       "id": 115,
       "name": "Immature Nether Wart",
-      "color": "70081c",
+      "color": "#70081c",
       "transparent": true,
       "variants": [
         {
           "data": 3,
           "name": "Mature Nether Wart",
-          "color": "8e181b"
+          "color": "#8e181b"
         }
       ]
     },
     {
       "id": 116,
       "name": "Enchantment Table",
-      "color": "3c3056",
+      "color": "#3c3056",
       "transparent": true
     },
     {
       "id": 117,
       "name": "Brewing Stand",
-      "color": "bea84a",
+      "color": "#bea84a",
       "transparent": true
     },
     {
       "id": 118,
       "name": "Cauldron",
-      "color": "4d4d4d",
+      "color": "#4d4d4d",
       "transparent": true
     },
     {
       "id": 119,
       "name": "End Portal",
-      "color": "0c0b0a",
+      "color": "#0c0b0a",
       "transparent": true
     },
     {
       "id": 120,
       "name": "End Portal Frame",
-      "color": "2f5754",
+      "color": "#2f5754",
       "mask": 4,
       "transparent": true,
       "rendercube": true,
@@ -1393,130 +1395,130 @@
         {
           "data": 4,
           "name": "End Portal Frame (on)",
-          "color": "406852"
+          "color": "#406852"
         }
       ]
     },
     {
       "id": 121,
       "name": "End Stone",
-      "color": "d9dc9e"
+      "color": "#d9dc9e"
     },
     {
       "id": 122,
       "name": "Dragon Egg",
-      "color": "2d0133"
+      "color": "#2d0133"
     },
     {
       "id": 123,
       "name": "Redstone Lamp (off)",
-      "color": "b0744c"
+      "color": "#b0744c"
     },
     {
       "id": 124,
       "name": "Redstone Lamp (on)",
-      "color": "f1d1af",
+      "color": "#f1d1af",
       "transparent": true
     },
     {
       "id": 125,
       "name": "Double Oak Wood Slab",
-      "color": "b4905a",
+      "color": "#b4905a",
       "variants": [
         {
           "data": 1,
           "name": "Double Spruce Wood Slab",
-          "color": "664f2f"
+          "color": "#664f2f"
         },
         {
           "data": 2,
           "name": "Double Birch Wood Slab",
-          "color": "d7cb8d"
+          "color": "#d7cb8d"
         },
         {
           "data": 3,
           "name": "Double Jungle Wood Slab",
-          "color": "b1805c"
+          "color": "#b1805c"
         },
         {
           "data": 4,
           "name": "Double Acacia Wood Slab",
-          "color": "ad5d32"
+          "color": "#ad5d32"
         },
         {
           "data": 5,
           "name": "Double Dark Oak Wood Slab",
-          "color": "462d15"
+          "color": "#462d15"
         }
       ]
     },
     {
       "id": 126,
       "name": "Oak Wood Slab",
-      "color": "b4905a",
+      "color": "#b4905a",
       "transparent": true,
       "variants": [
         {
           "data": 1,
           "name": "Spruce Wood Slab",
-          "color": "664f2f"
+          "color": "#664f2f"
         },
         {
           "data": 2,
           "name": "Birch Wood Slab",
-          "color": "d7cb8d"
+          "color": "#d7cb8d"
         },
         {
           "data": 3,
           "name": "Jungle Wood Slab",
-          "color": "b1805c"
+          "color": "#b1805c"
         },
         {
           "data": 4,
           "name": "Acacia Wood Slab",
-          "color": "ba6337"
+          "color": "#ba6337"
         },
         {
           "data": 5,
           "name": "Dark Oak Wood Slab",
-          "color": "462d15"
+          "color": "#462d15"
         },
         {
           "data": 8,
           "name": "Upper Oak Wood Slab",
-          "color": "b4905a"
+          "color": "#b4905a"
         },
         {
           "data": 9,
           "name": "Upper Spruce Wood Slab",
-          "color": "664f2f"
+          "color": "#664f2f"
         },
         {
           "data": 10,
           "name": "Upper Birch Wood Slab",
-          "color": "d7cb8d"
+          "color": "#d7cb8d"
         },
         {
           "data": 11,
           "name": "Upper Jungle Wood Slab",
-          "color": "b1805c"
+          "color": "#b1805c"
         },
         {
           "data": 12,
           "name": "Upper Acacia Wood Slab",
-          "color": "ba6337"
+          "color": "#ba6337"
         },
         {
           "data": 13,
           "name": "Upper Dark Oak Wood Slab",
-          "color": "462d15"
+          "color": "#462d15"
         }
       ]
     },
     {
       "id": 127,
       "name": "Immature Cocoa Pod",
-      "color": "929943",
+      "color": "#929943",
       "transparent": true,
       "spawninside": true,
       "mask": 12,
@@ -1524,31 +1526,31 @@
         {
           "data": 8,
           "name": "Mature Cocoa Pod",
-          "color": "d4924c"
+          "color": "#d4924c"
         }
       ]
     },
     {
       "id": 128,
       "name": "Sandstone Stairs",
-      "color": "e9e0b3",
+      "color": "#e9e0b3",
       "transparent": true
     },
     {
       "id": 129,
       "name": "Emerald Ore",
-      "color": "17dd62"
+      "color": "#17dd62"
     },
     {
       "id": 130,
       "name": "Ender Chest",
-      "color": "2d4042",
+      "color": "#2d4042",
       "transparent": true
     },
     {
       "id": 131,
       "name": "Tripwire Hook",
-      "color": "6e6e6e",
+      "color": "#6e6e6e",
       "transparent": true,
       "spawninside": true,
       "canProvidePower": true
@@ -1556,151 +1558,151 @@
     {
       "id": 132,
       "name": "Tripwire",
-      "color": "ebebeb",
+      "color": "#ebebeb",
       "transparent": true
     },
     {
       "id": 133,
       "name": "Block of Emerald",
-      "color": "64ea8a"
+      "color": "#64ea8a"
     },
     {
       "id": 134,
       "name": "Spruce Wood Stairs",
-      "color": "664f2f",
+      "color": "#664f2f",
       "transparent": true
     },
     {
       "id": 135,
       "name": "Birch Wood Stairs",
-      "color": "d7cb8d",
+      "color": "#d7cb8d",
       "transparent": true
     },
     {
       "id": 136,
       "name": "Jungle Wood Stairs",
-      "color": "b1805c",
+      "color": "#b1805c",
       "transparent": true
     },
     {
       "id": 137,
       "name": "Command Block",
-      "color": "b18972"
+      "color": "#b18972"
     },
     {
       "id": 138,
       "name": "Beacon",
-      "color": "c4fffe"
+      "color": "#c4fffe"
     },
     {
       "id": 139,
       "name": "Cobblestone Wall",
-      "color": "505050",
+      "color": "#505050",
       "transparent": true
     },
     {
       "id": 140,
       "name": "Flower Pot (empty)",
-      "color": "7c4536",
+      "color": "#7c4536",
       "transparent": true,
       "variants": [
         {
           "data": 1,
           "name": "Flower Pot (poppy)",
-          "color": "910205"
+          "color": "#910205"
         },
         {
           "data": 2,
           "name": "Flower Pot (dandelion)",
-          "color": "f1f902"
+          "color": "#f1f902"
         },
         {
           "data": 3,
           "name": "Flower Pot (oak)",
-          "color": "408f2f"
+          "color": "#408f2f"
         },
         {
           "data": 4,
           "name": "Flower Pot (spruce)",
-          "color": "395a39"
+          "color": "#395a39"
         },
         {
           "data": 5,
           "name": "Flower Pot (birch)",
-          "color": "cfe3ba"
+          "color": "#cfe3ba"
         },
         {
           "data": 6,
           "name": "Flower Pot (jungle)",
-          "color": "2c6c18"
+          "color": "#2c6c18"
         },
         {
           "data": 7,
           "name": "Flower Pot (red mushroom)",
-          "color": "9a171c"
+          "color": "#9a171c"
         },
         {
           "data": 8,
           "name": "Flower Pot (brown mushroom)",
-          "color": "725643"
+          "color": "#725643"
         },
         {
           "data": 9,
           "name": "Flower Pot (cactus)",
-          "color": "128a20"
+          "color": "#128a20"
         },
         {
           "data": 10,
           "name": "Flower Pot (dead bush)",
-          "color": "946428"
+          "color": "#946428"
         },
         {
           "data": 11,
           "name": "Flower Pot (fern)",
-          "color": "315e05"
+          "color": "#315e05"
         },
         {
           "data": 12,
           "name": "Flower Pot (acacia)",
-          "color": "946428"
+          "color": "#946428"
         },
         {
           "data": 13,
           "name": "Flower Pot (dark oak)",
-          "color": "315e05"
+          "color": "#315e05"
         }
       ]
     },
     {
       "id": 141,
       "name": "Immature Carrots",
-      "color": "00c617",
+      "color": "#00c617",
       "transparent": true,
       "variants": [
         {
           "data": 7,
           "name": "Mature Carrots",
-          "color": "004e00"
+          "color": "#004e00"
         }
       ]
     },
     {
       "id": 142,
       "name": "Immature Potatoes",
-      "color": "00c617",
+      "color": "#00c617",
       "transparent": true,
       "variants": [
         {
           "data": 7,
           "name": "Mature Potatoes",
-          "color": "3aa649"
+          "color": "#3aa649"
         }
       ]
     },
     {
       "id": 143,
       "name": "Wooden Button",
-      "color": "b4905a",
+      "color": "#b4905a",
       "transparent": true,
       "spawninside": true,
       "canProvidePower": true
@@ -1708,13 +1710,13 @@
     {
       "id": 144,
       "name": "Mob Head",
-      "color": "1a1a1a",
+      "color": "#1a1a1a",
       "transparent": true
     },
     {
       "id": 145,
       "name": "Anvil",
-      "color": "474747",
+      "color": "#474747",
       "transparent": true,
       "mask": 12,
       "variants": [
@@ -1731,14 +1733,14 @@
     {
       "id": 146,
       "name": "Trapped Chest",
-      "color": "ab792d",
+      "color": "#ab792d",
       "transparent": true,
       "canProvidePower": true
     },
     {
       "id": 147,
       "name": "Weighted Pressure Plate (Light)",
-      "color": "fdfb4f",
+      "color": "#fdfb4f",
       "transparent": true,
       "spawninside": true,
       "canProvidePower": true
@@ -1746,7 +1748,7 @@
     {
       "id": 148,
       "name": "Weighted Pressure Plate (Heavy)",
-      "color": "e6e6e6",
+      "color": "#e6e6e6",
       "transparent": true,
       "spawninside": true,
       "canProvidePower": true
@@ -1754,257 +1756,257 @@
     {
       "id": 149,
       "name": "Redstone Comparator (off)",
-      "color": "4f1010",
+      "color": "#4f1010",
       "transparent": true,
       "canProvidePower": true
     },
     {
       "id": 150,
       "name": "Redstone Comparator (on)",
-      "color": "fd1010",
+      "color": "#fd1010",
       "transparent": true,
       "canProvidePower": true
     },
     {
       "id": 151,
       "name": "Daylight Sensor",
-      "color": "d2c1ab",
+      "color": "#d2c1ab",
       "transparent": true,
       "canProvidePower": true
     },
     {
       "id": 152,
       "name": "Block of Redstone",
-      "color": "bb1c0a",
+      "color": "#bb1c0a",
       "transparent": true,
       "canProvidePower": true
     },
     {
       "id": 153,
       "name": "Nether Quartz Ore",
-      "color": "ddcbbe"
+      "color": "#ddcbbe"
     },
     {
       "id": 154,
       "name": "Hopper",
-      "color": "444444",
+      "color": "#444444",
       "transparent": true
     },
     {
       "id": 155,
       "name": "Block of Quartz",
-      "color": "edebe5",
+      "color": "#edebe5",
       "variants": [
         {
           "data": 1,
           "name": "Chiseled Quartz Block",
-          "color": "e3dfd5"
+          "color": "#e3dfd5"
         },
         {
           "data": 2,
           "name": "Pillar Quartz Block",
-          "color": "e1dcd3"
+          "color": "#e1dcd3"
         },
         {
           "data": 3,
           "name": "Pillar Quartz Block",
-          "color": "e1dcd3"
+          "color": "#e1dcd3"
         },
         {
           "data": 4,
           "name": "Pillar Quartz Block",
-          "color": "e1dcd3"
+          "color": "#e1dcd3"
         }
       ]
     },
     {
       "id": 156,
       "name": "Quartz Stairs",
-      "color": "dfdacf",
+      "color": "#dfdacf",
       "transparent": true
     },
     {
       "id": 157,
       "name": "Activator Rail",
-      "color": "ab0301",
+      "color": "#ab0301",
       "transparent": true,
       "spawninside": true
     },
     {
       "id": 158,
       "name": "Dropper",
-      "color": "848484"
+      "color": "#848484"
     },
     {
       "id": 159,
       "name": "White Stained Clay",
-      "color": "d1b1a1",
+      "color": "#d1b1a1",
       "variants": [
         {
           "data": 1,
           "name": "Orange Stained Clay",
-          "color": "a55728"
+          "color": "#a55728"
         },
         {
           "data": 2,
           "name": "Magenta Stained Clay",
-          "color": "95586d"
+          "color": "#95586d"
         },
         {
           "data": 3,
           "name": "Light Blue Stained Clay",
-          "color": "6f6b89"
+          "color": "#6f6b89"
         },
         {
           "data": 4,
           "name": "Yellow Stained Clay",
-          "color": "b9821f"
+          "color": "#b9821f"
         },
         {
           "data": 5,
           "name": "Lime Stained Clay",
-          "color": "667330"
+          "color": "#667330"
         },
         {
           "data": 6,
           "name": "Pink Stained Clay",
-          "color": "a04b4e"
+          "color": "#a04b4e"
         },
         {
           "data": 7,
           "name": "Gray Stained Clay",
-          "color": "3a2a24"
+          "color": "#3a2a24"
         },
         {
           "data": 8,
           "name": "Silver Stained Clay",
-          "color": "876b62"
+          "color": "#876b62"
         },
         {
           "data": 9,
           "name": "Cyan Stained Clay",
-          "color": "565a5b"
+          "color": "#565a5b"
         },
         {
           "data": 10,
           "name": "Purple Stained Clay",
-          "color": "734454"
+          "color": "#734454"
         },
         {
           "data": 11,
           "name": "Blue Stained Clay",
-          "color": "4a3b5b"
+          "color": "#4a3b5b"
         },
         {
           "data": 12,
           "name": "Brown Stained Clay",
-          "color": "4d3324"
+          "color": "#4d3324"
         },
         {
           "data": 13,
           "name": "Green Stained Clay",
-          "color": "4e562c"
+          "color": "#4e562c"
         },
         {
           "data": 14,
           "name": "Red Stained Clay",
-          "color": "8e3d2f"
+          "color": "#8e3d2f"
         },
         {
           "data": 15,
           "name": "Black Stained Clay",
-          "color": "271912"
+          "color": "#271912"
         }
       ]
     },
     {
       "id": 160,
       "name": "White Stained Glass Pane",
-      "color": "ededed",
+      "color": "#ededed",
       "alpha": 0.5,
       "transparent": true,
       "variants": [
         {
           "data": 1,
           "name": "Orange Stained Glass Pane",
-          "color": "c9762f"
+          "color": "#c9762f"
         },
         {
           "data": 2,
           "name": "Magenta Stained Glass Pane",
-          "color": "aa49cf"
+          "color": "#aa49cf"
         },
         {
           "data": 3,
           "name": "Light Blue Stained Glass Pane",
-          "color": "5e8ec9"
+          "color": "#5e8ec9"
         },
         {
           "data": 4,
           "name": "Yellow Stained Glass Pane",
-          "color": "e4e432"
+          "color": "#e4e432"
         },
         {
           "data": 5,
           "name": "Lime Stained Glass Pane",
-          "color": "76bd17"
+          "color": "#76bd17"
         },
         {
           "data": 6,
           "name": "Pink Stained Glass Pane",
-          "color": "e1769a"
+          "color": "#e1769a"
         },
         {
           "data": 7,
           "name": "Gray Stained Glass Pane",
-          "color": "4c4c4c"
+          "color": "#4c4c4c"
         },
         {
           "data": 8,
           "name": "Silver Stained Glass Pane",
-          "color": "929292"
+          "color": "#929292"
         },
         {
           "data": 9,
           "name": "Cyan Stained Glass Pane",
-          "color": "4c7f98"
+          "color": "#4c7f98"
         },
         {
           "data": 10,
           "name": "Purple Stained Glass Pane",
-          "color": "7f3fb1"
+          "color": "#7f3fb1"
         },
         {
           "data": 11,
           "name": "Blue Stained Glass Pane",
-          "color": "324cb1"
+          "color": "#324cb1"
         },
         {
           "data": 12,
           "name": "Brown Stained Glass Pane",
-          "color": "654c32"
+          "color": "#654c32"
         },
         {
           "data": 13,
           "name": "Green Stained Glass Pane",
-          "color": "617a30"
+          "color": "#617a30"
         },
         {
           "data": 14,
           "name": "Red Stained Glass Pane",
-          "color": "923030"
+          "color": "#923030"
         },
         {
           "data": 15,
           "name": "Black Stained Glass Pane",
-          "color": "191919"
+          "color": "#191919"
         }
       ]
     },
     {
       "id": 161,
       "name": "Acacia Leaves",
-      "color": "97a636",
+      "color": "#97a636",
       "transparent": true,
       "rendercube": true,
       "mask": 1,
@@ -2012,219 +2014,219 @@
         {
           "data": 1,
           "name": "Dark Oak Leaves",
-          "color": "45751c"
+          "color": "#45751c"
         }
       ]
     },
     {
       "id": 162,
       "name": "Acacia Wood",
-      "color": "b25b3b",
+      "color": "#b25b3b",
       "mask": 1,
       "variants": [
         {
           "data": 1,
           "name": "Dark Oak Wood",
-          "color": "5d4931"
+          "color": "#5d4931"
         }
       ]
     },
     {
       "id": 163,
       "name": "Acacia Stairs",
-      "color": "a15730",
+      "color": "#a15730",
       "transparent": true
     },
     {
       "id": 164,
       "name": "Dark Oak Stairs",
-      "color": "492f17",
+      "color": "#492f17",
       "transparent": true
     },
     {
       "id": 165,
       "name": "Slime Block",
-      "color": "59994a"
+      "color": "#59994a"
     },
     {
       "id": 166,
       "name": "Barrier",
-      "color": "00000000",
+      "color": "#00000000",
       "alpha": 0.0
     },
     {
       "id": 167,
       "name": "Iron Trapdoor",
-      "color": "c7c7c7",
+      "color": "#c7c7c7",
       "transparent": true
     },
     {
       "id": 168,
       "name": "Prismarine",
-      "color": "6baa97",
+      "color": "#6baa97",
       "variants": [
         {
           "data": 1,
           "name": "Prismarine Bricks",
-          "color": "64a08f"
+          "color": "#64a08f"
         },
         {
           "data": 2,
           "name": "Dark Prismarine",
-          "color": "3c584b"
+          "color": "#3c584b"
         }
       ]
     },
     {
       "id": 169,
       "name": "Sea Lantern",
-      "color": "abc8be"
+      "color": "#abc8be"
     },
     {
       "id": 170,
       "name": "Hay Bale",
-      "color": "af9711"
+      "color": "#af9711"
     },
     {
       "id": 171,
       "name": "White Carpet",
-      "color": "dddddd",
+      "color": "#dddddd",
       "transparent": true,
       "variants": [
         {
           "data": 1,
           "name": "Orange Carpet",
-          "color": "dd8143"
+          "color": "#dd8143"
         },
         {
           "data": 2,
           "name": "Magenta Carpet",
-          "color": "b650c0"
+          "color": "#b650c0"
         },
         {
           "data": 3,
           "name": "Light Blue Carpet",
-          "color": "8ea6d6"
+          "color": "#8ea6d6"
         },
         {
           "data": 4,
           "name": "Yellow Carpet",
-          "color": "c4b82e"
+          "color": "#c4b82e"
         },
         {
           "data": 5,
           "name": "Lime Carpet",
-          "color": "53c347"
+          "color": "#53c347"
         },
         {
           "data": 6,
           "name": "Pink Carpet",
-          "color": "cb778d"
+          "color": "#cb778d"
         },
         {
           "data": 7,
           "name": "Gray Carpet",
-          "color": "3b3b3b"
+          "color": "#3b3b3b"
         },
         {
           "data": 8,
           "name": "Silver Carpet",
-          "color": "aab0b0"
+          "color": "#aab0b0"
         },
         {
           "data": 9,
           "name": "Cyan Carpet",
-          "color": "2d6a83"
+          "color": "#2d6a83"
         },
         {
           "data": 10,
           "name": "Purple Carpet",
-          "color": "7537a9"
+          "color": "#7537a9"
         },
         {
           "data": 11,
           "name": "Blue Carpet",
-          "color": "323e9a"
+          "color": "#323e9a"
         },
         {
           "data": 12,
           "name": "Brown Carpet",
-          "color": "482e1c"
+          "color": "#482e1c"
         },
         {
           "data": 13,
           "name": "Green Carpet",
-          "color": "314119"
+          "color": "#314119"
         },
         {
           "data": 14,
           "name": "Red Carpet",
-          "color": "963330"
+          "color": "#963330"
         },
         {
           "data": 15,
           "name": "Black Carpet",
-          "color": "151111"
+          "color": "#151111"
         }
       ]
     },
     {
       "id": 172,
       "name": "Hardened Clay",
-      "color": "945a41"
+      "color": "#945a41"
     },
     {
       "id": 173,
       "name": "Block of Coal",
-      "color": "2b2b2b"
+      "color": "#2b2b2b"
     },
     {
       "id": 174,
       "name": "Packed Ice",
-      "color": "bfcee8"
+      "color": "#bfcee8"
     },
     {
       "id": 175,
       "name": "Sunflower",
-      "color": "f1e424",
+      "color": "#f1e424",
       "transparent": true,
       "spawninside": true,
       "variants": [
         {
           "data": 1,
           "name": "Lilac",
-          "color": "9f78a4"
+          "color": "#9f78a4"
         },
         {
           "data": 2,
           "name": "Double Tallgrass",
-          "color": "5e8328"
+          "color": "#5e8328"
         },
         {
           "data": 3,
           "name": "Large Fern",
-          "color": "617b2d"
+          "color": "#617b2d"
         },
         {
           "data": 4,
           "name": "Rose Bush",
-          "color": "ba050b"
+          "color": "#ba050b"
         },
         {
           "data": 5,
           "name": "Peony",
-          "color": "e6bff7"
+          "color": "#e6bff7"
         },
         {
           "data": 8,
           "name": "Large Flower (top part)",
-          "color": "ffffff",
+          "color": "#ffffff",
           "alpha": 0.0
         },
         {
           "data": 10,
           "name": "Large Flower (top part)",
-          "color": "ffffff",
+          "color": "#ffffff",
           "alpha": 0.0
         }
       ]
@@ -2232,261 +2234,261 @@
     {
       "id": 176,
       "name": "Standing Banner",
-      "color": "ffffff",
+      "color": "#ffffff",
       "transparent": true
     },
     {
       "id": 177,
       "name": "Wall Banner",
-      "color": "ffffff",
+      "color": "#ffffff",
       "transparent": true
     },
     {
       "id": 178,
       "name": "Inverted Daylight Sensor",
-      "color": "d2c1ab",
+      "color": "#d2c1ab",
       "transparent": true,
       "canProvidePower": true
     },
     {
       "id": 179,
       "name": "Red Sandstone",
-      "color": "a6551e",
+      "color": "#a6551e",
       "variants": [
         {
           "data": 1,
           "name": "Chiseled Red Sandstone",
-          "color": "a2531c"
+          "color": "#a2531c"
         },
         {
           "data": 2,
           "name": "Smooth Red Sandstone",
-          "color": "a8561e"
+          "color": "#a8561e"
         }
       ]
     },
     {
       "id": 180,
       "name": "Red Sandstone Stairs",
-      "color": "a6551e",
+      "color": "#a6551e",
       "transparent": true
     },
     {
       "id": 181,
       "name": "Double Red Sandstone Slab",
-      "color": "a6551e",
+      "color": "#a6551e",
       "variants": [
         {
           "data": 8,
           "name": "Full Red Sandstone Slab",
-          "color": "a7551e"
+          "color": "#a7551e"
         }
       ]
     },
     {
       "id": 182,
       "name": "Red Sandstone Slab",
-      "color": "a7551e",
+      "color": "#a7551e",
       "transparent": true,
       "variants": [
         {
           "data": 8,
           "name": "Upper Red Sandstone Slab",
-          "color": "a7551e"
+          "color": "#a7551e"
         }
       ]
     },
     {
       "id": 183,
       "name": "Spruce Fence Gate",
-      "color": "805e36",
+      "color": "#805e36",
       "alpha": 0.75,
       "transparent": true
     },
     {
       "id": 184,
       "name": "Birch Fence Gate",
-      "color": "c8b77a",
+      "color": "#c8b77a",
       "alpha": 0.75,
       "transparent": true
     },
     {
       "id": 185,
       "name": "Jungle Fence Gate",
-      "color": "b1805c",
+      "color": "#b1805c",
       "alpha": 0.75,
       "transparent": true
     },
     {
       "id": 186,
       "name": "Dark Oak Fence Gate",
-      "color": "462d15",
+      "color": "#462d15",
       "alpha": 0.75,
       "transparent": true
     },
     {
       "id": 187,
       "name": "Acacia Fence Gate",
-      "color": "ba6337",
+      "color": "#ba6337",
       "alpha": 0.75,
       "transparent": true
     },
     {
       "id": 188,
       "name": "Spruce Fence",
-      "color": "805e36",
+      "color": "#805e36",
       "alpha": 0.75,
       "transparent": true
     },
     {
       "id": 189,
       "name": "Birch Fence",
-      "color": "c8b77a",
+      "color": "#c8b77a",
       "alpha": 0.75,
       "transparent": true
     },
     {
       "id": 190,
       "name": "Jungle Fence",
-      "color": "b1805c",
+      "color": "#b1805c",
       "alpha": 0.75,
       "transparent": true
     },
     {
       "id": 191,
       "name": "Dark Oak Fence",
-      "color": "462d15",
+      "color": "#462d15",
       "alpha": 0.75,
       "transparent": true
     },
     {
       "id": 192,
       "name": "Acacia Fence",
-      "color": "ba6337",
+      "color": "#ba6337",
       "alpha": 0.75,
       "transparent": true
     },
     {
       "id": 193,
       "name": "Spruce Door",
-      "color": "6e563b",
+      "color": "#6e563b",
       "transparent": true
     },
     {
       "id": 194,
       "name": "Birch Door",
-      "color": "d2caa3",
+      "color": "#d2caa3",
       "transparent": true
     },
     {
       "id": 195,
       "name": "Jungle Door",
-      "color": "ac7da3",
+      "color": "#ac7da3",
       "transparent": true
     },
     {
       "id": 196,
       "name": "Acacia Door",
-      "color": "a5615b",
+      "color": "#a5615b",
       "transparent": true
     },
     {
       "id": 197,
       "name": "Dark Oak Door",
-      "color": "4a3118",
+      "color": "#4a3118",
       "transparent": true
     },
     {
       "id": 198,
       "name": "End Rod",
-      "color": "dcc5ce"
+      "color": "#dcc5ce"
     },
     {
       "id": 199,
       "name": "Chorus Plant",
-      "color": "603c60",
+      "color": "#603c60",
       "transparent": true
     },
     {
       "id": 200,
       "name": "Chorus Flower",
-      "color": "866886",
+      "color": "#866886",
       "transparent": true,
       "variants": [
         {
           "data": 5,
           "name": "Chorus Flower (fully grown)",
-          "color": "624060"
+          "color": "#624060"
         }
       ]
     },
     {
       "id": 201,
       "name": "Purpur Block",
-      "color": "a67aa6"
+      "color": "#a67aa6"
     },
     {
       "id": 202,
       "name": "Purpur Pillar",
-      "color": "ab80ab"
+      "color": "#ab80ab"
     },
     {
       "id": 203,
       "name": "Purpur Stairs",
-      "color": "a67aa6"
+      "color": "#a67aa6"
     },
     {
       "id": 204,
       "name": "Double Purpur Slab",
-      "color": "a67aa6"
+      "color": "#a67aa6"
     },
     {
       "id": 205,
       "name": "Purpur Slab",
-      "color": "a67aa6"
+      "color": "#a67aa6"
     },
     {
       "id": 206,
       "name": "End Stone Bricks",
-      "color": "e2e7ab"
+      "color": "#e2e7ab"
     },
     {
       "id": 207,
       "name": "Immature Beetroot",
-      "color": "02ab10",
+      "color": "#02ab10",
       "transparent": true,
       "variants": [
         {
           "data": 3,
           "name": "Mature Beetroot",
-          "color": "517136"
+          "color": "#517136"
         }
       ]
     },
     {
       "id": 208,
       "name": "Grass Path",
-      "color": "967d47"
+      "color": "#967d47"
     },
     {
       "id": 209,
       "name": "End Gateway Block",
-      "color": "000000"
+      "color": "#000000"
     },
     {
       "id": 210,
       "name": "Repeating Command Block",
-      "color": "8170b0"
+      "color": "#8170b0"
     },
     {
       "id": 211,
       "name": "Chain Command Block",
-      "color": "87a398"
+      "color": "#87a398"
     },
     {
       "id": 212,
       "name": "Frosted Ice",
-      "color": "77a9ff",
+      "color": "#77a9ff",
       "alpha": 0.62,
       "transparent": true,
       "rendercube": true
@@ -2494,22 +2496,22 @@
     {
       "id": 213,
       "name": "Magma Block",
-      "color": "87421a"
+      "color": "#87421a"
     },
     {
       "id": 214,
       "name": "Nether Wart Block",
-      "color": "750607"
+      "color": "#750607"
     },
     {
       "id": 215,
       "name": "Red Nether Brick",
-      "color": "440407"
+      "color": "#440407"
     },
     {
       "id": 216,
       "name": "Bone Block",
-      "color": "cec9b2"
+      "color": "#cec9b2"
     },
     {
       "id": 218,
@@ -2599,7 +2601,7 @@
     {
       "id": 255,
       "name": "Structure Block",
-      "color": "000000"
+      "color": "#000000"
     }
   ],
   "update": "https://github.com/mrkite/minutor/raw/master/definitions/vanilla_ids.json"

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -2516,87 +2516,87 @@
     {
       "id": 218,
       "name": "Observer",
-      "color": "535353"
+      "color": "#535353"
     },
     {
       "id": 219,
       "name": "White Shulker Box",
-      "color": "dedbdb"
+      "color": "#dedbdb"
     },
     {
       "id": 220,
       "name": "Orange Shulker Box",
-      "color": "ce7438"
+      "color": "#ce7438"
     },
     {
       "id": 221,
       "name": "Magenta Shulker Box",
-      "color": "ba64c2"
+      "color": "#ba64c2"
     },
     {
       "id": 222,
       "name": "Light Blue Shulker Box",
-      "color": "658ecb"
+      "color": "#658ecb"
     },
     {
       "id": 223,
       "name": "Yellow Shulker Box",
-      "color": "c1b73d"
+      "color": "#c1b73d"
     },
     {
       "id": 224,
       "name": "Lime Shulker Box",
-      "color": "47b73b"
+      "color": "#47b73b"
     },
     {
       "id": 225,
       "name": "Pink Shulker Box",
-      "color": "d08ca1"
+      "color": "#d08ca1"
     },
     {
       "id": 226,
       "name": "Gray Shulker Box",
-      "color": "535151"
+      "color": "#535151"
     },
     {
       "id": 227,
       "name": "Light Gray Shulker Box",
-      "color": "a4a2a2"
+      "color": "#a4a2a2"
     },
     {
       "id": 228,
       "name": "Cyan Shulker Box",
-      "color": "4488a4"
+      "color": "#4488a4"
     },
     {
       "id": 229,
       "name": "Purple Shulker Box",
-      "color": "976797"
+      "color": "#976797"
     },
     {
       "id": 230,
       "name": "Blue Shulker Box",
-      "color": "6571c9"
+      "color": "#6571c9"
     },
     {
       "id": 231,
       "name": "Brown Shulker Box",
-      "color": "8d705d"
+      "color": "#8d705d"
     },
     {
       "id": 232,
       "name": "Green Shulker Box",
-      "color": "6f8254"
+      "color": "#6f8254"
     },
     {
       "id": 233,
       "name": "Red Shulker Box",
-      "color": "c25855"
+      "color": "#c25855"
     },
     {
       "id": 234,
       "name": "Black Shulker Box",
-      "color": "383737"
+      "color": "#383737"
     },
     {
       "id": 255,

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -421,10 +421,9 @@ void MapView::renderChunk(Chunk *chunk) {
         if (light > 15) light = 15;
 
         // define the color
-        quint32 color = block.colors[light];
-        quint32 colr = color >> 16;
-        quint32 colg = (color >> 8) & 0xff;
-        quint32 colb = color & 0xff;
+        quint32 colr = block.colors[light].red();
+        quint32 colg = block.colors[light].green();
+        quint32 colb = block.colors[light].blue();
         if (flags & flgDepthShading) {
           // Use a table to define depth-relative shade:
           static const quint32 shadeTable[] = {
@@ -487,11 +486,10 @@ void MapView::renderChunk(Chunk *chunk) {
           }
         }
         if (flags & flgBiomeColors) {
-          auto &b = biomes->getBiome(chunk->biomes[(x & 0xf) + (z & 0xf) * 16]);
-          color = b.colors[light];
-          colr = color >> 16;
-          colg = (color >> 8) & 0xff;
-          colb = color & 0xff;
+          auto &bi = biomes->getBiome(chunk->biomes[(x & 0xf) + (z & 0xf) * 16]);
+          colr = bi.colors[light].red();
+          colg = bi.colors[light].green();
+          colb = bi.colors[light].blue();
           alpha = 0;
         }
         if (alpha == 0.0) {


### PR DESCRIPTION
Now all definition files use the Qt style color definition. So colors are defined #rrggbb and can also be defined via CSS color names.
The Pre-calculated light spectrum is done similar to Minecraft with 90% scaling per light level instead of YUV linear shading.