### PR TITLE
implemented cave mode

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -89,6 +89,10 @@ int main(int argc, char *argv[]) {
       minutor.setViewBiomeColors(true);
       continue;
     }
+    if (args[i] == "-C" || args[i] == "--cavemode") {
+      minutor.setViewCavemode(true);
+      continue;
+    }
   }
 
   minutor.show();

--- a/mapview.h
+++ b/mapview.h
@@ -82,6 +82,9 @@ class MapView : public QWidget {
   int getY(int x, int z);
   QList<QSharedPointer<OverlayItem>> getItems(int x, int y, int z);
 
+  static const int CAVE_DEPTH = 16;  // maximum depth caves are searched in cave mode
+  float caveshade[CAVE_DEPTH];
+
   int depth;
   double x, z;
   int scale;

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -375,7 +375,6 @@ void Minutor::createActions() {
   caveModeAct->setStatusTip(tr("Toggle cave mode on/off"));
   connect(caveModeAct, SIGNAL(triggered()),
           this,        SLOT(toggleFlags()));
-  caveModeAct->setEnabled(false);
 
   jumpToAct = new QAction(tr("&Jump To"), this);
   jumpToAct->setShortcut(tr("Ctrl+G"));


### PR DESCRIPTION
The look of cave mode can be adapted with these parameters:
* CAVE_DEPTH: number of blocks searched downwards (also slows down Minutor if selected too large, we should consider to implement multi-threading for Block rendering)
* 1/exp(i/(CAVE_DEPTH/2.0)): change the 2.0 to get different shape of exponential curve (flat vs steep). It describes how dark a cave gets rendered depending on the distance to the current level. Deeper caves should get brighter and close to surface caves darker.
* 1.5 * caveshade[i]: use larger factor to get it darker for smaller caves
* std::max(cave_factor,0.25f): to limit the darkness