### PR TITLE
Biome based Grass and Foliage colors

### DIFF
--- a/biomeidentifier.cpp
+++ b/biomeidentifier.cpp
@@ -96,8 +96,9 @@ QColor BiomeInfo::getBiomeColor( float temperature, float humidity, int elevatio
   return QColor::QColor(r,g,b);
 }
 
-QColor BiomeInfo::getBiomeGrassColor( int elevation )
+QColor BiomeInfo::getBiomeGrassColor( QColor blockcolor, int elevation )
 {
+  QColor colorizer;
   // remove variants from ID
   int id = this->id & 0x7f;
   // swampland
@@ -105,39 +106,63 @@ QColor BiomeInfo::getBiomeGrassColor( int elevation )
     // perlin noise generator omitted due to performance reasons
     // otherwise the random temperature distribution selects
     // (below -0.1°C) ‭4C.76.3C‬ or ‭6A.70.39 (above -0.1°C)
-    return QColor::QColor(0x6a,0x70,0x39);  // hard wired
+    colorizer = QColor::QColor(0x6a,0x70,0x39);  // hard wired
   }
   // roofed forest
   else if (id == 29) {
-    QColor color = getBiomeColor( this->temperature, this->humidity, elevation, grassCorners );
+    colorizer = getBiomeColor( this->temperature, this->humidity, elevation, grassCorners );
     // average with 0x28340A
-    color.setRed  ( (color.red()   + 0x28)>>1 );
-    color.setGreen( (color.green() + 0x34)>>1 );
-    color.setBlue ( (color.blue()  + 0x0A)>>1 );
-    return color;
+    colorizer.setRed  ( (colorizer.red()   + 0x28)>>1 );
+    colorizer.setGreen( (colorizer.green() + 0x34)>>1 );
+    colorizer.setBlue ( (colorizer.blue()  + 0x0A)>>1 );
   }
   // mesa
   else if ((id == 37) || (id == 38) || (id == 39)) {
-    return QColor::QColor(0x90,0x81,0x4d);  // hard wired
+    colorizer = QColor::QColor(0x90,0x81,0x4d);  // hard wired
   } else
     // standard way
-    return getBiomeColor( this->temperature, this->humidity, elevation, grassCorners );
+    colorizer = getBiomeColor( this->temperature, this->humidity, elevation, grassCorners );
+
+  QColor color;
+  if (false) {
+    color.setRed  ( colorizer.red()  /255.0f * blockcolor.red()   );
+    color.setGreen( colorizer.green()/255.0f * blockcolor.green() );
+    color.setBlue ( colorizer.blue() /255.0f * blockcolor.blue()  );
+  } else {
+    color.setRed  ( (colorizer.red()   + blockcolor.red()  ) / 2.0 );
+    color.setGreen( (colorizer.green() + blockcolor.green()) / 2.0 );
+    color.setBlue ( (colorizer.blue()  + blockcolor.blue() ) / 2.0 );
+  }
+  return color;
 }
 
-QColor BiomeInfo::getBiomeFoliageColor( int elevation )
+QColor BiomeInfo::getBiomeFoliageColor( QColor blockcolor, int elevation )
 {
+  QColor colorizer;
   // remove variants from ID
   int id = this->id & 0x7f;
   // swampland
   if (id == 6) {
-    return QColor::QColor(0x6a,0x70,0x39);  // hard wired
+    colorizer = QColor::QColor(0x6a,0x70,0x39);  // hard wired
   }
   // mesa
   else if ((id == 37) || (id == 38) || (id == 39)) {
-    return QColor::QColor(0x9e,0x81,0x4d);  // hard wired
+    colorizer = QColor::QColor(0x9e,0x81,0x4d);  // hard wired
   } else
     // standard way
-    return getBiomeColor( this->temperature, this->humidity, elevation, foliageCorners );
+    colorizer = getBiomeColor( this->temperature, this->humidity, elevation, foliageCorners );
+
+  QColor color;
+  if (false) {
+    color.setRed  ( colorizer.red()  /255.0f * blockcolor.red()   );
+    color.setGreen( colorizer.green()/255.0f * blockcolor.green() );
+    color.setBlue ( colorizer.blue() /255.0f * blockcolor.blue()  );
+  } else {
+    color.setRed  ( (colorizer.red()   + blockcolor.red()  ) / 2.0 );
+    color.setGreen( (colorizer.green() + blockcolor.green()) / 2.0 );
+    color.setBlue ( (colorizer.blue()  + blockcolor.blue() ) / 2.0 );
+  }
+  return color;
 }
 
 QColor BiomeInfo::getBiomeWaterColor( QColor watercolor )

--- a/biomeidentifier.cpp
+++ b/biomeidentifier.cpp
@@ -1,9 +1,16 @@
-/** Copyright (c) 2013, Sean Kasun */
+/*
+Copyright (c) 2013, Sean Kasun
+Copyright (c) 2016, EtlamGit
+*/
 
 #include <assert.h>
 
 #include "./biomeidentifier.h"
 #include "./json.h"
+
+// --------- --------- --------- ---------
+// BiomeInfo
+// --------- --------- --------- ---------
 
 static BiomeInfo unknownBiome;
 
@@ -11,11 +18,108 @@ BiomeInfo::BiomeInfo()
   : name("Unknown Biome")
   , enabled(false)
   , watermodifier(255,255,255)
+  , enabledwatermodifier(false)
   , alpha(1.0)
   , temperature(0.5)
   , humidity(0.5)
 {}
 
+
+// Biome based Grass and Foliage color is based on an interpolation in special
+// textures provided in the Minecraft assets. It is also possible to do the
+// interpolation based only on the color values at the threee corners of that
+// color triangle.
+
+// .\assets\minecraft\textures\colormap\grass.png
+// last checked with Minecraft 1.11.2
+BiomeInfo::T_BiomeCorner BiomeInfo::grassCorners[3] =
+{
+  { 191, 183,  85 },  // lower left  - temperature = 1.0
+  { 128, 180, 151 },  // lower right - temperature = 0.0
+  {  71, 205,  51 }   // upper left  - humidity = 1.0
+};
+
+// .\assets\minecraft\textures\colormap\foliage.png
+// last checked with Minecraft 1.11.2
+BiomeInfo::T_BiomeCorner BiomeInfo::foliageCorners[3] =
+{
+  { 174, 164,  42 },  // lower left  - temperature = 1.0
+  {  96, 161, 123 },  // lower right - temperature = 0.0
+  {  26, 191,   0 }   // upper left  - humidity = 1.0
+};
+
+// will be in STD with C++17
+template <typename T>
+T clamp(const T& n, const T& lower, const T& upper) {
+  return (n<lower)? lower : (n>upper)? upper : n;
+}
+
+/*
+This method is inspired from Mineways, Copyright (c) 2014, Eric Haines
+https://github.com/erich666/Mineways/blob/master/Win/biomes.h
+*/
+// do an interpolation inside the color triangle given by the corners
+// temperature: is the base value for the current Biome
+// humidity:    is the base value for the current Biome
+// elevation:   is number of meters above a height of 64
+QColor BiomeInfo::getBiomeColor( float temperature, float humidity, int elevation, T_BiomeCorner *corners )
+{
+  // check elevation
+  elevation = (elevation < 0) ? 0 : elevation;
+
+  // get local temperature and humidity
+  temperature = clamp( temperature - (float)elevation*0.00166667f, 0.0f, 1.0f );
+  humidity    = clamp( humidity, 0.0f, 1.0f );
+  humidity   *= temperature;  // scale by temperature to stay in triangle
+
+  // lambda values for barycentric coordinates
+  float lambda[3];
+  lambda[0] = temperature - humidity;
+  lambda[1] = 1.0f - temperature;
+  lambda[2] = humidity;
+
+  float red = 0.0f, green = 0.0f, blue = 0.0f;
+  for ( int i = 0; i < 3; i++ )
+  {
+    red   += lambda[i] * corners[i].red;
+    green += lambda[i] * corners[i].green;
+    blue  += lambda[i] * corners[i].blue;
+  }
+
+  int r = (int)clamp( red,   0.0f, 255.0f );
+  int g = (int)clamp( green, 0.0f, 255.0f );
+  int b = (int)clamp( blue,  0.0f, 255.0f );
+
+  return QColor::QColor(r,g,b);
+}
+
+QColor BiomeInfo::getBiomeGrassColor( int elevation )
+{
+  return getBiomeColor( this->temperature, this->humidity, elevation, grassCorners );
+}
+
+QColor BiomeInfo::getBiomeFoliageColor( int elevation )
+{
+  return getBiomeColor( this->temperature, this->humidity, elevation, foliageCorners );
+}
+
+QColor BiomeInfo::getBiomeWaterColor( QColor watercolor )
+{
+  if (this->enabledwatermodifier) {
+    // calculate modified color components
+    int r = (int)( watercolor.red()   * watermodifier.red()   / 255 );
+    int g = (int)( watercolor.green() * watermodifier.green() / 255 );
+    int b = (int)( watercolor.blue()  * watermodifier.blue()  / 255 );
+    // return combined modified color
+    return QColor::QColor(r, g, b );
+  } else
+    return watercolor;
+}
+
+
+// --------- --------- --------- ---------
+// BiomeIdentifier
+// --------- --------- --------- ---------
 
 BiomeIdentifier::BiomeIdentifier() {
   unknownBiome.name = "Unknown";
@@ -86,6 +190,7 @@ int BiomeIdentifier::addDefinitions(JSONArray *defs, int pack) {
     // get watermodifier definition
     if (b->has("watermodifier")) {
       biome->watermodifier.setNamedColor(b->at("watermodifier")->asString());
+      biome->enabledwatermodifier = true;
       assert(biome->watermodifier.isValid());
     }
 

--- a/biomeidentifier.cpp
+++ b/biomeidentifier.cpp
@@ -91,6 +91,32 @@ QColor BiomeInfo::getBiomeColor( float temperature, float humidity, int elevatio
   return QColor::QColor(r,g,b);
 }
 
+QColor BiomeInfo::mixColor( QColor colorizer, QColor blockcolor )
+{
+  // get hue components
+  float hueC = colorizer.hslHueF();
+  float hueB = blockcolor.hslHueF();  // monochrome blocks result in -1
+  // get saturation components
+  float satC = colorizer.hslSaturationF();
+  float satB = blockcolor.hslSaturationF();
+  // get lightness components
+  float ligC = colorizer.lightnessF();
+  float ligB = blockcolor.lightnessF();
+
+  // mix final color
+  float hue = hueC;
+  float sat = satC;
+  if ((satB != 0) && (hueB != -1.0f)) {
+    // when block contains some color component
+    hue = (hueC + hueB ) / 2.0f;
+    sat = (satC + satB ) / 2.0f;
+  }
+//float lig = std::clamp( ligC + ligB - 0.5f, 0.0f, 1.0f );  // more brightness contrast
+  float lig = (ligC + ligB ) / 2.0f;
+  return QColor::QColor().fromHslF( hue, sat, lig );
+}
+
+
 QColor BiomeInfo::getBiomeGrassColor( QColor blockcolor, int elevation )
 {
   QColor colorizer;
@@ -118,17 +144,7 @@ QColor BiomeInfo::getBiomeGrassColor( QColor blockcolor, int elevation )
     // standard way
     colorizer = getBiomeColor( this->temperature, this->humidity, elevation, grassCorners );
 
-  QColor color;
-  if (false) {
-    color.setRed  ( colorizer.red()  /255.0f * blockcolor.red()   );
-    color.setGreen( colorizer.green()/255.0f * blockcolor.green() );
-    color.setBlue ( colorizer.blue() /255.0f * blockcolor.blue()  );
-  } else {
-    color.setRed  ( (colorizer.red()   + blockcolor.red()  ) / 2.0 );
-    color.setGreen( (colorizer.green() + blockcolor.green()) / 2.0 );
-    color.setBlue ( (colorizer.blue()  + blockcolor.blue() ) / 2.0 );
-  }
-  return color;
+  return mixColor( colorizer, blockcolor );
 }
 
 QColor BiomeInfo::getBiomeFoliageColor( QColor blockcolor, int elevation )
@@ -147,17 +163,7 @@ QColor BiomeInfo::getBiomeFoliageColor( QColor blockcolor, int elevation )
     // standard way
     colorizer = getBiomeColor( this->temperature, this->humidity, elevation, foliageCorners );
 
-  QColor color;
-  if (false) {
-    color.setRed  ( colorizer.red()  /255.0f * blockcolor.red()   );
-    color.setGreen( colorizer.green()/255.0f * blockcolor.green() );
-    color.setBlue ( colorizer.blue() /255.0f * blockcolor.blue()  );
-  } else {
-    color.setRed  ( (colorizer.red()   + blockcolor.red()  ) / 2.0 );
-    color.setGreen( (colorizer.green() + blockcolor.green()) / 2.0 );
-    color.setBlue ( (colorizer.blue()  + blockcolor.blue() ) / 2.0 );
-  }
-  return color;
+  return mixColor( colorizer, blockcolor );
 }
 
 QColor BiomeInfo::getBiomeWaterColor( QColor watercolor )

--- a/biomeidentifier.cpp
+++ b/biomeidentifier.cpp
@@ -10,7 +10,7 @@ static BiomeInfo unknownBiome;
 BiomeInfo::BiomeInfo()
   : name("Unknown Biome")
   , enabled(false)
-  , watercolor(255,255,255)
+  , watermodifier(255,255,255)
   , alpha(1.0)
   , temperature(0.5)
   , humidity(0.5)
@@ -83,10 +83,10 @@ int BiomeIdentifier::addDefinitions(JSONArray *defs, int pack) {
     if (b->has("humidity"))
       biome->humidity = b->at("humidity")->asNumber();
 
-    // get watercolor definition
-    if (b->has("watercolor")) {
-      biome->watercolor.setNamedColor(b->at("watercolor")->asString());
-      assert(biome->watercolor.isValid());
+    // get watermodifier definition
+    if (b->has("watermodifier")) {
+      biome->watermodifier.setNamedColor(b->at("watermodifier")->asString());
+      assert(biome->watermodifier.isValid());
     }
 
     // get color definition

--- a/biomeidentifier.cpp
+++ b/biomeidentifier.cpp
@@ -13,7 +13,7 @@ BiomeInfo::BiomeInfo()
   , watercolor(255,255,255)
   , alpha(1.0)
   , temperature(0.5)
-  , rainfall(0.5)
+  , humidity(0.5)
 {}
 
 
@@ -79,9 +79,9 @@ int BiomeIdentifier::addDefinitions(JSONArray *defs, int pack) {
     if (b->has("temperature"))
       biome->temperature = b->at("temperature")->asNumber();
 
-    // get rainfall definition
-    if (b->has("rainfall"))
-      biome->rainfall = b->at("rainfall")->asNumber();
+    // get humidity definition
+    if (b->has("humidity"))
+      biome->humidity = b->at("humidity")->asNumber();
 
     // get watercolor definition
     if (b->has("watercolor")) {

--- a/biomeidentifier.cpp
+++ b/biomeidentifier.cpp
@@ -7,6 +7,7 @@ Copyright (c) 2016, EtlamGit
 
 #include "./biomeidentifier.h"
 #include "./json.h"
+#include "./clamp.h"
 
 // --------- --------- --------- ---------
 // BiomeInfo
@@ -49,12 +50,6 @@ BiomeInfo::T_BiomeCorner BiomeInfo::foliageCorners[3] =
   {  26, 191,   0 }   // upper left  - humidity = 1.0
 };
 
-// will be in STD with C++17
-template <typename T>
-T clamp(const T& n, const T& lower, const T& upper) {
-  return (n<lower)? lower : (n>upper)? upper : n;
-}
-
 /*
 This method is inspired from Mineways, Copyright (c) 2014, Eric Haines
 https://github.com/erich666/Mineways/blob/master/Win/biomes.h
@@ -71,8 +66,8 @@ QColor BiomeInfo::getBiomeColor( float temperature, float humidity, int elevatio
 
   // get local temperature and humidity
   // perlin noise generator omitted due to performance reasons
-  temperature = clamp( temperature - (float)elevation*0.00166667f, 0.0f, 1.0f );
-  humidity    = clamp( humidity, 0.0f, 1.0f );
+  temperature = std::clamp( temperature - (float)elevation*0.00166667f, 0.0f, 1.0f );
+  humidity    = std::clamp( humidity, 0.0f, 1.0f );
   humidity   *= temperature;  // scale by temperature to stay in triangle
 
   // lambda values for barycentric coordinates
@@ -89,9 +84,9 @@ QColor BiomeInfo::getBiomeColor( float temperature, float humidity, int elevatio
     blue  += lambda[i] * corners[i].blue;
   }
 
-  int r = (int)clamp( red,   0.0f, 255.0f );
-  int g = (int)clamp( green, 0.0f, 255.0f );
-  int b = (int)clamp( blue,  0.0f, 255.0f );
+  int r = (int)std::clamp( red,   0.0f, 255.0f );
+  int g = (int)std::clamp( green, 0.0f, 255.0f );
+  int b = (int)std::clamp( blue,  0.0f, 255.0f );
 
   return QColor::QColor(r,g,b);
 }
@@ -169,9 +164,9 @@ QColor BiomeInfo::getBiomeWaterColor( QColor watercolor )
 {
   if (this->enabledwatermodifier) {
     // calculate modified color components
-    int r = (int)( watercolor.red()   * watermodifier.red()   / 255 );
-    int g = (int)( watercolor.green() * watermodifier.green() / 255 );
-    int b = (int)( watercolor.blue()  * watermodifier.blue()  / 255 );
+    int r = (int)( watercolor.red()   * watermodifier.redF() );
+    int g = (int)( watercolor.green() * watermodifier.greenF() );
+    int b = (int)( watercolor.blue()  * watermodifier.blueF() );
     // return combined modified color
     return QColor::QColor(r, g, b);
   } else
@@ -214,10 +209,6 @@ void BiomeIdentifier::disableDefinitions(int pack) {
   int len = packs[pack].length();
   for (int i = 0; i < len; i++)
     packs[pack][i]->enabled = false;
-}
-
-static int clamp(int v, int min, int max) {
-  return (v < max ? (v > min ? v : min) : max);
 }
 
 int BiomeIdentifier::addDefinitions(JSONArray *defs, int pack) {

--- a/biomeidentifier.cpp
+++ b/biomeidentifier.cpp
@@ -6,9 +6,21 @@
 #include "./json.h"
 
 static BiomeInfo unknownBiome;
+
+BiomeInfo::BiomeInfo()
+  : name("Unknown Biome")
+  , enabled(false)
+  , watercolor(255,255,255)
+  , alpha(1.0)
+  , temperature(0.5)
+  , rainfall(0.5)
+{}
+
+
 BiomeIdentifier::BiomeIdentifier() {
   unknownBiome.name = "Unknown";
 }
+
 BiomeIdentifier::~BiomeIdentifier() {
   for (int i = 0; i < packs.length(); i++) {
     for (int j = 0; j < packs[i].length(); j++)
@@ -57,15 +69,25 @@ int BiomeIdentifier::addDefinitions(JSONArray *defs, int pack) {
     biome->enabled = true;
     if (b->has("name"))
       biome->name = b->at("name")->asString();
-    else
-      biome->name = "Unknown";
 
     // check for "alpha" (0: transparent / 1: saturated)
     // probably never used
     if (b->has("alpha"))
       biome->alpha = b->at("alpha")->asNumber();
-    else
-      biome->alpha = 1.0;
+
+    // get temperature definition
+    if (b->has("temperature"))
+      biome->temperature = b->at("temperature")->asNumber();
+
+    // get rainfall definition
+    if (b->has("rainfall"))
+      biome->rainfall = b->at("rainfall")->asNumber();
+
+    // get watercolor definition
+    if (b->has("watercolor")) {
+      biome->watercolor.setNamedColor(b->at("watercolor")->asString());
+      assert(biome->watercolor.isValid());
+    }
 
     // get color definition
     QColor biomecolor;

--- a/biomeidentifier.h
+++ b/biomeidentifier.h
@@ -39,6 +39,7 @@ class BiomeInfo {
   static T_BiomeCorner grassCorners[3];
   static T_BiomeCorner foliageCorners[3];
   static QColor getBiomeColor( float temperature, float humidity, int elevation, T_BiomeCorner *corners );
+  static QColor mixColor( QColor colorizer, QColor blockcolor );
 };
 
 class BiomeIdentifier {

--- a/biomeidentifier.h
+++ b/biomeidentifier.h
@@ -13,8 +13,8 @@ class BiomeInfo {
   // public methods
  public:
   BiomeInfo();
-  QColor getBiomeGrassColor  ( int elevation );
-  QColor getBiomeFoliageColor( int elevation );
+  QColor getBiomeGrassColor  ( QColor blockcolor, int elevation );
+  QColor getBiomeFoliageColor( QColor blockcolor, int elevation );
   QColor getBiomeWaterColor( QColor watercolor );
 
   // public members

--- a/biomeidentifier.h
+++ b/biomeidentifier.h
@@ -10,11 +10,14 @@ class JSONArray;
 
 class BiomeInfo {
  public:
-  BiomeInfo() {}
+  BiomeInfo();
   QString name;
   bool enabled;
   QColor colors[16];
+  QColor watercolor;
   double alpha;
+  double temperature;
+  double rainfall;
 };
 
 class BiomeIdentifier {

--- a/biomeidentifier.h
+++ b/biomeidentifier.h
@@ -17,7 +17,7 @@ class BiomeInfo {
   QColor watercolor;
   double alpha;
   double temperature;
-  double rainfall;
+  double humidity;
 };
 
 class BiomeIdentifier {

--- a/biomeidentifier.h
+++ b/biomeidentifier.h
@@ -19,6 +19,7 @@ class BiomeInfo {
 
   // public members
  public:
+  int id;
   QString name;
   bool enabled;
   QColor colors[16];

--- a/biomeidentifier.h
+++ b/biomeidentifier.h
@@ -8,16 +8,36 @@
 #include <QColor>
 class JSONArray;
 
+
 class BiomeInfo {
+  // public methods
  public:
   BiomeInfo();
+  QColor getBiomeGrassColor  ( int elevation );
+  QColor getBiomeFoliageColor( int elevation );
+  QColor getBiomeWaterColor( QColor watercolor );
+
+  // public members
+ public:
   QString name;
   bool enabled;
   QColor colors[16];
   QColor watermodifier;
+  bool   enabledwatermodifier;
   double alpha;
   double temperature;
   double humidity;
+
+  // private methods and members
+ private:
+  typedef struct T_BiomeCorner {
+    int red;
+    int green;
+    int blue;
+  } T_BiomeCorner;
+  static T_BiomeCorner grassCorners[3];
+  static T_BiomeCorner foliageCorners[3];
+  static QColor getBiomeColor( float temperature, float humidity, int elevation, T_BiomeCorner *corners );
 };
 
 class BiomeIdentifier {

--- a/biomeidentifier.h
+++ b/biomeidentifier.h
@@ -14,7 +14,7 @@ class BiomeInfo {
   QString name;
   bool enabled;
   QColor colors[16];
-  QColor watercolor;
+  QColor watermodifier;
   double alpha;
   double temperature;
   double humidity;

--- a/blockidentifier.cpp
+++ b/blockidentifier.cpp
@@ -9,7 +9,7 @@
 static BlockInfo unknownBlock;
 
 BlockInfo::BlockInfo() : transparent(false), liquid(false), rendernormal(true),
-  providepower(false), spawninside(false) {}
+  providepower(false), spawninside(false), grass(false), foliage(false) {}
 
 bool BlockInfo::isOpaque() {
   return !(this->transparent);
@@ -51,10 +51,8 @@ void BlockInfo::setName(const QString & newname) {
   halfslab = this->name.contains("Slab") && !this->name.contains("Double") &&
       !this->name.contains("Full");
   snow = this->name.contains("Snow");
-  // precompute biome based colors
+  // precompute biome based watercolormodifier
   water = this->name.contains("Water");
-  grass = this->name.compare("Grass", Qt::CaseInsensitive) == 0;
-  foliage = false;
 }
 
 const QString & BlockInfo::getName() { return name; }
@@ -70,6 +68,8 @@ bool BlockInfo::biomeWater()   { return water; }
 bool BlockInfo::biomeGrass()   { return grass; }
 bool BlockInfo::biomeFoliage() { return foliage; }
 
+void BlockInfo::setBiomeGrass(bool value)   { grass = value; }
+void BlockInfo::setBiomeFoliage(bool value) { foliage = value; }
 
 BlockIdentifier::BlockIdentifier() {
   // clear cache pointers
@@ -257,6 +257,13 @@ void BlockIdentifier::parseDefinition(JSONObject *b, BlockInfo *parent,
                             255*block->alpha );
   }
 
+  // biome dependant color
+  if (b->has("biomeGrass"))
+    block->setBiomeGrass( b->at("biomeGrass")->asBool() );
+  if (b->has("biomeFoliage"))
+    block->setBiomeFoliage( b->at("biomeFoliage")->asBool() );
+
+  // variant reduction mask
   if (b->has("mask"))
     block->mask = b->at("mask")->asNumber();
   else if (b->has("variants"))

--- a/blockidentifier.cpp
+++ b/blockidentifier.cpp
@@ -155,10 +155,6 @@ int BlockIdentifier::addDefinitions(JSONArray *defs, int pack) {
   return pack;
 }
 
-static int clamp(int v, int min, int max) {
-  return (v < max ? (v > min ? v : min) : max);
-}
-
 void BlockIdentifier::clearCache() {
   for (int i = 0; i < 65536; i++) {
     cache[i] = NULL;

--- a/blockidentifier.cpp
+++ b/blockidentifier.cpp
@@ -42,13 +42,19 @@ bool BlockInfo::canProvidePower() {
 }
 
 void BlockInfo::setName(const QString & newname) {
+  // set name
   name = newname;
+  // precompute mob spawning conditions
   bedrock = this->name.contains("Bedrock");
   hopper = this->name.contains("Hopper");
   stairs = this->name.contains("Stairs");
   halfslab = this->name.contains("Slab") && !this->name.contains("Double") &&
       !this->name.contains("Full");
   snow = this->name.contains("Snow");
+  // precompute biome based colors
+  water = this->name.contains("Water");
+  grass = this->name.compare("Grass", Qt::CaseInsensitive) == 0;
+  foliage = false;
 }
 
 const QString & BlockInfo::getName() { return name; }
@@ -60,6 +66,9 @@ bool BlockInfo::isStairs()   { return stairs; }
 bool BlockInfo::isHalfSlab() { return halfslab; }
 bool BlockInfo::isSnow()     { return snow; }
 
+bool BlockInfo::biomeWater()   { return water; }
+bool BlockInfo::biomeGrass()   { return grass; }
+bool BlockInfo::biomeFoliage() { return foliage; }
 
 
 BlockIdentifier::BlockIdentifier() {

--- a/blockidentifier.h
+++ b/blockidentifier.h
@@ -36,6 +36,11 @@ class BlockInfo {
   bool isHalfSlab();
   bool isSnow();
 
+  // special blocks with Biome based Grass, Foliage and Water colors
+  bool biomeWater();
+  bool biomeGrass();
+  bool biomeFoliage();
+
   void setName(const QString &newname);
   const QString &getName();
 
@@ -58,6 +63,9 @@ class BlockInfo {
   bool    stairs;
   bool    halfslab;
   bool    snow;
+  bool    water;
+  bool    grass;
+  bool    foliage;
 };
 
 class BlockIdentifier {

--- a/blockidentifier.h
+++ b/blockidentifier.h
@@ -11,17 +11,12 @@
 class JSONArray;
 class JSONObject;
 
-// bit masks for the flags
-#define BlockTransparent 1
-#define BlockSolid 2
-#define BlockLiquid 4
-
-// mobs can't spawn on transparent, but need 2 blocks of transparent,
-// non solid, non liquid above
 
 class BlockInfo {
  public:
   BlockInfo();
+
+  // special block attribute used during mob spawning detection
   bool isOpaque();
   bool isLiquid();
   bool doesBlockHaveSolidTopSurface(int data);
@@ -29,7 +24,7 @@ class BlockInfo {
   bool renderAsNormalBlock();
   bool canProvidePower();
 
-  // special blocks used during mob spawning detection
+  // special block type used during mob spawning detection
   bool isBedrock();
   bool isHopper();
   bool isStairs();
@@ -42,6 +37,8 @@ class BlockInfo {
   bool biomeFoliage();
 
   void setName(const QString &newname);
+  void setBiomeGrass(bool value);
+  void setBiomeFoliage(bool value);
   const QString &getName();
 
   int id;

--- a/chunk.cpp
+++ b/chunk.cpp
@@ -62,6 +62,7 @@ void Chunk::load(const NBT &nbt) {
     }
   }
 }
+
 Chunk::~Chunk() {
   if (loaded) {
     for (int i = 0; i < 16; i++)
@@ -80,13 +81,25 @@ quint16 ChunkSection::getBlock(int x, int y, int z) {
   return blocks[xoffset + yoffset + zoffset];
 }
 
+quint16 ChunkSection::getBlock(int offset, int y) {
+  int yoffset = (y & 0x0f) << 8;
+  return blocks[offset + yoffset];
+}
+
 quint8 ChunkSection::getData(int x, int y, int z) {
   int xoffset = x;
   int yoffset = (y & 0x0f) << 8;
   int zoffset = z << 4;
   int value = data[(xoffset + yoffset + zoffset) / 2];
   if (x & 1) value >>= 4;
-  return value&0x0f;
+  return value & 0x0f;
+}
+
+quint8 ChunkSection::getData(int offset, int y) {
+  int yoffset = (y & 0x0f) << 8;
+  int value = data[(offset + yoffset) / 2];
+  if (offset & 1) value >>= 4;
+  return value & 0x0f;
 }
 
 quint8 ChunkSection::getLight(int x, int y, int z) {
@@ -95,5 +108,12 @@ quint8 ChunkSection::getLight(int x, int y, int z) {
   int zoffset = z << 4;
   int value = light[(xoffset + yoffset + zoffset) / 2];
   if (x & 1) value >>= 4;
+  return value & 0x0f;
+}
+
+quint8 ChunkSection::getLight(int offset, int y) {
+  int yoffset = (y & 0x0f) << 8;
+  int value = light[(offset + yoffset) / 2];
+  if (offset & 1) value >>= 4;
   return value & 0x0f;
 }

--- a/chunk.h
+++ b/chunk.h
@@ -12,8 +12,11 @@ class BlockIdentifier;
 class ChunkSection {
  public:
   quint16 getBlock(int x, int y, int z);
+  quint16 getBlock(int offset, int y);
   quint8  getData(int x, int y, int z);
+  quint8  getData(int offset, int y);
   quint8  getLight(int x, int y, int z);
+  quint8  getLight(int offset, int y);
 
   quint16 blocks[4096];
   quint8  data[2048];

--- a/clamp.h
+++ b/clamp.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2016, EtlamGit
+#ifndef CLAMP_H_
+#define CLAMP_H_
+
+namespace std {
+
+// will be in STD with C++17
+template < class T >
+const T& clamp( const T& value, const T& lower, const T& upper )
+{
+  return (value<lower)? lower : (upper<value)? upper : value;
+}
+
+}
+#endif  // CLAMP_H_

--- a/definitions/readme.txt
+++ b/definitions/readme.txt
@@ -57,9 +57,30 @@ deobfuscated 1.8.x code is not available.
 
 
 
-Other special attribute value pairs in this file:
+Other attribute value pairs in this file:
 
-"mask": number
+"id": integer_number
+
+Numerical code used in the savegame for this block
+
+
+"name": "Name of Block"
+
+String representation of this Block, shown in status bar when hovering mouse over
+
+
+"color": "#ffffff"
+
+Color usedd for rendering this block
+
+
+"alpha": float_number
+
+In case the block is transparent (e.g. water) this defines the amount it coveres
+the block below. 0.0 is completely transparent. 1.0 is the default, a opaque block.
+
+
+"mask": integer_number
 
 In case a block has variants a mask can be given to blend out bits in the data
 field that are not used to define the block itself. These bits are mostely used
@@ -67,6 +88,17 @@ to define block orientation.
  if a block has no variants defined,   "mask":  0 is predefined
  if a block has some variants defined, "mask": 15 is predefined
 
+
+"biomeGrass": boolean
+
+When color of block is changing based on Biome and is based on the Grass Colorizer,
+this flag has to be set true. Defaults to false.
+
+
+"biomeFoliage": boolean
+
+When color of block is changing based on Biome and is based on the Foliage Colorizer,
+this flag has to be set true. Defaults to false.
 
 
 [EtlamGit]

--- a/definitions/readme_biomes.txt
+++ b/definitions/readme_biomes.txt
@@ -18,7 +18,7 @@ Inside the "data" tag available biomes are defined:
       "color": "#07f9b2",
       "watercolor" : 14745518,
       "temperature": 0.8,
-      "rainfall": 0.9
+      "humidity": 0.9
     },
     [...]
   ]
@@ -31,7 +31,7 @@ some special values can be derived from the Minecraft source code:
 
 "watercolor"  - special color of water (in swamps)
 "temperature" - default 0.5
-"rainfall"    - default 0.5
+"humidity"    - default 0.5
 
 
 

--- a/definitions/readme_biomes.txt
+++ b/definitions/readme_biomes.txt
@@ -1,0 +1,47 @@
+FAQ and detailed description for vanilla_biomes.json
+
+
+The biome definition file contains all data needed to describe available Biomes.
+
+Inside the "data" tag available biomes are defined:
+
+  "data": [
+    {
+      "id": 0,
+      "name": "Ocean",
+      "color": "#000070"
+    },
+    [...]
+    {
+      "id": 6,
+      "name": "Swampland",
+      "color": "#07f9b2",
+      "watercolor" : 14745518,
+      "temperature": 0.8,
+      "rainfall": 0.9
+    },
+    [...]
+  ]
+
+"id"    - the SaveGameID used by Minecraft
+"color" - color used in Biome Overly (e.g. AMIDST color code)
+ if color is omitted a pseudo random color is calculated based on the hashed name
+
+some special values can be derived from the Minecraft source code:
+
+"watercolor"  - special color of water (in swamps)
+"temperature" - default 0.5
+"rainfall"    - default 0.5
+
+
+
+All colors can be defined in a syntax readable by Qt::QColor::setNamedColor( QString )
+ http://qt-project.org/doc/qt-4.8/qcolor.html#setNamedColor
+
+This is basically all hex definitions like #rrggbb but also all named colors from
+ http://www.w3.org/TR/SVG/types.html#ColorKeywords
+are possible.
+
+
+
+[EtlamGit]

--- a/definitions/vanilla_biomes.json
+++ b/definitions/vanilla_biomes.json
@@ -47,7 +47,7 @@
       "id": 6,
       "name": "Swampland",
       "color": "#07f9b2",
-      "watercolor": "#e0ffae",
+      "watermodifier": "#e0ffae",
       "temperature": 0.8,
       "humidity": 0.9
     },
@@ -320,7 +320,7 @@
       "id": 134,
       "name": "Swampland M",
       "color": "#2fffda",
-      "watercolor": "#e0ffae",
+      "watermodifier": "#e0ffae",
       "temperature": 0.8,
       "humidity": 0.9
     },

--- a/definitions/vanilla_biomes.json
+++ b/definitions/vanilla_biomes.json
@@ -11,32 +11,45 @@
     {
       "id": 1,
       "name": "Plains",
-      "color": "#8db360"
+      "color": "#8db360",
+      "temperature": 0.8,
+      "rainfall": 0.4
     },
     {
       "id": 2,
       "name": "Desert",
-      "color": "#fa9418"
+      "color": "#fa9418",
+      "temperature": 2.0,
+      "rainfall": 0.0
     },
     {
       "id": 3,
       "name": "Extreme Hills",
-      "color": "#606060"
+      "color": "#606060",
+      "temperature": 0.2,
+      "rainfall": 0.3
     },
     {
       "id": 4,
       "name": "Forest",
-      "color": "#056621"
+      "color": "#056621",
+      "temperature": 0.7,
+      "rainfall": 0.8
     },
     {
       "id": 5,
       "name": "Taiga",
-      "color": "#0b6659"
+      "color": "#0b6659",
+      "temperature": 0.25,
+      "rainfall": 0.8
     },
     {
       "id": 6,
       "name": "Swampland",
-      "color": "#07f9b2"
+      "color": "#07f9b2",
+      "watercolor" : 14745518,
+      "temperature": 0.8,
+      "rainfall": 0.9
     },
     {
       "id": 7,
@@ -46,7 +59,9 @@
     {
       "id": 8,
       "name": "Hell",
-      "color": "#ff0000"
+      "color": "#ff0000",
+      "temperature": 2.0,
+      "rainfall": 0.0
     },
     {
       "id": 9,
@@ -56,72 +71,100 @@
     {
       "id": 10,
       "name": "Frozen Ocean",
-      "color": "#9090a0"
+      "color": "#9090a0",
+      "temperature": 0.0,
+      "rainfall": 0.5
     },
     {
       "id": 11,
       "name": "Frozen River",
-      "color": "#a0a0ff"
+      "color": "#a0a0ff",
+      "temperature": 0.0,
+      "rainfall": 0.5
     },
     {
       "id": 12,
       "name": "Ice Plains",
-      "color": "#ffffff"
+      "color": "#ffffff",
+      "temperature": 0.0,
+      "rainfall": 0.5
     },
     {
       "id": 13,
       "name": "Ice Mountains",
-      "color": "#a0a0a0"
+      "color": "#a0a0a0",
+      "temperature": 0.0,
+      "rainfall": 0.5
     },
     {
       "id": 14,
       "name": "Mushroom Island",
-      "color": "#ff00ff"
+      "color": "#ff00ff",
+      "temperature": 0.9,
+      "rainfall": 1.0
     },
     {
       "id": 15,
       "name": "Mushroom Island Shore",
-      "color": "#a000ff"
+      "color": "#a000ff",
+      "temperature": 0.9,
+      "rainfall": 1.0
     },
     {
       "id": 16,
       "name": "Beach",
-      "color": "#fade55"
+      "color": "#fade55",
+      "temperature": 0.8,
+      "rainfall": 0.4
     },
     {
       "id": 17,
       "name": "Desert Hills",
-      "color": "#d25f12"
+      "color": "#d25f12",
+      "temperature": 2.0,
+      "rainfall": 0.0
     },
     {
       "id": 18,
       "name": "Forest Hills",
-      "color": "#22551c"
+      "color": "#22551c",
+      "temperature": 0.7,
+      "rainfall": 0.8
     },
     {
       "id": 19,
       "name": "Taiga Hills",
-      "color": "#163933"
+      "color": "#163933",
+      "temperature": 0.25,
+      "rainfall": 0.8
     },
     {
       "id": 20,
       "name": "Extreme Hills Edge",
-      "color": "#72789a"
+      "color": "#72789a",
+      "temperature": 0.2,
+      "rainfall": 0.3
     },
     {
       "id": 21,
       "name": "Jungle",
-      "color": "#537b09"
+      "color": "#537b09",
+      "temperature": 0.95,
+      "rainfall": 0.9
     },
     {
       "id": 22,
       "name": "Jungle Hills",
-      "color": "#2c4205"
+      "color": "#2c4205",
+      "temperature": 0.95,
+      "rainfall": 0.9
     },
     {
       "id": 23,
       "name": "Jungle Edge",
-      "color": "#628b17"
+      "color": "#628b17",
+      "temperature": 0.95,
+      "rainfall": 0.8
     },
     {
       "id": 24,
@@ -131,77 +174,107 @@
     {
       "id": 25,
       "name": "Stone Beach",
-      "color": "#a2a284"
+      "color": "#a2a284",
+      "temperature": 0.2,
+      "rainfall": 0.3
     },
     {
       "id": 26,
       "name": "Cold Beach",
-      "color": "#faf0c0"
+      "color": "#faf0c0",
+      "temperature": 0.05,
+      "rainfall": 0.3
     },
     {
       "id": 27,
       "name": "Birch Forest",
-      "color": "#307444"
+      "color": "#307444",
+      "temperature": 0.6,
+      "rainfall": 0.6
     },
     {
       "id": 28,
       "name": "Birch Forest Hills",
-      "color": "#1f5f32"
+      "color": "#1f5f32",
+      "temperature": 0.6,
+      "rainfall": 0.6
     },
     {
       "id": 29,
       "name": "Roofed Forest",
-      "color": "#40511a"
+      "color": "#40511a",
+      "temperature": 0.7,
+      "rainfall": 0.8
     },
     {
       "id": 30,
       "name": "Cold Taiga",
-      "color": "#31554a"
+      "color": "#31554a",
+      "temperature": -0.5,
+      "rainfall": 0.4
     },
     {
       "id": 31,
       "name": "Cold Taiga Hills",
-      "color": "#243f36"
+      "color": "#243f36",
+      "temperature": -0.5,
+      "rainfall": 0.4
     },
     {
       "id": 32,
       "name": "Mega Taiga",
-      "color": "#596651"
+      "color": "#596651",
+      "temperature": 0.3,
+      "rainfall": 0.8
     },
     {
       "id": 33,
       "name": "Mega Taiga Hills",
-      "color": "#454f3e"
+      "color": "#454f3e",
+      "temperature": 0.3,
+      "rainfall": 0.8
     },
     {
       "id": 34,
       "name": "Extreme Hills+",
-      "color": "#507050"
+      "color": "#507050",
+      "temperature": 0.2,
+      "rainfall": 0.3
     },
     {
       "id": 35,
       "name": "Savanna",
-      "color": "#bdb25f"
+      "color": "#bdb25f",
+      "temperature": 1.2,
+      "rainfall": 0.0
     },
     {
       "id": 36,
       "name": "Savanna Plateau",
-      "color": "#a79d64"
+      "color": "#a79d64",
+      "temperature": 1.0,
+      "rainfall": 0.0
     },
     {
       "id": 37,
       "name": "Mesa",
-      "color": "#d94515"
+      "color": "#d94515",
+      "temperature": 2.0,
+      "rainfall": 0.0
     },
     {
       "id": 38,
       "name": "Mesa Plateau F",
-      "color": "#b09765"
+      "color": "#b09765",
+      "temperature": 2.0,
+      "rainfall": 0.0
     },
     {
       "id": 39,
       "name": "Mesa Plateau",
-      "color": "#ca8c65"
+      "color": "#ca8c65",
+      "temperature": 2.0,
+      "rainfall": 0.0
     },
     {
       "id": 127,
@@ -211,107 +284,150 @@
     {
       "id": 129,
       "name": "Sunflower Plains",
-      "color": "#b5db88"
+      "color": "#b5db88",
+      "temperature": 0.8,
+      "rainfall": 0.4
     },
     {
       "id": 130,
       "name": "Desert M",
-      "color": "#ffbc40"
+      "color": "#ffbc40",
+      "temperature": 2.0,
+      "rainfall": 0.0
     },
     {
       "id": 131,
       "name": "Extreme Hills M",
-      "color": "#888888"
+      "color": "#888888",
+      "temperature": 0.2,
+      "rainfall": 0.3
     },
     {
       "id": 132,
       "name": "Flower Forest",
-      "color": "#2d8e49"
+      "color": "#2d8e49",
+      "temperature": 0.7,
+      "rainfall": 0.8
     },
     {
       "id": 133,
       "name": "Taiga M",
-      "color": "#338e81"
+      "color": "#338e81",
+      "temperature": 0.25,
+      "rainfall": 0.8
     },
     {
       "id": 134,
       "name": "Swampland M",
-      "color": "#2fffda"
+      "color": "#2fffda",
+      "watercolor" : 14745518,
+      "temperature": 0.8,
+      "rainfall": 0.9
     },
     {
       "id": 140,
       "name": "Ice Plains Spikes",
-      "color": "#b4dcdc"
+      "color": "#b4dcdc",
+      "temperature": 0.0,
+      "rainfall": 0.5
     },
     {
       "id": 149,
       "name": "Jungle M",
-      "color": "#7ba331"
+      "color": "#7ba331",
+      "temperature": 0.95,
+      "rainfall": 0.9
     },
     {
       "id": 151,
       "name": "Jungle Edge M",
-      "color": "#8ab33f"
+      "color": "#8ab33f",
+      "temperature": 0.95,
+      "rainfall": 0.8
     },
     {
       "id": 155,
       "name": "Birch Forest M",
-      "color": "#589c6c"
+      "color": "#589c6c",
+      "temperature": 0.6,
+      "rainfall": 0.6
     },
     {
       "id": 156,
       "name": "Birch Forest Hills M",
-      "color": "#47875a"
+      "color": "#47875a",
+      "temperature": 0.6,
+      "rainfall": 0.6
     },
     {
       "id": 157,
       "name": "Roofed Forest M",
-      "color": "#687942"
+      "color": "#687942",
+      "temperature": 0.7,
+      "rainfall": 0.8
     },
     {
       "id": 158,
       "name": "Cold Taiga M",
-      "color": "#597d72"
+      "color": "#597d72",
+      "temperature": -0.5,
+      "rainfall": 0.4
     },
     {
       "id": 160,
       "name": "Mega Spruce Taiga",
-      "color": "#818e79"
+      "color": "#818e79",
+      "temperature": 0.25,
+      "rainfall": 0.8
     },
     {
       "id": 161,
       "name": "Mega Spruce Taiga Hills",
-      "color": "#6d7766"
+      "color": "#6d7766",
+      "temperature": 0.25,
+      "rainfall": 0.8
     },
     {
       "id": 162,
       "name": "Extreme Hills+ M",
-      "color": "#789878"
+      "color": "#789878",
+      "temperature": 0.2,
+      "rainfall": 0.3
     },
     {
       "id": 163,
       "name": "Savanna M",
-      "color": "#e5da87"
+      "color": "#e5da87",
+      "temperature": 1.1,
+      "rainfall": 0.0
     },
     {
       "id": 164,
       "name": "Savanna Plateau M",
-      "color": "#cfc58c"
+      "color": "#cfc58c",
+      "temperature": 1.0,
+      "rainfall": 0.0
     },
     {
       "id": 165,
       "name": "Mesa (Bryce)",
-      "color": "#ff6d3d"
+      "color": "#ff6d3d",
+      "temperature": 2.0,
+      "rainfall": 0.0
     },
     {
       "id": 166,
       "name": "Mesa Plateau F M",
-      "color": "#d8bf8d"
+      "color": "#d8bf8d",
+      "temperature": 2.0,
+      "rainfall": 0.0
     },
     {
       "id": 167,
       "name": "Mesa Plateau M",
-      "color": "#f2b48d"
+      "color": "#f2b48d",
+      "temperature": 2.0,
+      "rainfall": 0.0
     }
   ],
   "update": "https://github.com/mrkite/minutor/raw/master/definitions/vanilla_biomes.json"

--- a/definitions/vanilla_biomes.json
+++ b/definitions/vanilla_biomes.json
@@ -1,7 +1,7 @@
 {
   "name": "Vanilla",
   "type": "biome",
-  "version": "1.9.15w37a",
+  "version": "1.10.2",
   "data": [
     {
       "id": 0,
@@ -47,7 +47,7 @@
       "id": 6,
       "name": "Swampland",
       "color": "#07f9b2",
-      "watercolor" : 14745518,
+      "watercolor": "#e0ffae",
       "temperature": 0.8,
       "rainfall": 0.9
     },
@@ -320,7 +320,7 @@
       "id": 134,
       "name": "Swampland M",
       "color": "#2fffda",
-      "watercolor" : 14745518,
+      "watercolor": "#e0ffae",
       "temperature": 0.8,
       "rainfall": 0.9
     },

--- a/definitions/vanilla_biomes.json
+++ b/definitions/vanilla_biomes.json
@@ -1,7 +1,7 @@
 {
   "name": "Vanilla",
   "type": "biome",
-  "version": "1.10.2",
+  "version": "1.11.2",
   "data": [
     {
       "id": 0,

--- a/definitions/vanilla_biomes.json
+++ b/definitions/vanilla_biomes.json
@@ -13,35 +13,35 @@
       "name": "Plains",
       "color": "#8db360",
       "temperature": 0.8,
-      "rainfall": 0.4
+      "humidity": 0.4
     },
     {
       "id": 2,
       "name": "Desert",
       "color": "#fa9418",
       "temperature": 2.0,
-      "rainfall": 0.0
+      "humidity": 0.0
     },
     {
       "id": 3,
       "name": "Extreme Hills",
       "color": "#606060",
       "temperature": 0.2,
-      "rainfall": 0.3
+      "humidity": 0.3
     },
     {
       "id": 4,
       "name": "Forest",
       "color": "#056621",
       "temperature": 0.7,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 5,
       "name": "Taiga",
       "color": "#0b6659",
       "temperature": 0.25,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 6,
@@ -49,7 +49,7 @@
       "color": "#07f9b2",
       "watercolor": "#e0ffae",
       "temperature": 0.8,
-      "rainfall": 0.9
+      "humidity": 0.9
     },
     {
       "id": 7,
@@ -61,7 +61,7 @@
       "name": "Hell",
       "color": "#ff0000",
       "temperature": 2.0,
-      "rainfall": 0.0
+      "humidity": 0.0
     },
     {
       "id": 9,
@@ -73,98 +73,98 @@
       "name": "Frozen Ocean",
       "color": "#9090a0",
       "temperature": 0.0,
-      "rainfall": 0.5
+      "humidity": 0.5
     },
     {
       "id": 11,
       "name": "Frozen River",
       "color": "#a0a0ff",
       "temperature": 0.0,
-      "rainfall": 0.5
+      "humidity": 0.5
     },
     {
       "id": 12,
       "name": "Ice Plains",
       "color": "#ffffff",
       "temperature": 0.0,
-      "rainfall": 0.5
+      "humidity": 0.5
     },
     {
       "id": 13,
       "name": "Ice Mountains",
       "color": "#a0a0a0",
       "temperature": 0.0,
-      "rainfall": 0.5
+      "humidity": 0.5
     },
     {
       "id": 14,
       "name": "Mushroom Island",
       "color": "#ff00ff",
       "temperature": 0.9,
-      "rainfall": 1.0
+      "humidity": 1.0
     },
     {
       "id": 15,
       "name": "Mushroom Island Shore",
       "color": "#a000ff",
       "temperature": 0.9,
-      "rainfall": 1.0
+      "humidity": 1.0
     },
     {
       "id": 16,
       "name": "Beach",
       "color": "#fade55",
       "temperature": 0.8,
-      "rainfall": 0.4
+      "humidity": 0.4
     },
     {
       "id": 17,
       "name": "Desert Hills",
       "color": "#d25f12",
       "temperature": 2.0,
-      "rainfall": 0.0
+      "humidity": 0.0
     },
     {
       "id": 18,
       "name": "Forest Hills",
       "color": "#22551c",
       "temperature": 0.7,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 19,
       "name": "Taiga Hills",
       "color": "#163933",
       "temperature": 0.25,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 20,
       "name": "Extreme Hills Edge",
       "color": "#72789a",
       "temperature": 0.2,
-      "rainfall": 0.3
+      "humidity": 0.3
     },
     {
       "id": 21,
       "name": "Jungle",
       "color": "#537b09",
       "temperature": 0.95,
-      "rainfall": 0.9
+      "humidity": 0.9
     },
     {
       "id": 22,
       "name": "Jungle Hills",
       "color": "#2c4205",
       "temperature": 0.95,
-      "rainfall": 0.9
+      "humidity": 0.9
     },
     {
       "id": 23,
       "name": "Jungle Edge",
       "color": "#628b17",
       "temperature": 0.95,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 24,
@@ -176,105 +176,105 @@
       "name": "Stone Beach",
       "color": "#a2a284",
       "temperature": 0.2,
-      "rainfall": 0.3
+      "humidity": 0.3
     },
     {
       "id": 26,
       "name": "Cold Beach",
       "color": "#faf0c0",
       "temperature": 0.05,
-      "rainfall": 0.3
+      "humidity": 0.3
     },
     {
       "id": 27,
       "name": "Birch Forest",
       "color": "#307444",
       "temperature": 0.6,
-      "rainfall": 0.6
+      "humidity": 0.6
     },
     {
       "id": 28,
       "name": "Birch Forest Hills",
       "color": "#1f5f32",
       "temperature": 0.6,
-      "rainfall": 0.6
+      "humidity": 0.6
     },
     {
       "id": 29,
       "name": "Roofed Forest",
       "color": "#40511a",
       "temperature": 0.7,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 30,
       "name": "Cold Taiga",
       "color": "#31554a",
       "temperature": -0.5,
-      "rainfall": 0.4
+      "humidity": 0.4
     },
     {
       "id": 31,
       "name": "Cold Taiga Hills",
       "color": "#243f36",
       "temperature": -0.5,
-      "rainfall": 0.4
+      "humidity": 0.4
     },
     {
       "id": 32,
       "name": "Mega Taiga",
       "color": "#596651",
       "temperature": 0.3,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 33,
       "name": "Mega Taiga Hills",
       "color": "#454f3e",
       "temperature": 0.3,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 34,
       "name": "Extreme Hills+",
       "color": "#507050",
       "temperature": 0.2,
-      "rainfall": 0.3
+      "humidity": 0.3
     },
     {
       "id": 35,
       "name": "Savanna",
       "color": "#bdb25f",
       "temperature": 1.2,
-      "rainfall": 0.0
+      "humidity": 0.0
     },
     {
       "id": 36,
       "name": "Savanna Plateau",
       "color": "#a79d64",
       "temperature": 1.0,
-      "rainfall": 0.0
+      "humidity": 0.0
     },
     {
       "id": 37,
       "name": "Mesa",
       "color": "#d94515",
       "temperature": 2.0,
-      "rainfall": 0.0
+      "humidity": 0.0
     },
     {
       "id": 38,
       "name": "Mesa Plateau F",
       "color": "#b09765",
       "temperature": 2.0,
-      "rainfall": 0.0
+      "humidity": 0.0
     },
     {
       "id": 39,
       "name": "Mesa Plateau",
       "color": "#ca8c65",
       "temperature": 2.0,
-      "rainfall": 0.0
+      "humidity": 0.0
     },
     {
       "id": 127,
@@ -286,35 +286,35 @@
       "name": "Sunflower Plains",
       "color": "#b5db88",
       "temperature": 0.8,
-      "rainfall": 0.4
+      "humidity": 0.4
     },
     {
       "id": 130,
       "name": "Desert M",
       "color": "#ffbc40",
       "temperature": 2.0,
-      "rainfall": 0.0
+      "humidity": 0.0
     },
     {
       "id": 131,
       "name": "Extreme Hills M",
       "color": "#888888",
       "temperature": 0.2,
-      "rainfall": 0.3
+      "humidity": 0.3
     },
     {
       "id": 132,
       "name": "Flower Forest",
       "color": "#2d8e49",
       "temperature": 0.7,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 133,
       "name": "Taiga M",
       "color": "#338e81",
       "temperature": 0.25,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 134,
@@ -322,112 +322,112 @@
       "color": "#2fffda",
       "watercolor": "#e0ffae",
       "temperature": 0.8,
-      "rainfall": 0.9
+      "humidity": 0.9
     },
     {
       "id": 140,
       "name": "Ice Plains Spikes",
       "color": "#b4dcdc",
       "temperature": 0.0,
-      "rainfall": 0.5
+      "humidity": 0.5
     },
     {
       "id": 149,
       "name": "Jungle M",
       "color": "#7ba331",
       "temperature": 0.95,
-      "rainfall": 0.9
+      "humidity": 0.9
     },
     {
       "id": 151,
       "name": "Jungle Edge M",
       "color": "#8ab33f",
       "temperature": 0.95,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 155,
       "name": "Birch Forest M",
       "color": "#589c6c",
       "temperature": 0.6,
-      "rainfall": 0.6
+      "humidity": 0.6
     },
     {
       "id": 156,
       "name": "Birch Forest Hills M",
       "color": "#47875a",
       "temperature": 0.6,
-      "rainfall": 0.6
+      "humidity": 0.6
     },
     {
       "id": 157,
       "name": "Roofed Forest M",
       "color": "#687942",
       "temperature": 0.7,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 158,
       "name": "Cold Taiga M",
       "color": "#597d72",
       "temperature": -0.5,
-      "rainfall": 0.4
+      "humidity": 0.4
     },
     {
       "id": 160,
       "name": "Mega Spruce Taiga",
       "color": "#818e79",
       "temperature": 0.25,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 161,
       "name": "Mega Spruce Taiga Hills",
       "color": "#6d7766",
       "temperature": 0.25,
-      "rainfall": 0.8
+      "humidity": 0.8
     },
     {
       "id": 162,
       "name": "Extreme Hills+ M",
       "color": "#789878",
       "temperature": 0.2,
-      "rainfall": 0.3
+      "humidity": 0.3
     },
     {
       "id": 163,
       "name": "Savanna M",
       "color": "#e5da87",
       "temperature": 1.1,
-      "rainfall": 0.0
+      "humidity": 0.0
     },
     {
       "id": 164,
       "name": "Savanna Plateau M",
       "color": "#cfc58c",
       "temperature": 1.0,
-      "rainfall": 0.0
+      "humidity": 0.0
     },
     {
       "id": 165,
       "name": "Mesa (Bryce)",
       "color": "#ff6d3d",
       "temperature": 2.0,
-      "rainfall": 0.0
+      "humidity": 0.0
     },
     {
       "id": 166,
       "name": "Mesa Plateau F M",
       "color": "#d8bf8d",
       "temperature": 2.0,
-      "rainfall": 0.0
+      "humidity": 0.0
     },
     {
       "id": 167,
       "name": "Mesa Plateau M",
       "color": "#f2b48d",
       "temperature": 2.0,
-      "rainfall": 0.0
+      "humidity": 0.0
     }
   ],
   "update": "https://github.com/mrkite/minutor/raw/master/definitions/vanilla_biomes.json"

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -1,7 +1,7 @@
 {
   "name": "Vanilla",
   "type": "block",
-  "version": "1.11.16w39a",
+  "version": "1.11.16w40a",
   "data": [
     {
       "id": 0,
@@ -51,7 +51,8 @@
     {
       "id": 2,
       "name": "Grass",
-      "color": "#78bf64"
+      "color": "#939393",
+      "biomeGrass": true
     },
     {
       "id": 3,
@@ -358,12 +359,14 @@
         {
           "data": 1,
           "name": "Tall Grass",
-          "color": "#83bf54"
+          "color": "#909090",
+          "biomeGrass": true
         },
         {
           "data": 2,
           "name": "Fern",
-          "color": "#8fbb64"
+          "color": "#828282",
+          "biomeGrass": true
         }
       ]
     },
@@ -942,9 +945,10 @@
     {
       "id": 83,
       "name": "Sugar Cane",
-      "color": "#aadb74",
+      "color": "#97c06b",
       "spawninside": true,
-      "transparent": true
+      "transparent": true,
+      "biomeGrass": true
     },
     {
       "id": 84,
@@ -2200,12 +2204,14 @@
         {
           "data": 2,
           "name": "Double Tallgrass",
-          "color": "#5e8328"
+          "color": "#969696",
+          "biomeGrass": true
         },
         {
           "data": 3,
           "name": "Large Fern",
-          "color": "#617b2d"
+          "color": "#828282",
+          "biomeGrass": true
         },
         {
           "data": 4,

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -237,25 +237,29 @@
     {
       "id": 18,
       "name": "Oak Leaves",
-      "color": "#3d9b3d",
+      "color": "#8b8b8b",
       "transparent": true,
       "rendercube": true,
+      "biomeFoliage": true,
       "mask": 3,
       "variants": [
         {
           "data": 1,
           "name": "Spruce Leaves",
-          "color": "#519b5a"
+          "color": "#519b5a",
+          "biomeFoliage": false
         },
         {
           "data": 2,
           "name": "Birch Leaves",
-          "color": "#6faa3b"
+          "color": "#6faa3b",
+          "biomeFoliage": false
         },
         {
           "data": 3,
           "name": "Jungle Leaves",
-          "color": "#649642"
+          "color": "#94938e",
+          "biomeFoliage": true
         }
       ]
     },
@@ -1300,9 +1304,10 @@
     {
       "id": 106,
       "name": "Vines",
-      "color": "#6cc44a",
+      "color": "#6f6f6f",
       "transparent": true,
-      "spawninside": true
+      "spawninside": true,
+      "biomeFoliage": true
     },
     {
       "id": 107,
@@ -2010,15 +2015,17 @@
     {
       "id": 161,
       "name": "Acacia Leaves",
-      "color": "#97a636",
+      "color": "#8b8b8b",
       "transparent": true,
       "rendercube": true,
+      "biomeFoliage": true,
       "mask": 1,
       "variants": [
         {
           "data": 1,
           "name": "Dark Oak Leaves",
-          "color": "#45751c"
+          "color": "#8b8b8b",
+          "biomeFoliage": true
         }
       ]
     },

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -1,7 +1,7 @@
 {
   "name": "Vanilla",
   "type": "block",
-  "version": "1.11.16w40a",
+  "version": "1.11.2",
   "data": [
     {
       "id": 0,
@@ -237,7 +237,7 @@
     {
       "id": 18,
       "name": "Oak Leaves",
-      "color": "#8b8b8b",
+      "color": "#515151",
       "transparent": true,
       "rendercube": true,
       "biomeFoliage": true,
@@ -246,19 +246,19 @@
         {
           "data": 1,
           "name": "Spruce Leaves",
-          "color": "#519b5a",
+          "color": "#619961",
           "biomeFoliage": false
         },
         {
           "data": 2,
           "name": "Birch Leaves",
-          "color": "#6faa3b",
+          "color": "#80a755",
           "biomeFoliage": false
         },
         {
           "data": 3,
           "name": "Jungle Leaves",
-          "color": "#94938e",
+          "color": "#727069",
           "biomeFoliage": true
         }
       ]
@@ -2015,7 +2015,7 @@
     {
       "id": 161,
       "name": "Acacia Leaves",
-      "color": "#8b8b8b",
+      "color": "#515151",
       "transparent": true,
       "rendercube": true,
       "biomeFoliage": true,
@@ -2024,7 +2024,7 @@
         {
           "data": 1,
           "name": "Dark Oak Leaves",
-          "color": "#8b8b8b",
+          "color": "#515151",
           "biomeFoliage": true
         }
       ]

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -383,6 +383,7 @@ void MapView::renderChunk(Chunk *chunk) {
       uchar r = 0, g = 0, b = 0;
       double alpha = 0.0;
       // get Biome
+      auto &biome = biomes->getBiome(chunk->biomes[offset]);
       int top = depth;
       if (top > chunk->highest)
         top = chunk->highest;
@@ -396,10 +397,10 @@ void MapView::renderChunk(Chunk *chunk) {
         }
 
         // get data value
-        int data = section->getData(x, y, z);
+        int data = section->getData(offset, y);
 
         // get BlockInfo from block value
-        BlockInfo &block = blocks->getBlock(section->getBlock(x, y, z),
+        BlockInfo &block = blocks->getBlock(section->getBlock(offset, y),
                                             data);
         if (block.alpha == 0.0) continue;
 
@@ -407,9 +408,9 @@ void MapView::renderChunk(Chunk *chunk) {
         int light = 0;
         ChunkSection *section1 = NULL;
         if (y < 255)
-          section1 = chunk->sections[(y + 1) >> 4];
+          section1 = chunk->sections[(y+1) >> 4];
         if (section1)
-          light = section1->getLight(x, y + 1, z);
+          light = section1->getLight(offset, y+1);
         int light1 = light;
         if (!(flags & flgLighting))
           light = 13;
@@ -463,26 +464,26 @@ void MapView::renderChunk(Chunk *chunk) {
           ChunkSection *section2 = NULL;
           ChunkSection *sectionB = NULL;
           if (y < 254)
-            section2 = chunk->sections[(y + 2) >> 4];
+            section2 = chunk->sections[(y+2) >> 4];
           if (y > 0)
-            sectionB = chunk->sections[(y - 1) >> 4];
+            sectionB = chunk->sections[(y-1) >> 4];
           if (section1) {
-            blid1 = section1->getBlock(x, y + 1, z);
-            data1 = section1->getData(x, y + 1, z);
+            blid1 = section1->getBlock(offset, y+1);
+            data1 = section1->getData(offset, y+1);
           }
           if (section2) {
-            blid2 = section2->getBlock(x, y + 2, z);
-            data2 = section2->getData(x, y + 2, z);
+            blid2 = section2->getBlock(offset, y+2);
+            data2 = section2->getData(offset, y+2);
           }
           if (sectionB) {
-            blidB = sectionB->getBlock(x, y - 1, z);
-            dataB = sectionB->getData(x, y - 1, z);
+            blidB = sectionB->getBlock(offset, y-1);
+            dataB = sectionB->getData(offset, y-1);
           }
           BlockInfo &block2 = blocks->getBlock(blid2, data2);
           BlockInfo &block1 = blocks->getBlock(blid1, data1);
           BlockInfo &block0 = block;
           BlockInfo &blockB = blocks->getBlock(blidB, dataB);
-          int light0 = section->getLight(x, y, z);
+          int light0 = section->getLight(offset, y);
 
           // spawn check #1: on top of solid block
           if (block0.doesBlockHaveSolidTopSurface(data) &&

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -91,11 +91,11 @@ void MapView::clearCache() {
   redraw();
 }
 
-static int lastX = -1, lastY = -1;
+static int lastMouseX = -1, lastMouseY = -1;
 static bool dragging = false;
 void MapView::mousePressEvent(QMouseEvent *event) {
-  lastX = event->x();
-  lastY = event->y();
+  lastMouseX = event->x();
+  lastMouseY = event->y();
   dragging = true;
 }
 
@@ -116,12 +116,13 @@ void MapView::mouseMoveEvent(QMouseEvent *event) {
     getToolTip(mx, mz);
     return;
   }
-  x += (lastX-event->x()) / zoom;
-  z += (lastY-event->y()) / zoom;
-  lastX = event->x();
-  lastY = event->y();
+  x += (lastMouseX-event->x()) / zoom;
+  z += (lastMouseY-event->y()) / zoom;
+  lastMouseX = event->x();
+  lastMouseY = event->y();
   redraw();
 }
+
 void MapView::mouseReleaseEvent(QMouseEvent * /* event */) {
   dragging = false;
 }
@@ -163,6 +164,7 @@ void MapView::wheelEvent(QWheelEvent *event) {
     redraw();
   }
 }
+
 void MapView::keyPressEvent(QKeyEvent *event) {
   switch (event->key()) {
     case Qt::Key_Up:
@@ -214,6 +216,7 @@ void MapView::resizeEvent(QResizeEvent *event) {
   image = QImage(event->size(), QImage::Format_RGB32);
   redraw();
 }
+
 void MapView::paintEvent(QPaintEvent * /* event */) {
   QPainter p(this);
   p.drawImage(QPoint(0, 0), image);
@@ -303,6 +306,7 @@ void MapView::redraw() {
 
   update();
 }
+
 void MapView::drawChunk(int x, int z) {
   if (!this->isEnabled())
     return;
@@ -424,26 +428,22 @@ void MapView::renderChunk(Chunk *chunk) {
 //        if (light > 15) light = 15;
 
         // get current block color
-        QColor col;
+        QColor blockcolor = block.colors[15];  // get the color from Block definition
         if (block.biomeWater()) {
-          col = biome.getBiomeWaterColor(block.colors[15]);
+          blockcolor = biome.getBiomeWaterColor(blockcolor);
         }
         else if (block.biomeGrass()) {
-          col = biome.getBiomeGrassColor(y-64);
+          blockcolor = biome.getBiomeGrassColor(blockcolor, y-64);
         }
         else if (block.biomeFoliage()) {
-          col = biome.getBiomeFoliageColor(y-64);
-        }
-        else {
-          // get the color from Block definition
-          col = block.colors[15];
+          blockcolor = biome.getBiomeFoliageColor(blockcolor, y-64);
         }
 
         // shade color based on light value
         double light_factor = pow(0.90,15-light);
-        quint32 colr = light_factor*col.red();
-        quint32 colg = light_factor*col.green();
-        quint32 colb = light_factor*col.blue();
+        quint32 colr = light_factor*blockcolor.red();
+        quint32 colg = light_factor*blockcolor.green();
+        quint32 colb = light_factor*blockcolor.blue();
 
         // process flags
         if (flags & flgDepthShading) {

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -417,13 +417,21 @@ void MapView::renderChunk(Chunk *chunk) {
           else if (lasty > y)
             light -= 2;
         }
-        if (light < 0) light = 0;
-        if (light > 15) light = 15;
+//        if (light < 0) light = 0;
+//        if (light > 15) light = 15;
 
-        // define the color
-        quint32 colr = block.colors[light].red();
-        quint32 colg = block.colors[light].green();
-        quint32 colb = block.colors[light].blue();
+        // get the color from Block definition
+        quint32 colr = block.colors[15].red();
+        quint32 colg = block.colors[15].green();
+        quint32 colb = block.colors[15].blue();
+
+        // shade color based on light value
+        double light_factor = pow(0.90,15-light);
+        colr = light_factor*colr;
+        colg = light_factor*colg;
+        colb = light_factor*colb;
+
+        // process flags
         if (flags & flgDepthShading) {
           // Use a table to define depth-relative shade:
           static const quint32 shadeTable[] = {
@@ -502,7 +510,7 @@ void MapView::renderChunk(Chunk *chunk) {
           r = (quint8)(alpha * r + (1.0 - alpha) * colr);
           g = (quint8)(alpha * g + (1.0 - alpha) * colg);
           b = (quint8)(alpha * b + (1.0 - alpha) * colb);
-          alpha+=block.alpha * (1.0 - alpha);
+          alpha += block.alpha * (1.0 - alpha);
         }
 
         // finish depth (Y) scanning when color is saturated enough

--- a/minutor.pro
+++ b/minutor.pro
@@ -40,7 +40,8 @@ HEADERS += \
     settings.h \
     village.h \
     worldsave.h \
-    zipreader.h
+    zipreader.h \
+    clamp.h
 SOURCES += \
 	  labelledslider.cpp \
     biomeidentifier.cpp \


### PR DESCRIPTION
Vanilla Minecraft uses different color for plants based on the Biome they grow in. Therefore color of Grass and Leaves change dramatically from Biome to Biome. The code changes introduced here add the same behavior for Minutor. All features are controllable via the definition files.
The feature itself was inspired by [erich666 project Mineways](https://github.com/erich666/Mineways). But development here was completely redone and cross-checked based on 1.10 vanilla source code (mcp931).

To get a visual impression, what changed, here the old style:
![minutor_start](https://cloud.githubusercontent.com/assets/5821779/21564673/624f5692-ce90-11e6-91ba-cc4e47a6df31.png)

and the new Biome based one:
![minutor_final](https://cloud.githubusercontent.com/assets/5821779/21564670/5f92aac6-ce90-11e6-825a-bb91f7add335.png)

This will close issue #46 