### PR TITLE
add UI dialog to define a bounding box for PNG export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Makefile.Release
 
 *.pdb
 *.user
+*.pro.user.*

--- a/main.cpp
+++ b/main.cpp
@@ -15,7 +15,7 @@ int main(int argc, char *argv[]) {
   app.installTranslator(&translator);
 
   app.setApplicationName("Minutor");
-  app.setApplicationVersion("2.1.2");
+  app.setApplicationVersion("2.1.3");
   app.setOrganizationName("seancode");
 
   Minutor minutor;
@@ -23,6 +23,10 @@ int main(int argc, char *argv[]) {
   // Process the cmdline arguments:
   QStringList args = app.arguments();
   int numArgs = args.size();
+  int ex_top    = 0;
+  int ex_left   = 0;
+  int ex_bottom = 0;
+  int ex_right  = 0;
   bool regionChecker = false;
   bool chunkChecker = false;
   for (int i = 0; i < numArgs; i++) {
@@ -43,8 +47,17 @@ int main(int argc, char *argv[]) {
       chunkChecker = true;
       continue;
     }
+    if ((args[i] == "-r" || args[i] == "--exportrange") && i + 4 < numArgs) {
+      ex_top    = args[i + 1].toInt();
+      ex_left   = args[i + 2].toInt();
+      ex_bottom = args[i + 3].toInt();
+      ex_right  = args[i + 4].toInt();
+      i += 4;
+      continue;
+    }
     if ((args[i] == "-s" || args[i] == "--savepng") && i + 1 < numArgs) {
-      minutor.savePNG(args[i + 1], true, regionChecker, chunkChecker);
+      minutor.savePNG(args[i + 1], true, regionChecker, chunkChecker,
+                      ex_top, ex_left, ex_bottom, ex_right);
       i += 1;
       continue;
     }

--- a/main.cpp
+++ b/main.cpp
@@ -23,10 +23,10 @@ int main(int argc, char *argv[]) {
   // Process the cmdline arguments:
   QStringList args = app.arguments();
   int numArgs = args.size();
-  int ex_top    = 0;
-  int ex_left   = 0;
-  int ex_bottom = 0;
-  int ex_right  = 0;
+  int ex_Xmin = 0;
+  int ex_Xmax = 0;
+  int ex_Zmin = 0;
+  int ex_Zmax = 0;
   bool regionChecker = false;
   bool chunkChecker = false;
   for (int i = 0; i < numArgs; i++) {
@@ -48,16 +48,16 @@ int main(int argc, char *argv[]) {
       continue;
     }
     if ((args[i] == "-r" || args[i] == "--exportrange") && i + 4 < numArgs) {
-      ex_top    = args[i + 1].toInt();
-      ex_left   = args[i + 2].toInt();
-      ex_bottom = args[i + 3].toInt();
-      ex_right  = args[i + 4].toInt();
+      ex_Xmin = args[i + 1].toInt();
+      ex_Xmax = args[i + 2].toInt();
+      ex_Zmin = args[i + 3].toInt();
+      ex_Zmax = args[i + 4].toInt();
       i += 4;
       continue;
     }
     if ((args[i] == "-s" || args[i] == "--savepng") && i + 1 < numArgs) {
       minutor.savePNG(args[i + 1], true, regionChecker, chunkChecker,
-                      ex_top, ex_left, ex_bottom, ex_right);
+                      ex_Zmin, ex_Xmin, ex_Zmax, ex_Xmax);
       i += 1;
       continue;
     }

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -24,6 +24,7 @@
 #include "./generatedstructure.h"
 #include "./village.h"
 #include "./jumpto.h"
+#include "./pngexport.h"
 
 Minutor::Minutor(): maxentitydistance(0) {
   mapview = new MapView;
@@ -126,6 +127,15 @@ void Minutor::reload() {
 }
 
 void Minutor::save() {
+  int w_top, w_left, w_right, w_bottom;
+  WorldSave::findBounds(mapview->getWorldPath(),
+                        &w_top, &w_left, &w_bottom, &w_right);
+  PngExport pngoptions;
+  pngoptions.setBounds(w_top, w_left, w_bottom, w_right);
+  pngoptions.exec();
+  if (pngoptions.result() == QDialog::Rejected)
+    return;
+
   // get filname to save to
   QFileDialog fileDialog(this);
   fileDialog.setDefaultSuffix("png");
@@ -144,15 +154,20 @@ void Minutor::save() {
   }
 
   // save world to PNG image
-  savePNG(filename, false, false, false);
+  savePNG(filename, false,
+          pngoptions.getRegionChecker(), pngoptions.getChunkChecker(),
+          pngoptions.getTop(), pngoptions.getLeft(),
+          pngoptions.getBottom(), pngoptions.getRight());
 }
 
-void Minutor::savePNG(QString filename, bool autoclose, bool regionChecker,
-                      bool chunkChecker) {
+void Minutor::savePNG(QString filename, bool autoclose,
+                      bool regionChecker, bool chunkChecker,
+                      int w_top, int w_lef, int w_bottom, int w_right) {
   progressAutoclose = autoclose;
   if (!filename.isEmpty()) {
-    WorldSave *ws = new WorldSave(filename, mapview, regionChecker,
-                                  chunkChecker);
+    WorldSave *ws = new WorldSave(filename, mapview,
+                                  regionChecker, chunkChecker,
+                                  w_top, w_left, w_bottom, w_right);
     progress = new QProgressDialog();
     progress->setCancelButton(NULL);
     progress->setMaximum(100);

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -162,7 +162,7 @@ void Minutor::save() {
 
 void Minutor::savePNG(QString filename, bool autoclose,
                       bool regionChecker, bool chunkChecker,
-                      int w_top, int w_lef, int w_bottom, int w_right) {
+                      int w_top, int w_left, int w_bottom, int w_right) {
   progressAutoclose = autoclose;
   if (!filename.isEmpty()) {
     WorldSave *ws = new WorldSave(filename, mapview,

--- a/minutor.h
+++ b/minutor.h
@@ -38,7 +38,8 @@ class Minutor : public QMainWindow {
   void loadWorld(QDir path);
 
   void savePNG(QString filename, bool autoclose = false,
-               bool regionChecker = false, bool chunkChecker = false);
+               bool regionChecker = false, bool chunkChecker = false,
+               int w_top = 0, int w_left = 0, int w_bottom = 0, int w_right = 0);
 
   void jumpToXZ(int blockX, int blockZ);  // jumps to the block coords
   void setViewLighting(bool value);       // set View->Ligthing

--- a/minutor.pro
+++ b/minutor.pro
@@ -42,7 +42,8 @@ HEADERS += \
     worldsave.h \
     zipreader.h \
     clamp.h \
-    jumpto.h
+    jumpto.h \
+    pngexport.h
 SOURCES += \
 	  labelledslider.cpp \
     biomeidentifier.cpp \
@@ -66,7 +67,8 @@ SOURCES += \
     village.cpp \
     worldsave.cpp \
     zipreader.cpp \
-    jumpto.cpp
+    jumpto.cpp \
+    pngexport.cpp
 RESOURCES = minutor.qrc
 
 win32:SOURCES += zlib/adler32.c \
@@ -95,4 +97,5 @@ INSTALLS += desktopfile pixmapfile target
 FORMS += \
     properties.ui \
     settings.ui \
-    jumpto.ui
+    jumpto.ui \
+    pngexport.ui

--- a/pngexport.cpp
+++ b/pngexport.cpp
@@ -1,0 +1,88 @@
+#include "pngexport.h"
+#include "ui_pngexport.h"
+
+PngExport::PngExport(QWidget *parent) :
+  QDialog(parent),
+  ui(new Ui::PngExport)
+{
+  ui->setupUi(this);
+
+  // connect value change signals to check slots
+  connect(ui->spinBox_top,    SIGNAL(valueChanged(int)),
+          this,               SLOT(checkTop(int)));
+  connect(ui->spinBox_left,   SIGNAL(valueChanged(int)),
+          this,               SLOT(checkLeft(int)));
+  connect(ui->spinBox_bottom, SIGNAL(valueChanged(int)),
+          this,               SLOT(checkBottom(int)));
+  connect(ui->spinBox_right,  SIGNAL(valueChanged(int)),
+          this,               SLOT(checkRight(int)));
+
+}
+
+PngExport::~PngExport()
+{
+  delete ui;
+}
+
+void PngExport::setBounds(int top, int left, int bottom, int right)
+{
+  // convert from Chunks to Blocks
+  w_top    = 16*top;
+  w_left   = 16*left;
+  w_bottom = 16*bottom+15;
+  w_right  = 16*right+15;
+
+  // restrict range of spin boxes to world dimension
+  ui->spinBox_top   ->setRange(w_top, w_bottom-15);
+  ui->spinBox_left  ->setRange(w_left, w_right-15);
+  ui->spinBox_bottom->setRange(w_top+15, w_bottom);
+  ui->spinBox_right ->setRange(w_left+15, w_right);
+
+  // initialize spin boxes to complete world dimension
+  ui->spinBox_top   ->setValue(w_top);
+  ui->spinBox_left  ->setValue(w_left);
+  ui->spinBox_bottom->setValue(w_bottom);
+  ui->spinBox_right ->setValue(w_right);
+}
+
+
+void PngExport::checkTop(int value)
+{
+//  value = 16*round(float(value)/16);
+//  ui->spinBox_top->setValue(value);
+  if (value+15 > ui->spinBox_bottom->value())
+    ui->spinBox_bottom->setValue(value+15);
+}
+
+void PngExport::checkLeft(int value)
+{
+//  value = 16*round(float(value)/16);
+//  ui->spinBox_left->setValue(value);
+  if (value+15 > ui->spinBox_right->value())
+    ui->spinBox_right->setValue(value+15);
+}
+
+void PngExport::checkBottom(int value)
+{
+//  value = 16*round(float(value)/16);
+//  ui->spinBox_bottom->setValue(value);
+  if (value-15 < ui->spinBox_top->value())
+    ui->spinBox_top->setValue(value-15);
+}
+
+void PngExport::checkRight(int value)
+{
+//  value = 16*round(float(value)/16);
+//  ui->spinBox_right->setValue(value);
+  if (value-15 < ui->spinBox_left->value())
+    ui->spinBox_left->setValue(value-15);
+}
+
+
+int PngExport::getTop()    { return ui->spinBox_top->value(); }
+int PngExport::getLeft()   { return ui->spinBox_left->value(); }
+int PngExport::getBottom() { return ui->spinBox_bottom->value(); }
+int PngExport::getRight()  { return ui->spinBox_right->value(); }
+
+bool PngExport::getChunkChecker()  { return ui->checkBox_chunk->checkState(); }
+bool PngExport::getRegionChecker() { return ui->checkBox_region->checkState(); }

--- a/pngexport.h
+++ b/pngexport.h
@@ -1,0 +1,44 @@
+/** Copyright (c) 2017, EtlamGit */
+#ifndef PNGEXPORT_H
+#define PNGEXPORT_H
+
+#include <QDialog>
+
+namespace Ui {
+class PngExport;
+}
+
+class PngExport : public QDialog
+{
+  Q_OBJECT
+
+public:
+  explicit PngExport(QWidget *parent = 0);
+  ~PngExport();
+
+  void setBounds(int top, int left, int bottom, int right);
+
+  int getTop();
+  int getLeft();
+  int getBottom();
+  int getRight();
+
+  bool getChunkChecker();
+  bool getRegionChecker();
+
+private:
+  Ui::PngExport *ui;
+
+  int w_top;
+  int w_left;
+  int w_bottom;
+  int w_right;
+
+private slots:
+  void checkTop(int value);
+  void checkLeft(int value);
+  void checkBottom(int value);
+  void checkRight(int value);
+};
+
+#endif // PNGEXPORT_H

--- a/pngexport.ui
+++ b/pngexport.ui
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PngExport</class>
+ <widget class="QDialog" name="PngExport">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>240</width>
+    <height>237</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Export region</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Z top</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spinBox_top">
+          <property name="singleStep">
+           <number>16</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Z top</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>X left</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spinBox_left">
+          <property name="singleStep">
+           <number>16</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_5">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spinBox_right">
+          <property name="singleStep">
+           <number>16</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>X right</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Z bottom</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_6">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spinBox_bottom">
+          <property name="singleStep">
+           <number>16</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Z bottom</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Checkerboard pattern</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QCheckBox" name="checkBox_chunk">
+        <property name="text">
+         <string>Chunks</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBox_region">
+        <property name="text">
+         <string>Regions</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>PngExport</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>PngExport</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/pngexport.ui
+++ b/pngexport.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>PNG export options</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/settings.ui
+++ b/settings.ui
@@ -78,7 +78,7 @@
         <item>
          <widget class="QCheckBox" name="checkBox_AutoUpdate">
           <property name="text">
-           <string>Auto-check for updates</string>
+           <string>Auto-check for updates (every 7 days)</string>
           </property>
          </widget>
         </item>

--- a/worldsave.cpp
+++ b/worldsave.cpp
@@ -11,9 +11,17 @@
 #include "./mapview.h"
 #include "zlib/zlib.h"
 
-WorldSave::WorldSave(QString filename, MapView *map, bool regionChecker,
-                     bool chunkChecker) : filename(filename), map(map),
-  regionChecker(regionChecker), chunkChecker(chunkChecker) {
+WorldSave::WorldSave(QString filename, MapView *map,
+                     bool regionChecker, bool chunkChecker,
+                     int top, int left, int bottom, int right) :
+  filename(filename),
+  map(map),
+  top(top),
+  left(left),
+  bottom(bottom),
+  right(right),
+  regionChecker(regionChecker),
+  chunkChecker(chunkChecker) {
 }
 
 WorldSave::~WorldSave() {
@@ -46,10 +54,16 @@ void WorldSave::run() {
   emit progress(tr("Calculating world bounds"), 0.0);
   QString path = map->getWorldPath();
 
-  int top, left, right, bottom;
-  findBounds(path, &top, &left, &bottom, &right);
+  // convert from Blocks to Chunks
+  top    = top/16;
+  left   = left/16;
+  bottom = bottom/16;
+  right  = right/16;
 
-  int width = (right + 1 - left) * 16;
+  if ( top==0 && left==0 && right==0 && bottom==0)
+    findBounds(path, &top, &left, &bottom, &right);
+
+  int width  = (right + 1 - left) * 16;
   int height = (bottom + 1 - top) * 16;
 
   QFile png(filename);

--- a/worldsave.h
+++ b/worldsave.h
@@ -11,23 +11,33 @@ class Chunk;
 class WorldSave : public QObject, public QRunnable {
   Q_OBJECT
  public:
-  WorldSave(QString filename, MapView *map, bool regionChecker = false,
-            bool chunkChecker = false);
+  WorldSave(QString filename, MapView *map,
+            bool regionChecker = false, bool chunkChecker = false,
+            int w_top = 0, int w_left = 0, int w_bottom = 0, int w_right = 0);
   ~WorldSave();
+
  signals:
   void progress(QString status, double amount);
   void finished();
+
  protected:
   void run();
+
  private:
-  void findBounds(QString path, int *top, int *left, int *bottom, int *right);
   void blankChunk(uchar *scanlines, int stride, int x);
   void drawChunk(uchar *scanlines, int stride, int x, Chunk *chunk);
 
   QString filename;
   MapView *map;
+  int top;
+  int left;
+  int bottom;
+  int right;
   bool regionChecker;
   bool chunkChecker;
+
+ public: // static
+  static void findBounds(QString path, int *top, int *left, int *bottom, int *right);
 };
 
 #endif  // WORLDSAVE_H_


### PR DESCRIPTION
With these changes it is possible to define a region to be used for PNG export:
+ it can be set via command line
+ and also with a GUI dialog
+ also the checkerboard patterns are now configurable via this export GUI
Export region is given in Block coordinates, but export is still rounded to complete Chunks.