### PR TITLE
fix definition update for multi-packet-transfers

### DIFF
--- a/definitionmanager.cpp
+++ b/definitionmanager.cpp
@@ -22,6 +22,7 @@
 
 DefinitionManager::DefinitionManager(QWidget *parent) :
     QWidget(parent),
+    isUpdating(false),
     entityManager(EntityIdentifier::Instance()) {
   setWindowFlags(Qt::Window);
   setWindowTitle(tr("Definitions"));

--- a/definitionupdater.h
+++ b/definitionupdater.h
@@ -19,7 +19,7 @@ class DefinitionUpdater : public QObject {
   void updated(DefinitionUpdater *, QString filename, QString version);
  private slots:
   void checkReply();
-  void checkVersion();
+  void checkReadyRead();
   void finishUpdate();
  private:
   QString parseVersion(const QByteArray & data);

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -8,6 +8,7 @@
 #include "./definitionmanager.h"
 #include "./blockidentifier.h"
 #include "./biomeidentifier.h"
+#include "./clamp.h"
 
 MapView::MapView(QWidget *parent) : QWidget(parent) {
   depth = 255;
@@ -441,9 +442,9 @@ void MapView::renderChunk(Chunk *chunk) {
 
         // shade color based on light value
         double light_factor = pow(0.90,15-light);
-        quint32 colr = light_factor*blockcolor.red();
-        quint32 colg = light_factor*blockcolor.green();
-        quint32 colb = light_factor*blockcolor.blue();
+        quint32 colr = std::clamp( int(light_factor*blockcolor.red()),   0, 255 );
+        quint32 colg = std::clamp( int(light_factor*blockcolor.green()), 0, 255 );
+        quint32 colb = std::clamp( int(light_factor*blockcolor.blue()),  0, 255 );
 
         // process flags
         if (flags & flgDepthShading) {


### PR DESCRIPTION
When debugging the automatic update, all data is present at once. In real-life larger definition files may arrive in smaller parts.
Now also the later arriving parts are handled correctly.