### PR TITLE
Fix automatic definition file update via https

### DIFF
--- a/definitionmanager.cpp
+++ b/definitionmanager.cpp
@@ -20,7 +20,8 @@
 #include "./zipreader.h"
 #include "./definitionupdater.h"
 
-DefinitionManager::DefinitionManager(QWidget *parent) : QWidget(parent),
+DefinitionManager::DefinitionManager(QWidget *parent) :
+    QWidget(parent),
     entityManager(EntityIdentifier::Instance()) {
   setWindowFlags(Qt::Window);
   setWindowTitle(tr("Definitions"));
@@ -63,13 +64,12 @@ DefinitionManager::DefinitionManager(QWidget *parent) : QWidget(parent),
   emit packSelected(false);
   setLayout(layout);
 
-  dimensionList = new DimensionIdentifier;
-  blocks = new BlockIdentifier;
-  biomes = new BiomeIdentifier;
+  dimensionManager = new DimensionIdentifier;
+  blockManager = new BlockIdentifier;
+  biomeManager = new BiomeIdentifier;
 
   QSettings settings;
   sorted = settings.value("packs").toList();
-  lastUpdated = settings.value("packupdates").toHash();
 
   // copy over built-in definitions if necessary
   QString defdir = QStandardPaths::writableLocation(
@@ -95,19 +95,19 @@ DefinitionManager::DefinitionManager(QWidget *parent) : QWidget(parent),
 }
 
 DefinitionManager::~DefinitionManager() {
-  delete dimensionList;
-  delete blocks;
-  delete biomes;
+  delete dimensionManager;
+  delete blockManager;
+  delete biomeManager;
 }
 
 BlockIdentifier *DefinitionManager::blockIdentifier() {
-  return blocks;
+  return blockManager;
 }
 BiomeIdentifier *DefinitionManager::biomeIdentifier() {
-  return biomes;
+  return biomeManager;
 }
 DimensionIdentifier *DefinitionManager::dimensionIdentifer() {
-  return dimensionList;
+  return dimensionManager;
 }
 
 void DefinitionManager::refresh() {
@@ -151,21 +151,21 @@ void DefinitionManager::toggledPack(bool onoff) {
     switch (def.type) {
       case Definition::Block:
         if (onoff)
-          blocks->enableDefinitions(def.id);
+          blockManager->enableDefinitions(def.id);
         else
-          blocks->disableDefinitions(def.id);
+          blockManager->disableDefinitions(def.id);
         break;
       case Definition::Biome:
         if (onoff)
-          biomes->enableDefinitions(def.id);
+          biomeManager->enableDefinitions(def.id);
         else
-          biomes->disableDefinitions(def.id);
+          biomeManager->disableDefinitions(def.id);
         break;
       case Definition::Dimension:
         if (onoff)
-          dimensionList->enableDefinitions(def.id);
+          dimensionManager->enableDefinitions(def.id);
         else
-          dimensionList->disableDefinitions(def.id);
+          dimensionManager->disableDefinitions(def.id);
         break;
       case Definition::Entity:
         if (onoff)
@@ -175,14 +175,14 @@ void DefinitionManager::toggledPack(bool onoff) {
         break;
       case Definition::Pack:
         if (onoff) {
-          blocks->enableDefinitions(def.blockid);
-          biomes->enableDefinitions(def.biomeid);
-          dimensionList->enableDefinitions(def.dimensionid);
+          blockManager->enableDefinitions(def.blockid);
+          biomeManager->enableDefinitions(def.biomeid);
+          dimensionManager->enableDefinitions(def.dimensionid);
           entityManager.enableDefinitions(def.entityid);
         } else {
-          blocks->disableDefinitions(def.blockid);
-          biomes->disableDefinitions(def.biomeid);
-          dimensionList->disableDefinitions(def.dimensionid);
+          blockManager->disableDefinitions(def.blockid);
+          biomeManager->disableDefinitions(def.biomeid);
+          dimensionManager->disableDefinitions(def.dimensionid);
           entityManager.disableDefinitions(def.entityid);
         }
         break;
@@ -370,15 +370,15 @@ void DefinitionManager::loadDefinition(QString path) {
     QString key = d.name + type;
     d.enabled = true;  // should look this up
     if (type == "block") {
-      d.id = blocks->addDefinitions(
+      d.id = blockManager->addDefinitions(
           dynamic_cast<JSONArray*>(def->at("data")));
       d.type = Definition::Block;
     } else if (type == "biome") {
-      d.id = biomes->addDefinitions(
+      d.id = biomeManager->addDefinitions(
           dynamic_cast<JSONArray*>(def->at("data")));
       d.type = Definition::Biome;
     } else if (type == "dimension") {
-      d.id = dimensionList->addDefinitions(
+      d.id = dimensionManager->addDefinitions(
           dynamic_cast<JSONArray*>(def->at("data")));
       d.type = Definition::Dimension;
     } else if (type == "entity") {
@@ -421,13 +421,13 @@ void DefinitionManager::loadDefinition(QString path) {
       }
       QString type = def->at("type")->asString();
       if (type == "block")
-        d.blockid = blocks->addDefinitions(
+        d.blockid = blockManager->addDefinitions(
             dynamic_cast<JSONArray*>(def->at("data")), d.blockid);
       else if (type == "biome")
-        d.biomeid = biomes->addDefinitions(
+        d.biomeid = biomeManager->addDefinitions(
             dynamic_cast<JSONArray*>(def->at("data")), d.biomeid);
       else if (type == "dimension")
-        d.dimensionid = dimensionList->addDefinitions(
+        d.dimensionid = dimensionManager->addDefinitions(
             dynamic_cast<JSONArray*>(def->at("data")), d.dimensionid);
       else if (type == "entity")
         d.entityid = entityManager.addDefinitions(
@@ -445,21 +445,21 @@ void DefinitionManager::removeDefinition(QString path) {
   if (def.path == path) {
     switch (def.type) {
       case Definition::Block:
-        blocks->disableDefinitions(def.id);
+        blockManager->disableDefinitions(def.id);
         break;
       case Definition::Biome:
-        biomes->disableDefinitions(def.id);
+        biomeManager->disableDefinitions(def.id);
         break;
       case Definition::Dimension:
-        dimensionList->disableDefinitions(def.id);
+        dimensionManager->disableDefinitions(def.id);
         break;
       case Definition::Entity:
         entityManager.disableDefinitions(def.id);
         break;
       case Definition::Pack:
-        blocks->disableDefinitions(def.blockid);
-        biomes->disableDefinitions(def.biomeid);
-        dimensionList->disableDefinitions(def.dimensionid);
+        blockManager->disableDefinitions(def.blockid);
+        biomeManager->disableDefinitions(def.biomeid);
+        dimensionManager->disableDefinitions(def.dimensionid);
         entityManager.disableDefinitions(def.entityid);
         break;
     }

--- a/definitionmanager.cpp
+++ b/definitionmanager.cpp
@@ -489,15 +489,9 @@ void DefinitionManager::autoUpdate() {
     Definition &def = definitions[name];
     if (!def.update.isEmpty()) {
       isUpdating = true;
-      QDateTime last;
-      last.setMSecsSinceEpoch(0);
-      if (lastUpdated.contains(name))
-        last = lastUpdated[name].toDateTime();
-      auto updater = new DefinitionUpdater(name, def.update, last);
-      connect(updater,
-              SIGNAL(updated(DefinitionUpdater *, QString, QDateTime)),
-              this,
-              SLOT(updatePack(DefinitionUpdater *, QString, QDateTime)));
+      auto updater = new DefinitionUpdater(name, def.update, def.version);
+      connect(updater, SIGNAL(updated   (DefinitionUpdater *, QString, QString)),
+              this,    SLOT  (updatePack(DefinitionUpdater *, QString, QString)));
       updateQueue.append(updater);
       updater->update();
     }
@@ -505,14 +499,17 @@ void DefinitionManager::autoUpdate() {
 }
 
 void DefinitionManager::updatePack(DefinitionUpdater *updater,
-                                   QString filename, QDateTime timestamp) {
+                                   QString filename,
+                                   QString version) {
   updateQueue.removeOne(updater);
   delete updater;
-  if (lastUpdated[filename] != timestamp) {
+/*
+   if (lastUpdated[filename] != timestamp) {
     lastUpdated[filename] = timestamp;
     QSettings settings;
     settings.setValue("packupdates", lastUpdated);
   }
+*/
   if (updateQueue.isEmpty())
     emit updateFinished();
 }

--- a/definitionmanager.cpp
+++ b/definitionmanager.cpp
@@ -496,6 +496,9 @@ void DefinitionManager::autoUpdate() {
       updater->update();
     }
   }
+  QSettings settings;
+  settings.setValue("packupdate", QDateTime::currentDateTime());  // store current time
+  settings.remove("packupdates");  // remove now unused entries from registry
 }
 
 void DefinitionManager::updatePack(DefinitionUpdater *updater,
@@ -503,13 +506,7 @@ void DefinitionManager::updatePack(DefinitionUpdater *updater,
                                    QString version) {
   updateQueue.removeOne(updater);
   delete updater;
-/*
-   if (lastUpdated[filename] != timestamp) {
-    lastUpdated[filename] = timestamp;
-    QSettings settings;
-    settings.setValue("packupdates", lastUpdated);
-  }
-*/
+
   if (updateQueue.isEmpty())
     emit updateFinished();
 }

--- a/definitionmanager.h
+++ b/definitionmanager.h
@@ -73,16 +73,15 @@ class DefinitionManager : public QWidget {
   void removeDefinition(QString path);
   void refresh();
   QHash<QString, Definition> definitions;
-  BiomeIdentifier *biomes;
-  BlockIdentifier *blocks;
-  DimensionIdentifier *dimensionList;
+  BiomeIdentifier *biomeManager;  // todo: migrate to reference to singleton
+  BlockIdentifier *blockManager;  // todo: migrate to reference to singleton
+  DimensionIdentifier *dimensionManager;  // todo: migrate to reference to singleton
   EntityIdentifier &entityManager;
   QString selected;
   QList<QVariant> sorted;
 
   bool isUpdating;
   QList<DefinitionUpdater *> updateQueue;
-  QHash<QString, QVariant> lastUpdated;
 };
 
 #endif  // DEFINITIONMANAGER_H_

--- a/definitionmanager.h
+++ b/definitionmanager.h
@@ -59,8 +59,9 @@ class DefinitionManager : public QWidget {
   void removePack();
   void exportPack();
   void checkForUpdates();
-  void updatePack(DefinitionUpdater *updater, QString filename,
-                  QDateTime timestamp);
+  void updatePack(DefinitionUpdater *updater,
+                  QString filename,
+                  QString version);
 
  private:
   QTableWidget *table;

--- a/definitionupdater.cpp
+++ b/definitionupdater.cpp
@@ -7,51 +7,90 @@
 #include "./definitionupdater.h"
 
 DefinitionUpdater::DefinitionUpdater(QString filename, QString url,
-                                     QDateTime timestamp) :
-  filename(filename), url(url), timestamp(timestamp) {
+                                     QString version) :
+  filename(filename), url(url), version(version) {
   save = NULL;
 }
 
 void DefinitionUpdater::update() {
   reply = qnam.head(QNetworkRequest(url));
   connect(reply, SIGNAL(finished()),
-          this, SLOT(checkTime()));
+          this, SLOT(checkReply()));
 }
 
-void DefinitionUpdater::checkTime() {
-  QVariant redir =
-      reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
+void DefinitionUpdater::checkReply() {
+  // check for server side redirection
+  QVariant redir = reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
   if (!redir.isNull()) {
     reply->deleteLater();
+    // start update again with redirected URL
     url = redir.toUrl();
     update();
     return;
   }
-  QVariant lmod = reply->header(QNetworkRequest::LastModifiedHeader);
-  if (lmod.isValid() && lmod.toDateTime() > timestamp) {
-    timestamp = lmod.toDateTime();
-    reply->deleteLater();
-    reply = qnam.get(QNetworkRequest(url));
+  // final URL found -> get data
+  reply->deleteLater();
+  reply = qnam.get(QNetworkRequest(url));
+  connect(reply, SIGNAL(readyRead()),
+          this, SLOT(checkVersion()));
+}
+
+void DefinitionUpdater::checkVersion() {
+  // parse reply data for version information
+  QString data = reply->readAll();
+  reply->deleteLater();
+  int vtag   = data.indexOf("\"version\"");
+  int vstart = data.indexOf("\"", vtag+9) + 1;    // "version" is length 9
+  int vstop  = data.indexOf("\"", vstart) - vstart;
+  QString remoteversion = data.mid(vstart, vstop);
+
+  if (versionCompare(remoteversion,version)>0) {
+    version = remoteversion;
     save = new QFile(filename);
     save->open(QIODevice::WriteOnly | QIODevice::Truncate);
-    connect(reply, SIGNAL(finished()),
-            this, SLOT(didUpdate()));
-    connect(reply, SIGNAL(readyRead()),
-            this, SLOT(saveFile()));
-    return;
+    if (save) {
+      save->write(data.toStdString().c_str());
+      save->flush();
+      save->close();
+      delete save;
+      save = NULL;
+    }
   }
-  reply->deleteLater();
-  // no need to update
-  emit updated(this, filename, timestamp);
+  emit updated(this, filename, version);
 }
-void DefinitionUpdater::didUpdate() {
-  save->flush();
-  save->close();
-  delete save;
-  save = NULL;
-  emit updated(this, filename, timestamp);
-}
-void DefinitionUpdater::saveFile() {
-  if (save)
-    save->write(reply->readAll());
+
+int DefinitionUpdater::versionCompare(QString const &version1, QString const &version2)
+{
+  // split in major and minor version sections
+  QStringList sec1 = version1.split('.');
+  QStringList sec2 = version2.split('.');
+
+  // iterate over all main and minor version parts
+  int mm = 0;
+  while (mm<sec1.length() && mm<sec2.length()) {
+    int c = 0;
+    bool ok1, ok2;
+    int i1 = sec1[mm].toInt(&ok1,10);
+    int i2 = sec2[mm].toInt(&ok2,10);
+
+    if (ok1 && ok2) {   // both are integer numbers
+      c = i1 - i2;
+    }
+    if (!ok1 && !ok2) { // both are strings
+      c = QString::compare(sec1[mm], sec2[mm]);
+    }
+    if (ok1 && !ok2) { // 1 is an int 2 is a string
+      return 1; // int wins
+    }
+    if (!ok1 && ok2) { // 1 is a string 2 an int
+      return -1; // int wins
+    }
+
+    // finished when any difference is found
+    if (c != 0) return c;
+    // else proceed with next section
+    mm++;
+  }
+  // longer one wins :-)
+  return sec1.length() - sec2.length();
 }

--- a/definitionupdater.cpp
+++ b/definitionupdater.cpp
@@ -31,6 +31,8 @@ void DefinitionUpdater::checkReply() {
   // final URL found -> get data
   reply->deleteLater();
   reply = qnam.get(QNetworkRequest(url));
+  connect(reply, SIGNAL(finished()),
+          this, SLOT(finishUpdate()));
   connect(reply, SIGNAL(readyRead()),
           this, SLOT(checkVersion()));
 }
@@ -56,6 +58,9 @@ void DefinitionUpdater::checkVersion() {
       save = NULL;
     }
   }
+}
+
+void DefinitionUpdater::finishUpdate() {
   emit updated(this, filename, version);
 }
 

--- a/definitionupdater.h
+++ b/definitionupdater.h
@@ -13,18 +13,18 @@ class QNetworkReply;
 class DefinitionUpdater : public QObject {
   Q_OBJECT
  public:
-  DefinitionUpdater(QString filename, QString url, QDateTime timestamp);
+  DefinitionUpdater(QString filename, QString url, QString version);
   void update();
  signals:
-  void updated(DefinitionUpdater *, QString filename, QDateTime timestamp);
+  void updated(DefinitionUpdater *, QString filename, QString version);
  private slots:
-  void checkTime();
-  void didUpdate();
-  void saveFile();
+  void checkReply();
+  void checkVersion();
  private:
+  int versionCompare( QString const &version1, QString const &version2 );
   QString filename;
   QUrl url;
-  QDateTime timestamp;
+  QString version;
   QNetworkAccessManager qnam;
   QNetworkReply *reply;
   QFile *save;

--- a/definitionupdater.h
+++ b/definitionupdater.h
@@ -20,6 +20,7 @@ class DefinitionUpdater : public QObject {
  private slots:
   void checkReply();
   void checkVersion();
+  void finishUpdate();
  private:
   int versionCompare( QString const &version1, QString const &version2 );
   QString filename;

--- a/definitionupdater.h
+++ b/definitionupdater.h
@@ -22,6 +22,7 @@ class DefinitionUpdater : public QObject {
   void checkVersion();
   void finishUpdate();
  private:
+  QString parseVersion(const QByteArray & data);
   int versionCompare( QString const &version1, QString const &version2 );
   QString filename;
   QUrl url;

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -44,8 +44,15 @@ Minutor::Minutor(): maxentitydistance(0) {
           this, SLOT(rescanWorlds()));
 
 
-  if (settings->autoUpdate)
-    dm->autoUpdate();
+  if (settings->autoUpdate) {
+    // get time of last update
+    QSettings settings;
+    QDateTime lastUpdateTime = settings.value("packupdate").toDateTime();
+
+    // auto-update only once a week
+    if (lastUpdateTime.addDays(7) < QDateTime::currentDateTime())
+      dm->autoUpdate();
+  }
 
   createActions();
   createMenus();


### PR DESCRIPTION
for HTTPS support a recompile of Qt is necessary (HTTP would work without)

github.com does not provide a LastModification HTTP header response. Therefore the completely changed update code gets the remote definition file, extracts the version string and compares it with the local version.

Automatic update is done only once a week.

This should fix issue #103 at least it does it during my debugging sessions.

(contains also some name refactoring to align naming of objects through the code)