### PR TITLE
Settings: Fixed loading and defaults.

### DIFF
--- a/settings.h
+++ b/settings.h
@@ -15,6 +15,10 @@ class Settings : public QDialog {
   bool verticalDepth;
   QString mcpath;
 
+
+  /** Returns the default path to be used for Minecraft location. */
+  static QString getDefaultLocation();
+
  signals:
   void settingsUpdated();
   void locationChanged(const QString &loc);


### PR DESCRIPTION
The "use default location" was not applied when starting Minutor. This change produces more understandable flow of the settings initialization.

Fixes #93, at least on Windows.