### PR TITLE
backwards compatible 1.13 translation layer

### DIFF
--- a/blockdata.h
+++ b/blockdata.h
@@ -1,0 +1,14 @@
+/** Copyright (c) 2018, nnooney, EtlamGit */
+#ifndef BLOCKDATA_H_
+#define BLOCKDATA_H_
+
+#include <QString>
+#include <QMap>
+
+class BlockData {
+ public:
+  QString name;
+  QMap<QString, QVariant> properties;
+};
+
+#endif  // BLOCKDATA_H_

--- a/blockidentifier.h
+++ b/blockidentifier.h
@@ -20,6 +20,7 @@ class BlockInfo {
   bool isOpaque();
   bool isLiquid();
   bool doesBlockHaveSolidTopSurface(int data);
+  bool doesBlockHaveSolidTopSurface();
   bool isBlockNormalCube();
   bool renderAsNormalBlock();
   bool canProvidePower();
@@ -41,7 +42,7 @@ class BlockInfo {
   void setBiomeFoliage(bool value);
   const QString &getName();
 
-  int id;
+//  int id;
   double alpha;
   quint8 mask;
   bool enabled;
@@ -72,13 +73,11 @@ class BlockIdentifier {
   int addDefinitions(JSONArray *, int pack = -1);
   void enableDefinitions(int id);
   void disableDefinitions(int id);
-  BlockInfo &getBlock(QString name, int data);
+  BlockInfo &getBlock(QString name);
  private:
-  void clearCache();
   void parseDefinition(JSONObject *block, BlockInfo *parent, int pack);
-  QMap<QString, QList<BlockInfo *>> blocks;
+  QMap<QString, BlockInfo*> blocks;
   QList<QList<BlockInfo*> > packs;
-  BlockInfo *cache[65536];
 };
 
 #endif  // BLOCKIDENTIFIER_H_

--- a/chunk.cpp
+++ b/chunk.cpp
@@ -1,7 +1,9 @@
 /** Copyright (c) 2013, Sean Kasun */
 
-#include "./chunk.h"
 #include <algorithm>
+
+#include "./chunk.h"
+#include "./flatteningconverter.h"
 
 quint16 getBits(const unsigned char *data, int pos, int n) {
   quint16 result = 0;
@@ -30,46 +32,39 @@ void Chunk::load(const NBT &nbt) {
     this->sections[i] = NULL;
   highest = 0;
 
-  auto level = nbt.at("Level");
+  int version = nbt.at("DataVersion")->toInt();
+  const Tag * level = nbt.at("Level");
   chunkX = level->at("xPos")->toInt();
   chunkZ = level->at("zPos")->toInt();
 
+  // load Biome per column
   auto biomes = level->at("Biomes");
-  memcpy(this->biomes, biomes->toIntArray(), 4*biomes->length());
+  if (version >= 1519) {
+    memcpy(this->biomes, biomes->toIntArray(), sizeof(int)*biomes->length());
+  } else {
+    // convert quint8 to quint32
+    auto rawBiomes = biomes->toByteArray();
+    for (int i=0; i<256; i++)
+      this->biomes[i] = rawBiomes[i];
+  }
+
+  // load available Sections
   auto sections = level->at("Sections");
   int numSections = sections->length();
-  for (int i = 0; i < numSections; i++) {
-    auto section = sections->at(i);
-    auto cs = new ChunkSection();
-    // decode Palette to be able to map BlockStates
-    auto rawPalette = section->at("Palette");
-    cs->paletteLength = rawPalette->length();
-    cs->palette = new BlockData[cs->paletteLength];
-    for (int j = 0; j < rawPalette->length(); j++) {
-      cs->palette[j].name = rawPalette->at(j)->at("Name")->toString();
-      if (rawPalette->at(j)->has("Properties"))
-        cs->palette[j].properties = rawPalette->at(j)->at("Properties")->getData().toMap();
-    }
-    // map BlockStates to BlockData
-    // todo: bit fidling looks very complicated -> find easier code
-    auto raw = section->at("BlockStates")->toLongArray();
-    int blockStatesLength = section->at("BlockStates")->length();
-    unsigned char *byteData = new unsigned char[8*blockStatesLength];
-    memcpy(byteData, raw, 8*blockStatesLength);
-    std::reverse(byteData, byteData+(8*blockStatesLength));
-    int bitSize = (blockStatesLength)*64/4096;
-    for (int i = 0; i < 4096; i++) {
-      cs->blocks[4095-i] = getBits(byteData, i*bitSize, bitSize);
-    }
-    delete byteData;
-    // copy Light data (todo: Skylight is not needed)
-    memcpy(cs->skyLight, section->at("SkyLight")->toByteArray(), 2048);
-    memcpy(cs->blockLight, section->at("BlockLight")->toByteArray(), 2048);
+  // loop over all stored Sections, they are not guarantied to be ordered or consecutive
+  for (int s = 0; s < numSections; s++) {
+    ChunkSection *cs = new ChunkSection();
+    const Tag * section = sections->at(s);
+    if (version >= 1519)
+      loadSection1519(cs, section);
+    else
+      loadSection1000(cs, section);
+
     int idx = section->at("Y")->toInt();
     this->sections[idx] = cs;
   }
-  loaded = true;
 
+  loaded = true;
 
   auto entitylist = level->at("Entities");
   int numEntities = entitylist->length();
@@ -93,11 +88,71 @@ void Chunk::load(const NBT &nbt) {
   }
 }
 
+void Chunk::loadSection1000(ChunkSection *cs, const Tag *section) {
+  quint8 blocks[4096];
+  quint8 data[2048];
+  memcpy(blocks, section->at("Blocks")->toByteArray(), 4096);
+  memcpy(data,   section->at("Data")->toByteArray(),   2048);
+  memcpy(cs->blockLight, section->at("BlockLight")->toByteArray(), 2048);
+  // convert old BlockID + data into virtual ID
+  for (int i = 0; i < 4096; i++) {
+    int d = data[i>>1];
+    if (i & 1) d >>= 4;
+    int bid = blocks[i];
+    cs->blocks[i] = blocks[i] | ((d & 0x0f) << 8);
+  }
+// todo: identify this even more ancient stuff ???
+//  if (section->has("Add")) {
+//    raw = section->at("Add")->toByteArray();
+//    for (int i = 0; i < 2048; i++) {
+//      cs->blocks[i * 2] |= (raw[i] & 0xf) << 8;
+//      cs->blocks[i * 2 + 1] |= (raw[i] & 0xf0) << 4;
+//    }
+//  }
+
+  // link to Converter palette
+  cs->paletteLength = 0;
+  cs->palette = FlatteningConverter::Instance().getPalette();
+}
+
+// Cunk format afer "The Flattening" version 1509
+void Chunk::loadSection1519(ChunkSection *cs, const Tag *section) {
+  // decode Palette to be able to map BlockStates
+  auto rawPalette = section->at("Palette");
+  cs->paletteLength = rawPalette->length();
+  cs->palette = new BlockData[cs->paletteLength];
+  for (int j = 0; j < rawPalette->length(); j++) {
+    cs->palette[j].name = rawPalette->at(j)->at("Name")->toString();
+    if (rawPalette->at(j)->has("Properties"))
+      cs->palette[j].properties = rawPalette->at(j)->at("Properties")->getData().toMap();
+  }
+  // map BlockStates to BlockData
+  // todo: bit fidling looks very complicated -> find easier code
+  auto raw = section->at("BlockStates")->toLongArray();
+  int blockStatesLength = section->at("BlockStates")->length();
+  unsigned char *byteData = new unsigned char[8*blockStatesLength];
+  memcpy(byteData, raw, 8*blockStatesLength);
+  std::reverse(byteData, byteData+(8*blockStatesLength));
+  int bitSize = (blockStatesLength)*64/4096;
+  for (int i = 0; i < 4096; i++) {
+    cs->blocks[4095-i] = getBits(byteData, i*bitSize, bitSize);
+  }
+  delete byteData;
+  // copy Light data (todo: Skylight is not needed)
+  memcpy(cs->skyLight, section->at("SkyLight")->toByteArray(), 2048);
+  memcpy(cs->blockLight, section->at("BlockLight")->toByteArray(), 2048);
+}
+
 Chunk::~Chunk() {
   if (loaded) {
     for (int i = 0; i < 16; i++)
       if (sections[i]) {
-        delete[] sections[i]->palette;
+        if (sections[i]->paletteLength > 0) {
+          delete[] sections[i]->palette;
+          sections[i]->paletteLength = 0;
+        } else {
+          sections[i]->palette = NULL;
+        }
         delete sections[i];
         sections[i] = NULL;
       }

--- a/chunk.h
+++ b/chunk.h
@@ -34,6 +34,10 @@ class Chunk {
   void load(const NBT &nbt);
   ~Chunk();
  protected:
+  void loadSection1000(ChunkSection *cs, const Tag *section);
+  void loadSection1519(ChunkSection *cs, const Tag *section);
+
+
   typedef QMap<QString, QSharedPointer<OverlayItem>> EntityMap;
 
   quint32 biomes[256];

--- a/chunk.h
+++ b/chunk.h
@@ -7,13 +7,10 @@
 
 #include "./nbt.h"
 #include "./entity.h"
+#include "./blockdata.h"
+
 class BlockIdentifier;
 
-class BlockData {
- public:
-  QString name;
-  QMap<QString, QVariant> properties;
-};
 
 class ChunkSection {
  public:
@@ -26,9 +23,9 @@ class ChunkSection {
 
   BlockData *palette;
   int paletteLength;
-  quint16 blocks[4096];
-  quint8  skyLight[2048];
-  quint8  blockLight[2048];
+  quint16 blocks[16*16*16];
+  quint8  skyLight[16*16*16/2];
+  quint8  blockLight[16*16*16/2];
 };
 
 class Chunk {

--- a/definitionmanager.cpp
+++ b/definitionmanager.cpp
@@ -116,7 +116,7 @@ void DefinitionManager::refresh() {
   table->setRowCount(0);
   QStringList types;
   types << tr("block") << tr("biome") << tr("dimension")
-        << tr("entity") << tr("pack");
+        << tr("entity") << tr("pack") << tr("converter");
   for (int i = 0; i < sorted.length(); i++) {
     Definition &def = definitions[sorted[i].toString()];
     int row = table->rowCount();
@@ -371,6 +371,10 @@ void DefinitionManager::loadDefinition(QString path) {
     QString key = d.name + type;
     d.enabled = true;  // should look this up
     if (type == "block") {
+//      d.id = convertManager->addDefinitions(
+//          dynamic_cast<JSONArray*>(def->at("data")));
+      d.type = Definition::Converter;
+    } else if (type == "flatblock") {
       d.id = blockManager->addDefinitions(
           dynamic_cast<JSONArray*>(def->at("data")));
       d.type = Definition::Block;
@@ -421,18 +425,22 @@ void DefinitionManager::loadDefinition(QString path) {
         continue;
       }
       QString type = def->at("type")->asString();
-      if (type == "block")
-        d.blockid = blockManager->addDefinitions(
-            dynamic_cast<JSONArray*>(def->at("data")), d.blockid);
-      else if (type == "biome")
+      if (type == "block") {
+//        d.blockid = blockManager->addDefinitions(
+//            dynamic_cast<JSONArray*>(def->at("data")), d.blockid);
+      } else if (type == "flatblock") {
+          d.blockid = blockManager->addDefinitions(
+              dynamic_cast<JSONArray*>(def->at("data")), d.blockid);
+      } else if (type == "biome") {
         d.biomeid = biomeManager->addDefinitions(
             dynamic_cast<JSONArray*>(def->at("data")), d.biomeid);
-      else if (type == "dimension")
+      } else if (type == "dimension") {
         d.dimensionid = dimensionManager->addDefinitions(
             dynamic_cast<JSONArray*>(def->at("data")), d.dimensionid);
-      else if (type == "entity")
+      } else if (type == "entity") {
         d.entityid = entityManager.addDefinitions(
             dynamic_cast<JSONArray*>(def->at("data")), d.entityid);
+      }
       delete def;
     }
     definitions.insert(path, d);

--- a/definitionmanager.cpp
+++ b/definitionmanager.cpp
@@ -15,6 +15,7 @@
 #include "./blockidentifier.h"
 #include "./dimensionidentifier.h"
 #include "./entityidentifier.h"
+#include "./flatteningconverter.h"
 #include "./mapview.h"
 #include "./json.h"
 #include "./zipreader.h"
@@ -23,7 +24,8 @@
 DefinitionManager::DefinitionManager(QWidget *parent) :
     QWidget(parent),
     isUpdating(false),
-    entityManager(EntityIdentifier::Instance()) {
+    entityManager(EntityIdentifier::Instance()),
+    flatteningConverter(FlatteningConverter::Instance()) {
   setWindowFlags(Qt::Window);
   setWindowTitle(tr("Definitions"));
 
@@ -371,8 +373,8 @@ void DefinitionManager::loadDefinition(QString path) {
     QString key = d.name + type;
     d.enabled = true;  // should look this up
     if (type == "block") {
-//      d.id = convertManager->addDefinitions(
-//          dynamic_cast<JSONArray*>(def->at("data")));
+      d.id = flatteningConverter.addDefinitions(
+          dynamic_cast<JSONArray*>(def->at("data")));
       d.type = Definition::Converter;
     } else if (type == "flatblock") {
       d.id = blockManager->addDefinitions(
@@ -426,7 +428,7 @@ void DefinitionManager::loadDefinition(QString path) {
       }
       QString type = def->at("type")->asString();
       if (type == "block") {
-//        d.blockid = blockManager->addDefinitions(
+//        d.blockid = flatteningConverter->addDefinitions(
 //            dynamic_cast<JSONArray*>(def->at("data")), d.blockid);
       } else if (type == "flatblock") {
           d.blockid = blockManager->addDefinitions(

--- a/definitionmanager.h
+++ b/definitionmanager.h
@@ -16,6 +16,7 @@ class BiomeIdentifier;
 class BlockIdentifier;
 class DimensionIdentifier;
 class EntityIdentifier;
+class FlatteningConverter;
 class MapView;
 class JSONData;
 class DefinitionUpdater;
@@ -77,6 +78,7 @@ class DefinitionManager : public QWidget {
   BlockIdentifier *blockManager;  // todo: migrate to reference to singleton
   DimensionIdentifier *dimensionManager;  // todo: migrate to reference to singleton
   EntityIdentifier &entityManager;
+  FlatteningConverter &flatteningConverter;
   QString selected;
   QList<QVariant> sorted;
 

--- a/definitionmanager.h
+++ b/definitionmanager.h
@@ -25,7 +25,7 @@ struct Definition {
   QString version;
   QString path;
   QString update;
-  enum {Block, Biome, Dimension, Entity, Pack} type;
+  enum {Block, Biome, Dimension, Entity, Pack, Converter} type;
   int id;
   bool enabled;
   // for packs only

--- a/definitions/readme_biomes.txt
+++ b/definitions/readme_biomes.txt
@@ -24,14 +24,14 @@ Inside the "data" tag available biomes are defined:
   ]
 
 "id"    - the SaveGameID used by Minecraft
-"color" - color used in Biome Overly (e.g. AMIDST color code)
+"color" - color used in Biome Overlay (e.g. AMIDST color code)
  if color is omitted a pseudo random color is calculated based on the hashed name
 
 some special values can be derived from the Minecraft source code:
 
-"watercolor"  - special color of water (in swamps)
-"temperature" - default 0.5
-"humidity"    - default 0.5
+"watermodifier" - special color of water (in swamps)
+"temperature"   - default 0.5
+"humidity"      - default 0.5
 
 
 

--- a/definitions/vanilla_biomes.json
+++ b/definitions/vanilla_biomes.json
@@ -1,7 +1,7 @@
 {
   "name": "Vanilla",
   "type": "biome",
-  "version": "1.11.2",
+  "version": "1.13.18w26",
   "data": [
     {
       "id": 0,
@@ -128,7 +128,7 @@
     },
     {
       "id": 18,
-      "name": "Woodwd Hills",
+      "name": "Wooded Hills",
       "color": "#22551c",
       "temperature": 0.7,
       "humidity": 0.8

--- a/definitions/vanilla_blocks.json
+++ b/definitions/vanilla_blocks.json
@@ -1,0 +1,2486 @@
+{
+  "name": "Vanilla",
+  "type": "flatblock",
+  "version": "1.13",
+  "data": [
+    {
+      "name": "minecraft:air",
+      "color": "#ffffff",
+      "alpha": 0,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:cave_air",
+      "color": "#ffffff",
+      "alpha": 0,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:void_air",
+      "color": "#ffffff",
+      "alpha": 0,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:stone",
+      "color": "#747474"
+    },
+    {
+      "name": "minecraft:granite",
+      "color": "#977061"
+    },
+    {
+      "name": "minecraft:polished_granite",
+      "color": "#9d7160"
+    },
+    {
+      "name": "minecraft:diorite",
+      "color": "#b2b2b5"
+    },
+    {
+      "name": "minecraft:polished_diorite",
+      "color": "#b9b9bc"
+    },
+    {
+      "name": "minecraft:andesite",
+      "color": "#818181"
+    },
+    {
+      "name": "minecraft:polished_andesite",
+      "color": "#838385"
+    },
+    {
+      "name": "minecraft:grass",
+      "color": "#939393",
+      "biomeGrass": true
+    },
+    {
+      "name": "minecraft:grass_block",
+      "color": "#939393",
+      "biomeGrass": true
+    },
+    {
+      "name": "minecraft:dirt",
+      "color": "#835d40"
+    },
+    {
+      "name": "minecraft:coarse_dirt",
+      "color": "#76543a"
+    },
+    {
+      "name": "minecraft:podzol",
+      "color": "#573c1a"
+    },
+    {
+      "name": "minecraft:cobblestone",
+      "color": "#8f8f8f"
+    },
+    {
+      "name": "minecraft:oak_planks",
+      "color": "#b4905a"
+    },
+    {
+      "name": "minecraft:spruce_planks",
+      "color": "#805e36"
+    },
+    {
+      "name": "minecraft:birch_planks",
+      "color": "#c8b77a"
+    },
+    {
+      "name": "minecraft:jungle_planks",
+      "color": "#b1805c"
+    },
+    {
+      "name": "minecraft:acacia_planks",
+      "color": "#ba6337"
+    },
+    {
+      "name": "minecraft:dark_oak_planks",
+      "color": "#462d15"
+    },
+    {
+      "name": "minecraft:oak_sapling",
+      "color": "#1f6519",
+      "alpha": 0.3,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:spruce_sapling",
+      "color": "#395a39",
+      "alpha": 0.3,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:birch_sapling",
+      "color": "#51742d",
+      "alpha": 0.3,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:jungle_sapling",
+      "color": "#2c6c18",
+      "alpha": 0.3,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:acacia_sapling",
+      "color": "#677e17",
+      "alpha": 0.3,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:dark_oak_sapling",
+      "color": "#105210",
+      "alpha": 0.3,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:bedrock",
+      "color": "#333333"
+    },
+    {
+      "name": "minecraft:flowing_water",
+      "color": "#1f55ff",
+      "alpha": 0.53,
+      "transparent": true,
+      "liquid": true
+    },
+    {
+      "name": "minecraft:water",
+      "color": "#1f55ff",
+      "alpha": 0.53,
+      "transparent": true,
+      "liquid": true
+    },
+    {
+      "name": "minecraft:bubble_column",
+      "color": "#6b8fff",
+      "alpha": 0.53,
+      "transparent": true,
+      "liquid": true
+    },
+    {
+      "name": "minecraft:flowing_lava",
+      "color": "#fc5700",
+      "transparent": true,
+      "liquid": true
+    },
+    {
+      "name": "minecraft:lava",
+      "color": "#fc5700",
+      "transparent": true,
+      "liquid": true
+    },
+    {
+      "name": "minecraft:sand",
+      "color": "#d6cf97"
+    },
+    {
+      "name": "minecraft:red_sand",
+      "color": "#a6551e"
+    },
+    {
+      "name": "minecraft:gravel",
+      "color": "#817f7f"
+    },
+    {
+      "name": "minecraft:gold_ore",
+      "color": "#fcee4b"
+    },
+    {
+      "name": "minecraft:iron_ore",
+      "color": "#af8e77"
+    },
+    {
+      "name": "minecraft:coal_ore",
+      "color": "#454545"
+    },
+    {
+      "name": "minecraft:oak_log",
+      "color": "#665130",
+      "mask": 3
+    },
+    {
+      "name": "minecraft:spruce_log",
+      "color": "#2e1d0a"
+    },
+    {
+      "name": "minecraft:birch_log",
+      "color": "#d6dad6"
+    },
+    {
+      "name": "minecraft:jungle_log",
+      "color": "#584219"
+    },
+    {
+      "name": "minecraft:acacia_log",
+      "color": "#b25b3b",
+      "mask": 1
+    },
+    {
+      "name": "minecraft:dark_oak_log",
+      "color": "#5d4931"
+    },
+    {
+      "name": "minecraft:oak_wood",
+      "color": "#665130",
+      "mask": 3
+    },
+    {
+      "name": "minecraft:spruce_wood",
+      "color": "#2e1d0a"
+    },
+    {
+      "name": "minecraft:birch_wood",
+      "color": "#d6dad6"
+    },
+    {
+      "name": "minecraft:jungle_wood",
+      "color": "#584219"
+    },
+    {
+      "name": "minecraft:acacia_wood",
+      "color": "#b25b3b",
+      "mask": 1
+    },
+    {
+      "name": "minecraft:dark_oak_wood",
+      "color": "#5d4931"
+    },
+    {
+      "name": "minecraft:stripped_oak_wood",
+      "color": "#665130",
+      "mask": 3
+    },
+    {
+      "name": "minecraft:stripped_spruce_wood",
+      "color": "#2e1d0a"
+    },
+    {
+      "name": "minecraft:stripped_birch_wood",
+      "color": "#d6dad6"
+    },
+    {
+      "name": "minecraft:stripped_jungle_wood",
+      "color": "#584219"
+    },
+    {
+      "name": "minecraft:stripped_acacia_wood",
+      "color": "#b25b3b",
+      "mask": 1
+    },
+    {
+      "name": "minecraft:stripped_dark_oak_wood",
+      "color": "#5d4931"
+    },
+    {
+      "name": "minecraft:oak_leaves",
+      "color": "#515151",
+      "transparent": true,
+      "rendercube": true,
+      "biomeFoliage": true,
+      "mask": 3
+    },
+    {
+      "name": "minecraft:spruce_leaves",
+      "color": "#619961",
+      "biomeFoliage": false
+    },
+    {
+      "name": "minecraft:birch_leaves",
+      "color": "#80a755",
+      "biomeFoliage": false
+    },
+    {
+      "name": "minecraft:jungle_leaves",
+      "color": "#727069",
+      "biomeFoliage": true,
+    },
+    {
+      "name": "minecraft:acacia_leaves",
+      "color": "#515151",
+      "transparent": true,
+      "rendercube": true,
+      "biomeFoliage": true,
+      "mask": 1
+    },
+    {
+      "name": "minecraft:dark_oak_leaves",
+      "color": "#515151",
+      "biomeFoliage": true
+    },
+    {
+      "name": "minecraft:sponge",
+      "color": "#c3c455"
+    },
+    {
+      "name": "minecraft:wet_sponge",
+      "color": "#a09f3f"
+    },
+    {
+      "name": "minecraft:glass",
+      "color": "#c0f5fe",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:lapis_ore",
+      "color": "#1b43ad"
+    },
+    {
+      "name": "minecraft:lapis_block",
+      "color": "#0f26b8"
+    },
+    {
+      "name": "minecraft:dispenser",
+      "color": "#848484"
+    },
+    {
+      "name": "minecraft:sandstone",
+      "color": "#dfd7a5"
+    },
+    {
+      "name": "minecraft:chiseled_sandstone",
+      "color": "#ddd8ab"
+    },
+    {
+      "name": "minecraft:cut_sandstone",
+      "color": "#d9d29a"
+    },
+    {
+      "name": "minecraft:smooth_sandstone",
+      "color": "#d9d29a"
+    },
+    {
+      "name": "minecraft:note_block",
+      "color": "#915840"
+    },
+    {
+      "name": "minecraft:bed",
+      "color": "#8c1616",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:powered_rail",
+      "color": "#ab0301",
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:detector_rail",
+      "color": "#7d7171",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:sticky_piston",
+      "color": "#7bc070",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:cobweb",
+      "color": "#ededed",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:tall_seagrass",
+      "color": "#006428",
+      "biomeGrass": true
+    },
+    {
+      "name": "minecraft:seagrass",
+      "color": "#006428",
+      "biomeGrass": true
+    },
+    {
+      "name": "minecraft:tall_grass",
+      "color": "#946428",
+      "alpha": 0.3,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:tallgrass",
+      "color": "#909090",
+      "biomeGrass": true
+    },
+    {
+      "name": "minecraft:kelp",
+      "color": "#003013"
+    },
+    {
+      "name": "minecraft:kelp_plant",
+      "color": "#003013"
+    },
+    {
+      "name": "minecraft:fern",
+      "color": "#828282",
+      "biomeGrass": true
+    },
+    {
+      "name": "minecraft:dead_bush",
+      "color": "#946428",
+      "transparent": true,
+      "spawninside": true,
+      "alpha": 0.3
+    },
+    {
+      "name": "minecraft:piston",
+      "color": "#9f844d",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:piston_head",
+      "color": "#b4905a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:white_wool",
+      "color": "#eaeaea"
+    },
+    {
+      "name": "minecraft:orange_wool",
+      "color": "#db7b3b"
+    },
+    {
+      "name": "minecraft:magenta_wool",
+      "color": "#af44b8"
+    },
+    {
+      "name": "minecraft:light_blue_wool",
+      "color": "#7e99d0"
+    },
+    {
+      "name": "minecraft:yellow_wool",
+      "color": "#bcb02a"
+    },
+    {
+      "name": "minecraft:lime_wool",
+      "color": "#44b93b"
+    },
+    {
+      "name": "minecraft:pink_wool",
+      "color": "#d28a9e"
+    },
+    {
+      "name": "minecraft:gray_wool",
+      "color": "#454545"
+    },
+    {
+      "name": "minecraft:light_gray_wool",
+      "color": "#909898"
+    },
+    {
+      "name": "minecraft:cyan_wool",
+      "color": "#30728e"
+    },
+    {
+      "name": "minecraft:purple_wool",
+      "color": "#7737ad"
+    },
+    {
+      "name": "minecraft:blue_wool",
+      "color": "#2b3585"
+    },
+    {
+      "name": "minecraft:brown_wool",
+      "color": "#563822"
+    },
+    {
+      "name": "minecraft:green_wool",
+      "color": "#314119"
+    },
+    {
+      "name": "minecraft:red_wool",
+      "color": "#91312f"
+    },
+    {
+      "name": "minecraft:black_wool",
+      "color": "#1d1b1b"
+    },
+    {
+      "name": "minecraft:moving_piston",
+      "color": "#b4905a"
+    },
+    {
+      "name": "minecraft:dandelion",
+      "color": "#f1f902",
+      "transparent": true,
+      "spawninside": true,
+      "alpha": 0.3
+    },
+    {
+      "name": "minecraft:poppy",
+      "color": "#ba050b",
+      "transparent": true,
+      "spawninside": true,
+      "alpha": 0.3
+    },
+    {
+      "name": "minecraft:blue_orchid",
+      "color": "#29aefb"
+    },
+    {
+      "name": "minecraft:allium",
+      "color": "#b865fb"
+    },
+    {
+      "name": "minecraft:azure_bluet",
+      "color": "#e4eaf2"
+    },
+    {
+      "name": "minecraft:red_tulip",
+      "color": "#d33a17"
+    },
+    {
+      "name": "minecraft:orange_tulip",
+      "color": "#de731f"
+    },
+    {
+      "name": "minecraft:white_tulip",
+      "color": "#e7e7e7"
+    },
+    {
+      "name": "minecraft:pink_tulip",
+      "color": "#eabeea"
+    },
+    {
+      "name": "minecraft:oxeye_daisy",
+      "color": "#eae6ad"
+    },
+    {
+      "name": "minecraft:brown_mushroom",
+      "color": "#916d55",
+      "transparent": true,
+      "spawninside": true,
+      "alpha": 0.3
+    },
+    {
+      "name": "minecraft:red_mushroom",
+      "color": "#e21212",
+      "transparent": true,
+      "spawninside": true,
+      "alpha": 0.3
+    },
+    {
+      "name": "minecraft:gold_block",
+      "color": "#fdfb4f"
+    },
+    {
+      "name": "minecraft:iron_block",
+      "color": "#e6e6e6"
+    },
+    {
+      "name": "minecraft:double_stone_slab",
+      "color": "#a3a3a3"
+    },
+    {
+      "name": "minecraft:double_sandstone_slab",
+      "color": "#d7ce95"
+    },
+    {
+      "name": "minecraft:double_wooden_slab",
+      "color": "#b4905a"
+    },
+    {
+      "name": "minecraft:double_cobblestone_slab",
+      "color": "#8f8f8f"
+    },
+    {
+      "name": "minecraft:double_bricks_slab",
+      "color": "#7c4536"
+    },
+    {
+      "name": "minecraft:double_stone_brick_slab",
+      "color": "#797979"
+    },
+    {
+      "name": "minecraft:double_nether_brick_slab",
+      "color": "#30181c"
+    },
+    {
+      "name": "minecraft:double_quartz_slab",
+      "color": "#f0eee8"
+    },
+    {
+      "name": "minecraft:full_stone_slab",
+      "color": "#9c9c9c"
+    },
+    {
+      "name": "minecraft:full_sandstone_slab",
+      "color": "#d7cf9c"
+    },
+    {
+      "name": "minecraft:stone_slab",
+      "color": "#a3a3a3",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:sandstone_slab",
+      "color": "#d7ce95"
+    },
+    {
+      "name": "minecraft:wooden_slab",
+      "color": "#b4905a"
+    },
+    {
+      "name": "minecraft:cobblestone_slab",
+      "color": "#8f8f8f"
+    },
+    {
+      "name": "minecraft:brick_slab",
+      "color": "#7c4536"
+    },
+    {
+      "name": "minecraft:stone_brick_slab",
+      "color": "#797979"
+    },
+    {
+      "name": "minecraft:nether_brick_slab",
+      "color": "#30181c"
+    },
+    {
+      "name": "minecraft:quartz_slab",
+      "color": "#f0eee8"
+    },
+    {
+      "name": "minecraft:upper_stone_slab",
+      "color": "#a3a3a3"
+    },
+    {
+      "name": "minecraft:upper_sandstone_slab",
+      "color": "#d7ce95"
+    },
+    {
+      "name": "minecraft:upper_wooden_slab",
+      "color": "#b4905a"
+    },
+    {
+      "name": "minecraft:upper_cobblestone_slab",
+      "color": "#8f8f8f"
+    },
+    {
+      "name": "minecraft:upper_brick_slab",
+      "color": "#7c4536"
+    },
+    {
+      "name": "minecraft:upper_stone_brick_slab",
+      "color": "#797979"
+    },
+    {
+      "name": "minecraft:upper_nether_brick_slab",
+      "color": "#30181c"
+    },
+    {
+      "name": "minecraft:upper_quartz_slab",
+      "color": "#f0eee8"
+    },
+    {
+      "name": "minecraft:bricks",
+      "color": "#6a3b2e"
+    },
+    {
+      "name": "minecraft:tnt",
+      "color": "#a83414",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:bookshelf",
+      "color": "#9f844d"
+    },
+    {
+      "name": "minecraft:mossy_cobblestone",
+      "color": "#3a623a"
+    },
+    {
+      "name": "minecraft:obsidian",
+      "color": "#0e0e16"
+    },
+    {
+      "name": "minecraft:torch",
+      "color": "#ffd800",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:wall_torch",
+      "color": "#ffd800",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:fire",
+      "color": "#ff8f00",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:mob_spawner",
+      "color": "#1b2a35",
+      "transparent": true,
+      "rendercube": true
+    },
+    {
+      "name": "minecraft:oak_stairs",
+      "color": "#9f844d",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:chest",
+      "color": "#976b20",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:redstone_wire",
+      "color": "#d60000",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:diamond_ore",
+      "color": "#5decf5"
+    },
+    {
+      "name": "minecraft:diamond_block",
+      "color": "#91e8e4"
+    },
+    {
+      "name": "minecraft:crafting_table",
+      "color": "#a0693c"
+    },
+    {
+      "name": "minecraft:immature_wheat",
+      "color": "#8ba803",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:wheat",
+      "color": "#8e7c10"
+    },
+    {
+      "name": "minecraft:wet_farmland",
+      "color": "#43240b",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:farmland",
+      "color": "#633f24"
+    },
+    {
+      "name": "minecraft:furnace",
+      "color": "#535353"
+    },
+    {
+      "name": "minecraft:burning_furnace",
+      "color": "#535353"
+    },
+    {
+      "name": "minecraft:standing_sign",
+      "color": "#9f844d",
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:wooden_door",
+      "color": "#b0572a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:ladder",
+      "color": "#8e733c",
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:rail",
+      "color": "#a4a4a4",
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:cobblestone_stairs",
+      "color": "#565656",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:wall_sign",
+      "color": "#b4905a",
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:lever",
+      "color": "#735e39",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:stone_pressure_plate",
+      "color": "#8f8f8f",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:iron_door",
+      "color": "#b6b6b6",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:oak_pressure_plate",
+      "color": "#bc9862",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:redstone_ore",
+      "color": "#8f0303"
+    },
+    {
+      "name": "minecraft:redstone_ore_(glowing)",
+      "color": "#8f0303"
+    },
+    {
+      "name": "minecraft:unlit_redstone_torch",
+      "color": "#480000",
+      "transparent": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:redstone_torch",
+      "color": "#fd0000",
+      "transparent": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:stone_button",
+      "color": "#a8a8a8",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:snow",
+      "color": "#eeffff",
+      "spawninside": true,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:ice",
+      "color": "#77a9ff",
+      "alpha": 0.62,
+      "transparent": true,
+      "rendercube": true
+    },
+    {
+      "name": "minecraft:snow_block",
+      "color": "#eeffff"
+    },
+    {
+      "name": "minecraft:cactus",
+      "color": "#107e1d",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:clay",
+      "color": "#9da3ae"
+    },
+    {
+      "name": "minecraft:sugar_cane",
+      "color": "#97c06b",
+      "spawninside": true,
+      "transparent": true,
+      "biomeGrass": true
+    },
+    {
+      "name": "minecraft:jukebox",
+      "color": "#945f44"
+    },
+    {
+      "name": "minecraft:oak_fence",
+      "color": "#b4905a",
+      "alpha": 0.75,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:pumpkin",
+      "color": "#e3901d"
+    },
+    {
+      "name": "minecraft:carved_pumpkin",
+      "color": "#e3901d"
+    },
+    {
+      "name": "minecraft:netherrack",
+      "color": "#955744"
+    },
+    {
+      "name": "minecraft:soul_sand",
+      "color": "#554134"
+    },
+    {
+      "name": "minecraft:glowstone",
+      "color": "#f9d49c"
+    },
+    {
+      "name": "minecraft:nether_portal",
+      "color": "#d67fff",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:jack_o'lantern",
+      "color": "#e9b416"
+    },
+    {
+      "name": "minecraft:cake",
+      "color": "#eae9eb",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:powered_repeater",
+      "color": "#2a0002",
+      "transparent": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:redstone_repeater_(on)",
+      "color": "#fd0101",
+      "transparent": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:white_stained_glass",
+      "color": "#ffffff",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:orange_stained_glass",
+      "color": "#d87f33",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:magenta_stained_glass",
+      "color": "#b24cd8",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:light_blue_stained_glass",
+      "color": "#6699d8",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:yellow_stained_glass",
+      "color": "#e5e533",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:lime_stained_glass",
+      "color": "#7fcc19",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:pink_stained_glass",
+      "color": "#f27fa5",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:gray_stained_glass",
+      "color": "#4c4c4c",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:silver_stained_glass",
+      "color": "#999999",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:cyan_stained_glass",
+      "color": "#4c7f99",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:purple_stained_glass",
+      "color": "#7f3fb2",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:blue_stained_glass",
+      "color": "#334cb2",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:brown_stained_glass",
+      "color": "#664c33",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:green_stained_glass",
+      "color": "#667f33",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:red_stained_glass",
+      "color": "#993333",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:black_stained_glass",
+      "color": "#191919",
+      "transparent": true,
+      "alpha": 0.5
+    },
+    {
+      "name": "minecraft:oak_trapdoor",
+      "color": "#7c5a2a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:infested_stone",
+      "color": "#7a7a7a"
+    },
+    {
+      "name": "minecraft:infested_cobblestone",
+      "color": "#787878"
+    },
+    {
+      "name": "minecraft:infested_stone_bricks",
+      "color": "#777777"
+    },
+    {
+      "name": "minecraft:infested_mossy_stone_bricks",
+      "color": "#707467"
+    },
+    {
+      "name": "minecraft:infested_cracked_stone_bricks",
+      "color": "#747474"
+    },
+    {
+      "name": "minecraft:infested_chiseled_stone_bricks",
+      "color": "#747474"
+    },
+    {
+      "name": "minecraft:stone_bricks",
+      "color": "#797979"
+    },
+    {
+      "name": "minecraft:mossy_stone_bricks",
+      "color": "#637049"
+    },
+    {
+      "name": "minecraft:cracked_stone_bricks",
+      "color": "#656565"
+    },
+    {
+      "name": "minecraft:chiseled_stone_bricks",
+      "color": "#9c9c9c"
+    },
+    {
+      "name": "minecraft:brown_mushroom_block",
+      "color": "#8f6b53"
+    },
+    {
+      "name": "minecraft:red_mushroom_block",
+      "color": "#b51d1b"
+    },
+    {
+      "name": "minecraft:iron_bars",
+      "color": "#6d6e6e",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:glass_pane",
+      "color": "#c0f5fe",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:melon",
+      "color": "#adb82c"
+    },
+    {
+      "name": "minecraft:pumpkin_stem",
+      "color": "#6b6b0b",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:melon_stem",
+      "color": "#6b6b0b",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:vine",
+      "color": "#6f6f6f",
+      "transparent": true,
+      "spawninside": true,
+      "biomeFoliage": true
+    },
+    {
+      "name": "minecraft:oak_fence_gate",
+      "color": "#b4905a",
+      "alpha": 0.75,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:brick_stairs",
+      "color": "#7c4536",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:stone_brick_stairs",
+      "color": "#727272",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:mycelium",
+      "color": "#806b6f"
+    },
+    {
+      "name": "minecraft:lily_pad",
+      "color": "#88bf54",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:nether_bricks",
+      "color": "#30181c"
+    },
+    {
+      "name": "minecraft:nether_brick_fence",
+      "color": "#1c0e10",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:nether_brick_stairs",
+      "color": "#381a1f",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:immature_nether_wart",
+      "color": "#70081c",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:mature_nether_wart",
+      "color": "#8e181b"
+    },
+    {
+      "name": "minecraft:enchanting_table",
+      "color": "#3c3056",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:brewing_stand",
+      "color": "#bea84a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:cauldron",
+      "color": "#4d4d4d",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:end_portal",
+      "color": "#0c0b0a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:end_portal_frame",
+      "color": "#2f5754",
+      "mask": 4,
+      "transparent": true,
+      "rendercube": true
+    },
+    {
+      "name": "minecraft:end_portal_frame_(on)",
+      "color": "#406852"
+    },
+    {
+      "name": "minecraft:end_stone",
+      "color": "#d9dc9e"
+    },
+    {
+      "name": "minecraft:dragon_egg",
+      "color": "#2d0133"
+    },
+    {
+      "name": "minecraft:redstone_lamp",
+      "color": "#b0744c"
+    },
+    {
+      "name": "minecraft:redstone_lamp_(on)",
+      "color": "#f1d1af",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:double_oak_wood_slab",
+      "color": "#b4905a"
+    },
+    {
+      "name": "minecraft:double_spruce_wood_slab",
+      "color": "#664f2f"
+    },
+    {
+      "name": "minecraft:double_birch_wood_slab",
+      "color": "#d7cb8d"
+    },
+    {
+      "name": "minecraft:double_jungle_wood_slab",
+      "color": "#b1805c"
+    },
+    {
+      "name": "minecraft:double_acacia_wood_slab",
+      "color": "#ad5d32"
+    },
+    {
+      "name": "minecraft:double_dark_oak_wood_slab",
+      "color": "#462d15"
+    },
+    {
+      "name": "minecraft:oak_slab",
+      "color": "#b4905a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:spruce_slab",
+      "color": "#664f2f"
+    },
+    {
+      "name": "minecraft:birch_slab",
+      "color": "#d7cb8d"
+    },
+    {
+      "name": "minecraft:jungle_slab",
+      "color": "#b1805c"
+    },
+    {
+      "name": "minecraft:acacia_slab",
+      "color": "#ba6337"
+    },
+    {
+      "name": "minecraft:dark_oak_slab",
+      "color": "#462d15"
+    },
+    {
+      "name": "minecraft:upper_oak_wood_slab",
+      "color": "#b4905a"
+    },
+    {
+      "name": "minecraft:upper_spruce_wood_slab",
+      "color": "#664f2f"
+    },
+    {
+      "name": "minecraft:upper_birch_wood_slab",
+      "color": "#d7cb8d"
+    },
+    {
+      "name": "minecraft:upper_jungle_wood_slab",
+      "color": "#b1805c"
+    },
+    {
+      "name": "minecraft:upper_acacia_wood_slab",
+      "color": "#ba6337"
+    },
+    {
+      "name": "minecraft:upper_dark_oak_wood_slab",
+      "color": "#462d15"
+    },
+    {
+      "name": "minecraft:immature_cocoa_pod",
+      "color": "#929943",
+      "transparent": true,
+      "spawninside": true,
+      "mask": 12
+    },
+    {
+      "name": "minecraft:cocoa",
+      "color": "#d4924c"
+    },
+    {
+      "name": "minecraft:sandstone_stairs",
+      "color": "#e9e0b3",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:emerald_ore",
+      "color": "#17dd62"
+    },
+    {
+      "name": "minecraft:ender_chest",
+      "color": "#2d4042",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:tripwire_hook",
+      "color": "#6e6e6e",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:tripwire",
+      "color": "#ebebeb",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:emerald_block",
+      "color": "#64ea8a"
+    },
+    {
+      "name": "minecraft:spruce_stairs",
+      "color": "#664f2f",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:birch_stairs",
+      "color": "#d7cb8d",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:jungle_stairs",
+      "color": "#b1805c",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:command_block",
+      "color": "#b18972"
+    },
+    {
+      "name": "minecraft:beacon",
+      "color": "#c4fffe"
+    },
+    {
+      "name": "minecraft:cobblestone_wall",
+      "color": "#505050",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:flower_pot",
+      "color": "#7c4536",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:potted_poppy",
+      "color": "#910205"
+    },
+    {
+      "name": "minecraft:potted_dandelion",
+      "color": "#f1f902"
+    },
+    {
+      "name": "minecraft:potted_oak_sapling",
+      "color": "#408f2f"
+    },
+    {
+      "name": "minecraft:potted_spruce_sapling",
+      "color": "#395a39"
+    },
+    {
+      "name": "minecraft:potted_birch_sapling",
+      "color": "#cfe3ba"
+    },
+    {
+      "name": "minecraft:potted_jungle_sapling",
+      "color": "#2c6c18"
+    },
+    {
+      "name": "minecraft:potted_red_mushroom",
+      "color": "#9a171c"
+    },
+    {
+      "name": "minecraft:potted_brown_mushroom",
+      "color": "#725643"
+    },
+    {
+      "name": "minecraft:potted_cactus",
+      "color": "#128a20"
+    },
+    {
+      "name": "minecraft:potted_dead_bush",
+      "color": "#946428"
+    },
+    {
+      "name": "minecraft:potted_fern",
+      "color": "#315e05"
+    },
+    {
+      "name": "minecraft:potted_acacia_sapling",
+      "color": "#946428"
+    },
+    {
+      "name": "minecraft:potted_dark_oak_sapling",
+      "color": "#315e05"
+    },
+    {
+      "name": "minecraft:immature_carrots",
+      "color": "#00c617",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:carrots",
+      "color": "#004e00"
+    },
+    {
+      "name": "minecraft:immature_potatoes",
+      "color": "#00c617",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:potatoes",
+      "color": "#3aa649"
+    },
+    {
+      "name": "minecraft:oak_button",
+      "color": "#b4905a",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:skull",
+      "color": "#1a1a1a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:anvil",
+      "color": "#474747",
+      "transparent": true,
+      "mask": 12
+    },
+    {
+      "name": "minecraft:chipped_anvil",
+      "color": "#474747",
+      "transparent": true,
+      "mask": 12
+    },
+    {
+      "name": "minecraft:damaged_anvil",
+      "color": "#474747",
+      "transparent": true,
+      "mask": 12
+    },
+    {
+      "name": "minecraft:trapped_chest",
+      "color": "#ab792d",
+      "transparent": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:light_weighted_pressure_plate",
+      "color": "#fdfb4f",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:heavy_weighted_pressure_plate",
+      "color": "#e6e6e6",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:redstone_comparator_(off)",
+      "color": "#4f1010",
+      "transparent": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:powered_comparator",
+      "color": "#fd1010",
+      "transparent": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:daylight_detector",
+      "color": "#d2c1ab",
+      "transparent": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:redstone_block",
+      "color": "#bb1c0a",
+      "transparent": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:nether_quartz_ore",
+      "color": "#ddcbbe"
+    },
+    {
+      "name": "minecraft:hopper",
+      "color": "#444444",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:quartz_block",
+      "color": "#edebe5"
+    },
+    {
+      "name": "minecraft:chiseled_quartz_block",
+      "color": "#e3dfd5"
+    },
+    {
+      "name": "minecraft:quartz_pillar",
+      "color": "#e1dcd3"
+    },
+    {
+      "name": "minecraft:quartz_stairs",
+      "color": "#dfdacf",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:activator_rail",
+      "color": "#ab0301",
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:dropper",
+      "color": "#848484"
+    },
+    {
+      "name": "minecraft:white_terracotta",
+      "color": "#d1b1a1"
+    },
+    {
+      "name": "minecraft:orange_terracotta",
+      "color": "#a55728"
+    },
+    {
+      "name": "minecraft:magenta_terracotta",
+      "color": "#95586d"
+    },
+    {
+      "name": "minecraft:light_blue_terracotta",
+      "color": "#6f6b89"
+    },
+    {
+      "name": "minecraft:yellow_terracotta",
+      "color": "#b9821f"
+    },
+    {
+      "name": "minecraft:lime_terracotta",
+      "color": "#667330"
+    },
+    {
+      "name": "minecraft:pink_terracotta",
+      "color": "#a04b4e"
+    },
+    {
+      "name": "minecraft:gray_terracotta",
+      "color": "#3a2a24"
+    },
+    {
+      "name": "minecraft:light_gray_terracotta",
+      "color": "#876b62"
+    },
+    {
+      "name": "minecraft:cyan_terracotta",
+      "color": "#565a5b"
+    },
+    {
+      "name": "minecraft:purple_terracotta",
+      "color": "#734454"
+    },
+    {
+      "name": "minecraft:blue_terracotta",
+      "color": "#4a3b5b"
+    },
+    {
+      "name": "minecraft:brown_terracotta",
+      "color": "#4d3324"
+    },
+    {
+      "name": "minecraft:green_terracotta",
+      "color": "#4e562c"
+    },
+    {
+      "name": "minecraft:red_terracotta",
+      "color": "#8e3d2f"
+    },
+    {
+      "name": "minecraft:black_terracotta",
+      "color": "#271912"
+    },
+    {
+      "name": "minecraft:white_stained_glass_pane",
+      "color": "#ededed",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:orange_stained_glass_pane",
+      "color": "#c9762f",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:magenta_stained_glass_pane",
+      "color": "#aa49cf",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:light_blue_stained_glass_pane",
+      "color": "#5e8ec9",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:yellow_stained_glass_pane",
+      "color": "#e4e432",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:lime_stained_glass_pane",
+      "color": "#76bd17",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:pink_stained_glass_pane",
+      "color": "#e1769a",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:gray_stained_glass_pane",
+      "color": "#4c4c4c",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:silver_stained_glass_pane",
+      "color": "#929292",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:cyan_stained_glass_pane",
+      "color": "#4c7f98",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:purple_stained_glass_pane",
+      "color": "#7f3fb1",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:blue_stained_glass_pane",
+      "color": "#324cb1",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:brown_stained_glass_pane",
+      "color": "#654c32",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:green_stained_glass_pane",
+      "color": "#617a30",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:red_stained_glass_pane",
+      "color": "#923030",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:black_stained_glass_pane",
+      "color": "#191919",
+      "alpha": 0.5,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:acacia_stairs",
+      "color": "#a15730",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:dark_oak_stairs",
+      "color": "#492f17",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:slime_block",
+      "color": "#59994a"
+    },
+    {
+      "name": "minecraft:barrier",
+      "color": "#000000",
+      "alpha": 0
+    },
+    {
+      "name": "minecraft:iron_trapdoor",
+      "color": "#c7c7c7",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:prismarine",
+      "color": "#6baa97"
+    },
+    {
+      "name": "minecraft:prismarine_bricks",
+      "color": "#64a08f"
+    },
+    {
+      "name": "minecraft:dark_prismarine",
+      "color": "#3c584b"
+    },
+    {
+      "name": "minecraft:sea_lantern",
+      "color": "#abc8be"
+    },
+    {
+      "name": "minecraft:hay_block",
+      "color": "#af9711"
+    },
+    {
+      "name": "minecraft:white_carpet",
+      "color": "#dddddd",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:orange_carpet",
+      "color": "#dd8143",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:magenta_carpet",
+      "color": "#b650c0",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:light_blue_carpet",
+      "color": "#8ea6d6",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:yellow_carpet",
+      "color": "#c4b82e",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:lime_carpet",
+      "color": "#53c347",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:pink_carpet",
+      "color": "#cb778d",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:gray_carpet",
+      "color": "#3b3b3b",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:silver_carpet",
+      "color": "#aab0b0",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:cyan_carpet",
+      "color": "#2d6a83",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:purple_carpet",
+      "color": "#7537a9",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:blue_carpet",
+      "color": "#323e9a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:brown_carpet",
+      "color": "#482e1c",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:green_carpet",
+      "color": "#314119",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:red_carpet",
+      "color": "#963330",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:black_carpet",
+      "color": "#151111",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:terracotta",
+      "color": "#945a41"
+    },
+    {
+      "name": "minecraft:coal_block",
+      "color": "#2b2b2b"
+    },
+    {
+      "name": "minecraft:packed_ice",
+      "color": "#bfcee8"
+    },
+    {
+      "name": "minecraft:blue_ice",
+      "color": "#85b2ff"
+    },
+    {
+      "name": "minecraft:sunflower",
+      "color": "#f1e424",
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:lilac",
+      "color": "#9f78a4",
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:tall_grass",
+      "color": "#969696",
+      "biomeGrass": true,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:large_fern",
+      "color": "#828282",
+      "biomeGrass": true,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:rose_bush",
+      "color": "#ba050b",
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:peony",
+      "color": "#e6bff7",
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:large_flower_(top_part)",
+      "color": "#ffffff",
+      "alpha": 0
+    },
+    {
+      "name": "minecraft:large_flower_(top_part)",
+      "color": "#ffffff",
+      "alpha": 0
+    },
+    {
+      "name": "minecraft:standing_banner",
+      "color": "#ffffff",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:wall_banner",
+      "color": "#ffffff",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:inverted_daylight_sensor",
+      "color": "#d2c1ab",
+      "transparent": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:red_sandstone",
+      "color": "#a6551e"
+    },
+    {
+      "name": "minecraft:chiseled_red_sandstone",
+      "color": "#a2531c"
+    },
+    {
+      "name": "minecraft:smooth_red_sandstone",
+      "color": "#a8561e"
+    },
+    {
+      "name": "minecraft:red_sandstone_stairs",
+      "color": "#a6551e",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:double_red_sandstone_slab",
+      "color": "#a6551e"
+    },
+    {
+      "name": "minecraft:full_red_sandstone_slab",
+      "color": "#a7551e"
+    },
+    {
+      "name": "minecraft:red_sandstone_slab",
+      "color": "#a7551e",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:upper_red_sandstone_slab",
+      "color": "#a7551e"
+    },
+    {
+      "name": "minecraft:spruce_fence_gate",
+      "color": "#805e36",
+      "alpha": 0.75,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:birch_fence_gate",
+      "color": "#c8b77a",
+      "alpha": 0.75,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:jungle_fence_gate",
+      "color": "#b1805c",
+      "alpha": 0.75,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:dark_oak_fence_gate",
+      "color": "#462d15",
+      "alpha": 0.75,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:acacia_fence_gate",
+      "color": "#ba6337",
+      "alpha": 0.75,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:spruce_fence",
+      "color": "#805e36",
+      "alpha": 0.75,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:birch_fence",
+      "color": "#c8b77a",
+      "alpha": 0.75,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:jungle_fence",
+      "color": "#b1805c",
+      "alpha": 0.75,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:dark_oak_fence",
+      "color": "#462d15",
+      "alpha": 0.75,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:acacia_fence",
+      "color": "#ba6337",
+      "alpha": 0.75,
+      "transparent": true
+    },
+    {
+      "name": "minecraft:spruce_door",
+      "color": "#6e563b",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:birch_door",
+      "color": "#d2caa3",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:jungle_door",
+      "color": "#ac7da3",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:acacia_door",
+      "color": "#a5615b",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:dark_oak_door",
+      "color": "#4a3118",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:end_rod",
+      "color": "#dcc5ce"
+    },
+    {
+      "name": "minecraft:chorus_plant",
+      "color": "#603c60",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:chorus_flower",
+      "color": "#866886",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:chorus_flower_(fully_grown)",
+      "color": "#624060"
+    },
+    {
+      "name": "minecraft:purpur_block",
+      "color": "#a67aa6"
+    },
+    {
+      "name": "minecraft:purpur_pillar",
+      "color": "#ab80ab"
+    },
+    {
+      "name": "minecraft:purpur_stairs",
+      "color": "#a67aa6"
+    },
+    {
+      "name": "minecraft:purpur_double_slab",
+      "color": "#a67aa6"
+    },
+    {
+      "name": "minecraft:purpur_slab",
+      "color": "#a67aa6"
+    },
+    {
+      "name": "minecraft:end_stone_bricks",
+      "color": "#e2e7ab"
+    },
+    {
+      "name": "minecraft:immature_beetroot",
+      "color": "#02ab10",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:beetroots",
+      "color": "#517136"
+    },
+    {
+      "name": "minecraft:grass_path",
+      "color": "#967d47"
+    },
+    {
+      "name": "minecraft:end_gateway",
+      "color": "#000000"
+    },
+    {
+      "name": "minecraft:repeating_command_block",
+      "color": "#8170b0"
+    },
+    {
+      "name": "minecraft:chain_command_block",
+      "color": "#87a398"
+    },
+    {
+      "name": "minecraft:frosted_ice",
+      "color": "#77a9ff",
+      "alpha": 0.62,
+      "transparent": true,
+      "rendercube": true
+    },
+    {
+      "name": "minecraft:magma_block",
+      "color": "#87421a"
+    },
+    {
+      "name": "minecraft:nether_wart_block",
+      "color": "#750607"
+    },
+    {
+      "name": "minecraft:red_nether_bricks",
+      "color": "#440407"
+    },
+    {
+      "name": "minecraft:bone_block",
+      "color": "#cec9b2"
+    },
+    {
+      "name": "minecraft:structure_void",
+      "color": "#ffffff",
+      "alpha": 0,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:observer",
+      "color": "#535353"
+    },
+    {
+      "name": "minecraft:white_shulker_box",
+      "color": "#dedbdb"
+    },
+    {
+      "name": "minecraft:orange_shulker_box",
+      "color": "#ce7438"
+    },
+    {
+      "name": "minecraft:magenta_shulker_box",
+      "color": "#ba64c2"
+    },
+    {
+      "name": "minecraft:light_blue_shulker_box",
+      "color": "#658ecb"
+    },
+    {
+      "name": "minecraft:yellow_shulker_box",
+      "color": "#c1b73d"
+    },
+    {
+      "name": "minecraft:lime_shulker_box",
+      "color": "#47b73b"
+    },
+    {
+      "name": "minecraft:pink_shulker_box",
+      "color": "#d08ca1"
+    },
+    {
+      "name": "minecraft:gray_shulker_box",
+      "color": "#535151"
+    },
+    {
+      "name": "minecraft:light_gray_shulker_box",
+      "color": "#a4a2a2"
+    },
+    {
+      "name": "minecraft:cyan_shulker_box",
+      "color": "#4488a4"
+    },
+    {
+      "name": "minecraft:purple_shulker_box",
+      "color": "#976797"
+    },
+    {
+      "name": "minecraft:blue_shulker_box",
+      "color": "#6571c9"
+    },
+    {
+      "name": "minecraft:brown_shulker_box",
+      "color": "#8d705d"
+    },
+    {
+      "name": "minecraft:green_shulker_box",
+      "color": "#6f8254"
+    },
+    {
+      "name": "minecraft:red_shulker_box",
+      "color": "#c25855"
+    },
+    {
+      "name": "minecraft:black_shulker_box",
+      "color": "#383737"
+    },
+    {
+      "name": "minecraft:white_glazed_terracotta",
+      "color": "#ede8b2"
+    },
+    {
+      "name": "minecraft:orange_glazed_terracotta",
+      "color": "#be984e"
+    },
+    {
+      "name": "minecraft:magenta_glazed_terracotta",
+      "color": "#cd61bb"
+    },
+    {
+      "name": "minecraft:light_blue_glazed_terracotta",
+      "color": "#458cc4"
+    },
+    {
+      "name": "minecraft:yellow_glazed_terracotta",
+      "color": "#fbd972"
+    },
+    {
+      "name": "minecraft:lime_glazed_terracotta",
+      "color": "#8ac430"
+    },
+    {
+      "name": "minecraft:pink_glazed_terracotta",
+      "color": "#e89bb4"
+    },
+    {
+      "name": "minecraft:gray_glazed_terracotta",
+      "color": "#596063"
+    },
+    {
+      "name": "minecraft:light_gray_glazed_terracotta",
+      "color": "#a3acaf"
+    },
+    {
+      "name": "minecraft:cyan_glazed_terracotta",
+      "color": "#3d8285"
+    },
+    {
+      "name": "minecraft:purple_glazed_terracotta",
+      "color": "#7c3fa7"
+    },
+    {
+      "name": "minecraft:blue_glazed_terracotta",
+      "color": "#31458f"
+    },
+    {
+      "name": "minecraft:brown_glazed_terracotta",
+      "color": "#956741"
+    },
+    {
+      "name": "minecraft:green_glazed_terracotta",
+      "color": "#92a278"
+    },
+    {
+      "name": "minecraft:red_glazed_terracotta",
+      "color": "#a92f2b"
+    },
+    {
+      "name": "minecraft:black_glazed_terracotta",
+      "color": "#582528"
+    },
+    {
+      "name": "minecraft:white_concrete",
+      "color": "#d0d6d7"
+    },
+    {
+      "name": "minecraft:orange_concrete",
+      "color": "#e16201"
+    },
+    {
+      "name": "minecraft:magenta_concrete",
+      "color": "#aa31a0"
+    },
+    {
+      "name": "minecraft:light_blue_concrete",
+      "color": "#2489c7"
+    },
+    {
+      "name": "minecraft:yellow_concrete",
+      "color": "#f2b016"
+    },
+    {
+      "name": "minecraft:lime_concrete",
+      "color": "#5fa919"
+    },
+    {
+      "name": "minecraft:pink_concrete",
+      "color": "#d6658f"
+    },
+    {
+      "name": "minecraft:gray_concrete",
+      "color": "#373a3e"
+    },
+    {
+      "name": "minecraft:light_gray_concrete",
+      "color": "#7d7d73"
+    },
+    {
+      "name": "minecraft:cyan_concrete",
+      "color": "#167788"
+    },
+    {
+      "name": "minecraft:purple_concrete",
+      "color": "#65209d"
+    },
+    {
+      "name": "minecraft:blue_concrete",
+      "color": "#2d2f90"
+    },
+    {
+      "name": "minecraft:brown_concrete",
+      "color": "#613c20"
+    },
+    {
+      "name": "minecraft:green_concrete",
+      "color": "#4a5c25"
+    },
+    {
+      "name": "minecraft:red_concrete",
+      "color": "#8f2121"
+    },
+    {
+      "name": "minecraft:black_concrete",
+      "color": "#080a0f"
+    },
+    {
+      "name": "minecraft:white_concrete_powder",
+      "color": "#e3e5e5"
+    },
+    {
+      "name": "minecraft:orange_concrete_powder",
+      "color": "#e48521"
+    },
+    {
+      "name": "minecraft:magenta_concrete_powder",
+      "color": "#c154b8"
+    },
+    {
+      "name": "minecraft:light_blue_concrete_powder",
+      "color": "#4bb6d6"
+    },
+    {
+      "name": "minecraft:yellow_concrete_powder",
+      "color": "#e9c735"
+    },
+    {
+      "name": "minecraft:lime_concrete_powder",
+      "color": "#7dbd2a"
+    },
+    {
+      "name": "minecraft:pink_concrete_powder",
+      "color": "#e599b5"
+    },
+    {
+      "name": "minecraft:gray_concrete_powder",
+      "color": "#4e5256"
+    },
+    {
+      "name": "minecraft:light_gray_concrete_powder",
+      "color": "#9b9b94"
+    },
+    {
+      "name": "minecraft:cyan_concrete_powder",
+      "color": "#25929c"
+    },
+    {
+      "name": "minecraft:purple_concrete_powder",
+      "color": "#8438b2"
+    },
+    {
+      "name": "minecraft:blue_concrete_powder",
+      "color": "#4649a7"
+    },
+    {
+      "name": "minecraft:brown_concrete_powder",
+      "color": "#7d5536"
+    },
+    {
+      "name": "minecraft:green_concrete_powder",
+      "color": "#61762e"
+    },
+    {
+      "name": "minecraft:red_concrete_powder",
+      "color": "#a83633"
+    },
+    {
+      "name": "minecraft:black_concrete_powder",
+      "color": "#1a1c21"
+    },
+    {
+      "name": "minecraft:tube_coral",
+      "color": "#3f5be2"
+    },
+    {
+      "name": "minecraft:brain_coral",
+      "color": "#e78dc0"
+    },
+    {
+      "name": "minecraft:bubble_coral",
+      "color": "#c819ba"
+    },
+    {
+      "name": "minecraft:fire_coral",
+      "color": "#e34036"
+    },
+    {
+      "name": "minecraft:horn_coral",
+      "color": "#e4da4a"
+    },
+    {
+      "name": "minecraft:tube_coral_fan",
+      "color": "#3f5be2"
+    },
+    {
+      "name": "minecraft:brain_coral_fan",
+      "color": "#e78dc0"
+    },
+    {
+      "name": "minecraft:bubble_coral_fan",
+      "color": "#c819ba"
+    },
+    {
+      "name": "minecraft:fire_coral_fan",
+      "color": "#e34036"
+    },
+    {
+      "name": "minecraft:horn_coral_fan",
+      "color": "#e4da4a"
+    },
+    {
+      "name": "minecraft:tube_coral_block",
+      "color": "#2642c9"
+    },
+    {
+      "name": "minecraft:brain_coral_block",
+      "color": "#ce74a7"
+    },
+    {
+      "name": "minecraft:bubble_coral_block",
+      "color": "#af00a1"
+    },
+    {
+      "name": "minecraft:fire_coral_block",
+      "color": "#ca271d"
+    },
+    {
+      "name": "minecraft:horn_coral_block",
+      "color": "#cbc131"
+    },
+    {
+      "name": "minecraft:sea_pickle",
+      "color": "#56644a"
+    },
+    {
+      "name": "minecraft:structure_block_save",
+      "color": "#564757"
+    },
+    {
+      "name": "minecraft:structure_block_load",
+      "color": "#453946"
+    },
+    {
+      "name": "minecraft:structure_block_corner",
+      "color": "#443945"
+    },
+    {
+      "name": "minecraft:structure_block_id",
+      "color": "#4f4150"
+    }
+  ],
+  "update": "https://github.com/mrkite/minutor/raw/master/definitions/vanilla_ids.json"
+}

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -51,6 +51,7 @@
     {
       "id": 2,
       "name": "Grass",
+      "flatname": "minecraft:grass_block",
       "color": "#939393",
       "biomeGrass": true
     },
@@ -355,6 +356,7 @@
     {
       "id": 31,
       "name": "Dead Shrub",
+      "flatname": "minecraft:dead_bush",
       "color": "#946428",
       "alpha": 0.3,
       "transparent": true,
@@ -363,6 +365,7 @@
         {
           "data": 1,
           "name": "Tall Grass",
+          "flatname": "minecraft:grass",
           "color": "#909090",
           "biomeGrass": true
         },
@@ -1304,6 +1307,7 @@
     {
       "id": 106,
       "name": "Vines",
+      "flatname": "minecraft:vine",
       "color": "#6f6f6f",
       "transparent": true,
       "spawninside": true,

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -1,2491 +1,2889 @@
 {
-  "name": "Vanilla",
+  "name": "Vanilla Flattening Converter",
   "type": "block",
-  "version": "1.13",
+  "version": "1.12.17w13a",
   "data": [
     {
-      "name": "minecraft:air",
+      "id": 0,
+      "name": "Air",
       "color": "#ffffff",
-      "alpha": 0,
+      "alpha": 0.0,
       "transparent": true,
       "spawninside": true
     },
     {
-      "name": "minecraft:cave_air",
-      "color": "#ffffff",
-      "alpha": 0,
-      "transparent": true,
-      "spawninside": true
+      "id": 1,
+      "name": "Stone",
+      "color": "#747474",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Granite",
+          "color": "#977061"
+        },
+        {
+          "data": 2,
+          "name": "Polished Granite",
+          "color": "#9d7160"
+        },
+        {
+          "data": 3,
+          "name": "Diorite",
+          "color": "#b2b2b5"
+        },
+        {
+          "data": 4,
+          "name": "Polished Diorite",
+          "color": "#b9b9bc"
+        },
+        {
+          "data": 5,
+          "name": "Andesite",
+          "color": "#818181"
+        },
+        {
+          "data": 6,
+          "name": "Polished Andesite",
+          "color": "#838385"
+        }
+      ]
     },
     {
-      "name": "minecraft:void_air",
-      "color": "#ffffff",
-      "alpha": 0,
-      "transparent": true,
-      "spawninside": true
-    },
-    {
-      "name": "minecraft:stone",
-      "color": "#747474"
-    },
-    {
-      "name": "minecraft:granite",
-      "color": "#977061"
-    },
-    {
-      "name": "minecraft:polished_granite",
-      "color": "#9d7160"
-    },
-    {
-      "name": "minecraft:diorite",
-      "color": "#b2b2b5"
-    },
-    {
-      "name": "minecraft:polished_diorite",
-      "color": "#b9b9bc"
-    },
-    {
-      "name": "minecraft:andesite",
-      "color": "#818181"
-    },
-    {
-      "name": "minecraft:polished_andesite",
-      "color": "#838385"
-    },
-    {
-      "name": "minecraft:grass",
+      "id": 2,
+      "name": "Grass",
       "color": "#939393",
       "biomeGrass": true
     },
     {
-      "name": "minecraft:grass_block",
-      "color": "#939393",
-      "biomeGrass": true
+      "id": 3,
+      "name": "Dirt",
+      "color": "#835d40",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Coarse Dirt",
+          "color": "#76543a"
+        },
+        {
+          "data": 2,
+          "name": "Podzol",
+          "color": "#573c1a"
+        }
+      ]
     },
     {
-      "name": "minecraft:dirt",
-      "color": "#835d40"
-    },
-    {
-      "name": "minecraft:coarse_dirt",
-      "color": "#76543a"
-    },
-    {
-      "name": "minecraft:podzol",
-      "color": "#573c1a"
-    },
-    {
-      "name": "minecraft:cobblestone",
+      "id": 4,
+      "name": "Cobblestone",
       "color": "#8f8f8f"
     },
     {
-      "name": "minecraft:oak_planks",
-      "color": "#b4905a"
+      "id": 5,
+      "name": "Oak Wood Plank",
+      "color": "#b4905a",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Spruce Wood Plank",
+          "color": "#805e36"
+        },
+        {
+          "data": 2,
+          "name": "Birch Wood Plank",
+          "color": "#c8b77a"
+        },
+        {
+          "data": 3,
+          "name": "Jungle Wood Plank",
+          "color": "#b1805c"
+        },
+        {
+          "data": 4,
+          "name": "Acacia Wood Plank",
+          "color": "#ba6337"
+        },
+        {
+          "data": 5,
+          "name": "Dark Oak Wood Plank",
+          "color": "#462d15"
+        }
+      ]
     },
     {
-      "name": "minecraft:spruce_planks",
-      "color": "#805e36"
-    },
-    {
-      "name": "minecraft:birch_planks",
-      "color": "#c8b77a"
-    },
-    {
-      "name": "minecraft:jungle_planks",
-      "color": "#b1805c"
-    },
-    {
-      "name": "minecraft:acacia_planks",
-      "color": "#ba6337"
-    },
-    {
-      "name": "minecraft:dark_oak_planks",
-      "color": "#462d15"
-    },
-    {
-      "name": "minecraft:oak_sapling",
+      "id": 6,
+      "name": "Oak Sapling",
       "color": "#1f6519",
       "alpha": 0.3,
       "mask": 7,
       "transparent": true,
-      "spawninside": true
+      "spawninside": true,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Spruce Sapling",
+          "color": "#395a39"
+        },
+        {
+          "data": 2,
+          "name": "Birch Sapling",
+          "color": "#51742d"
+        },
+        {
+          "data": 3,
+          "name": "Jungle Sapling",
+          "color": "#2c6c18"
+        },
+        {
+          "data": 4,
+          "name": "Acacia Sapling",
+          "color": "#677e17"
+        },
+        {
+          "data": 5,
+          "name": "Dark Oak Sapling",
+          "color": "#105210"
+        }
+      ]
     },
     {
-      "name": "minecraft:spruce_sapling",
-      "color": "#395a39",
-      "alpha": 0.3,
-      "mask": 7,
-      "transparent": true,
-      "spawninside": true
-    },
-    {
-      "name": "minecraft:birch_sapling",
-      "color": "#51742d",
-      "alpha": 0.3,
-      "mask": 7,
-      "transparent": true,
-      "spawninside": true
-    },
-    {
-      "name": "minecraft:jungle_sapling",
-      "color": "#2c6c18",
-      "alpha": 0.3,
-      "mask": 7,
-      "transparent": true,
-      "spawninside": true
-    },
-    {
-      "name": "minecraft:acacia_sapling",
-      "color": "#677e17",
-      "alpha": 0.3,
-      "mask": 7,
-      "transparent": true,
-      "spawninside": true
-    },
-    {
-      "name": "minecraft:dark_oak_sapling",
-      "color": "#105210",
-      "alpha": 0.3,
-      "mask": 7,
-      "transparent": true,
-      "spawninside": true
-    },
-    {
-      "name": "minecraft:bedrock",
+      "id": 7,
+      "name": "Bedrock",
       "color": "#333333"
     },
     {
-      "name": "minecraft:flowing_water",
+      "id": 8,
+      "name": "Water (flowing)",
       "color": "#1f55ff",
       "alpha": 0.53,
       "transparent": true,
       "liquid": true
     },
     {
-      "name": "minecraft:water",
+      "id": 9,
+      "name": "Water",
       "color": "#1f55ff",
       "alpha": 0.53,
       "transparent": true,
       "liquid": true
     },
     {
-      "name": "minecraft:bubble_column",
-      "color": "#6b8fff",
-      "alpha": 0.53,
-      "transparent": true,
-      "liquid": true
-    },
-    {
-      "name": "minecraft:flowing_lava",
+      "id": 10,
+      "name": "Lava (flowing)",
       "color": "#fc5700",
       "transparent": true,
       "liquid": true
     },
     {
-      "name": "minecraft:lava",
+      "id": 11,
+      "name": "Lava",
       "color": "#fc5700",
       "transparent": true,
       "liquid": true
     },
     {
-      "name": "minecraft:sand",
-      "color": "#d6cf97"
+      "id": 12,
+      "name": "Sand",
+      "color": "#d6cf97",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Red Sand",
+          "color": "#a6551e"
+        }
+      ]
     },
     {
-      "name": "minecraft:red_sand",
-      "color": "#a6551e"
-    },
-    {
-      "name": "minecraft:gravel",
+      "id": 13,
+      "name": "Gravel",
       "color": "#817f7f"
     },
     {
-      "name": "minecraft:gold_ore",
+      "id": 14,
+      "name": "Gold Ore",
       "color": "#fcee4b"
     },
     {
-      "name": "minecraft:iron_ore",
+      "id": 15,
+      "name": "Iron Ore",
       "color": "#af8e77"
     },
     {
-      "name": "minecraft:coal_ore",
+      "id": 16,
+      "name": "Coal Ore",
       "color": "#454545"
     },
     {
-      "name": "minecraft:oak_log",
+      "id": 17,
+      "name": "Oak Wood",
       "color": "#665130",
-      "mask": 3
+      "mask": 3,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Spruce Wood",
+          "color": "#2e1d0a"
+        },
+        {
+          "data": 2,
+          "name": "Birch Wood",
+          "color": "#d6dad6"
+        },
+        {
+          "data": 3,
+          "name": "Jungle Wood",
+          "color": "#584219"
+        }
+      ]
     },
     {
-      "name": "minecraft:spruce_log",
-      "color": "#2e1d0a"
-    },
-    {
-      "name": "minecraft:birch_log",
-      "color": "#d6dad6"
-    },
-    {
-      "name": "minecraft:jungle_log",
-      "color": "#584219"
-    },
-    {
-      "name": "minecraft:acacia_log",
-      "color": "#b25b3b",
-      "mask": 1
-    },
-    {
-      "name": "minecraft:dark_oak_log",
-      "color": "#5d4931"
-    },
-    {
-      "name": "minecraft:oak_wood",
-      "color": "#665130",
-      "mask": 3
-    },
-    {
-      "name": "minecraft:spruce_wood",
-      "color": "#2e1d0a"
-    },
-    {
-      "name": "minecraft:birch_wood",
-      "color": "#d6dad6"
-    },
-    {
-      "name": "minecraft:jungle_wood",
-      "color": "#584219"
-    },
-    {
-      "name": "minecraft:acacia_wood",
-      "color": "#b25b3b",
-      "mask": 1
-    },
-    {
-      "name": "minecraft:dark_oak_wood",
-      "color": "#5d4931"
-    },
-    {
-      "name": "minecraft:stripped_oak_wood",
-      "color": "#665130",
-      "mask": 3
-    },
-    {
-      "name": "minecraft:stripped_spruce_wood",
-      "color": "#2e1d0a"
-    },
-    {
-      "name": "minecraft:stripped_birch_wood",
-      "color": "#d6dad6"
-    },
-    {
-      "name": "minecraft:stripped_jungle_wood",
-      "color": "#584219"
-    },
-    {
-      "name": "minecraft:stripped_acacia_wood",
-      "color": "#b25b3b",
-      "mask": 1
-    },
-    {
-      "name": "minecraft:stripped_dark_oak_wood",
-      "color": "#5d4931"
-    },
-    {
-      "name": "minecraft:oak_leaves",
+      "id": 18,
+      "name": "Oak Leaves",
       "color": "#515151",
       "transparent": true,
       "rendercube": true,
       "biomeFoliage": true,
-      "mask": 3
+      "mask": 3,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Spruce Leaves",
+          "color": "#619961",
+          "biomeFoliage": false
+        },
+        {
+          "data": 2,
+          "name": "Birch Leaves",
+          "color": "#80a755",
+          "biomeFoliage": false
+        },
+        {
+          "data": 3,
+          "name": "Jungle Leaves",
+          "color": "#727069",
+          "biomeFoliage": true
+        }
+      ]
     },
     {
-      "name": "minecraft:spruce_leaves",
-      "color": "#619961",
-      "biomeFoliage": false
+      "id": 19,
+      "name": "Sponge",
+      "color": "#c3c455",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Wet Sponge",
+          "color": "#a09f3f"
+        }
+      ]
     },
     {
-      "name": "minecraft:birch_leaves",
-      "color": "#80a755",
-      "biomeFoliage": false
-    },
-    {
-      "name": "minecraft:jungle_leaves",
-      "color": "#727069",
-      "biomeFoliage": true,
-    },
-    {
-      "name": "minecraft:acacia_leaves",
-      "color": "#515151",
-      "transparent": true,
-      "rendercube": true,
-      "biomeFoliage": true,
-      "mask": 1
-    },
-    {
-      "name": "minecraft:dark_oak_leaves",
-      "color": "#515151",
-      "biomeFoliage": true
-    },
-    {
-      "name": "minecraft:sponge",
-      "color": "#c3c455"
-    },
-    {
-      "name": "minecraft:wet_sponge",
-      "color": "#a09f3f"
-    },
-    {
-      "name": "minecraft:glass",
+      "id": 20,
+      "name": "Glass",
       "color": "#c0f5fe",
       "alpha": 0.5,
       "transparent": true
     },
     {
-      "name": "minecraft:lapis_ore",
+      "id": 21,
+      "name": "Lapis Lazuli Ore",
       "color": "#1b43ad"
     },
     {
-      "name": "minecraft:lapis_block",
+      "id": 22,
+      "name": "Lapis Lazuli Block",
       "color": "#0f26b8"
     },
     {
-      "name": "minecraft:dispenser",
+      "id": 23,
+      "name": "Dispenser",
       "color": "#848484"
     },
     {
-      "name": "minecraft:sandstone",
-      "color": "#dfd7a5"
+      "id": 24,
+      "name": "Sandstone",
+      "color": "#dfd7a5",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Chiseled Sandstone",
+          "color": "#ddd8ab"
+        },
+        {
+          "data": 2,
+          "name": "Smooth Sandstone",
+          "color": "#d9d29a"
+        }
+      ]
     },
     {
-      "name": "minecraft:chiseled_sandstone",
-      "color": "#ddd8ab"
-    },
-    {
-      "name": "minecraft:cut_sandstone",
-      "color": "#d9d29a"
-    },
-    {
-      "name": "minecraft:smooth_sandstone",
-      "color": "#d9d29a"
-    },
-    {
-      "name": "minecraft:note_block",
+      "id": 25,
+      "name": "Note Block",
       "color": "#915840"
     },
     {
-      "name": "minecraft:bed",
+      "id": 26,
+      "name": "Bed",
       "color": "#8c1616",
       "transparent": true
     },
     {
-      "name": "minecraft:powered_rail",
+      "id": 27,
+      "name": "Powered Rail",
       "color": "#ab0301",
       "transparent": true,
       "spawninside": true
     },
     {
-      "name": "minecraft:detector_rail",
+      "id": 28,
+      "name": "Detector Rail",
       "color": "#7d7171",
       "transparent": true,
       "spawninside": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:sticky_piston",
+      "id": 29,
+      "name": "Sticky Piston",
       "color": "#7bc070",
       "transparent": true
     },
     {
-      "name": "minecraft:cobweb",
+      "id": 30,
+      "name": "Cobweb",
       "color": "#ededed",
       "transparent": true
     },
     {
-      "name": "minecraft:tall_seagrass",
-      "color": "#006428",
-      "biomeGrass": true
-    },
-    {
-      "name": "minecraft:seagrass",
-      "color": "#006428",
-      "biomeGrass": true
-    },
-    {
-      "name": "minecraft:tall_grass",
+      "id": 31,
+      "name": "Dead Shrub",
       "color": "#946428",
       "alpha": 0.3,
       "transparent": true,
-      "spawninside": true
+      "spawninside": true,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Tall Grass",
+          "color": "#909090",
+          "biomeGrass": true
+        },
+        {
+          "data": 2,
+          "name": "Fern",
+          "color": "#828282",
+          "biomeGrass": true
+        }
+      ]
     },
     {
-      "name": "minecraft:tallgrass",
-      "color": "#909090",
-      "biomeGrass": true
-    },
-    {
-      "name": "minecraft:kelp",
-      "color": "#003013"
-    },
-    {
-      "name": "minecraft:kelp_plant",
-      "color": "#003013"
-    },
-    {
-      "name": "minecraft:fern",
-      "color": "#828282",
-      "biomeGrass": true
-    },
-    {
-      "name": "minecraft:dead_bush",
+      "id": 32,
+      "name": "Dead Bush",
       "color": "#946428",
       "transparent": true,
       "spawninside": true,
       "alpha": 0.3
     },
     {
-      "name": "minecraft:piston",
+      "id": 33,
+      "name": "Piston",
       "color": "#9f844d",
       "transparent": true
     },
     {
-      "name": "minecraft:piston_head",
-      "color": "#b4905a",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:white_wool",
-      "color": "#eaeaea"
-    },
-    {
-      "name": "minecraft:orange_wool",
-      "color": "#db7b3b"
-    },
-    {
-      "name": "minecraft:magenta_wool",
-      "color": "#af44b8"
-    },
-    {
-      "name": "minecraft:light_blue_wool",
-      "color": "#7e99d0"
-    },
-    {
-      "name": "minecraft:yellow_wool",
-      "color": "#bcb02a"
-    },
-    {
-      "name": "minecraft:lime_wool",
-      "color": "#44b93b"
-    },
-    {
-      "name": "minecraft:pink_wool",
-      "color": "#d28a9e"
-    },
-    {
-      "name": "minecraft:gray_wool",
-      "color": "#454545"
-    },
-    {
-      "name": "minecraft:light_gray_wool",
-      "color": "#909898"
-    },
-    {
-      "name": "minecraft:cyan_wool",
-      "color": "#30728e"
-    },
-    {
-      "name": "minecraft:purple_wool",
-      "color": "#7737ad"
-    },
-    {
-      "name": "minecraft:blue_wool",
-      "color": "#2b3585"
-    },
-    {
-      "name": "minecraft:brown_wool",
-      "color": "#563822"
-    },
-    {
-      "name": "minecraft:green_wool",
-      "color": "#314119"
-    },
-    {
-      "name": "minecraft:red_wool",
-      "color": "#91312f"
-    },
-    {
-      "name": "minecraft:black_wool",
-      "color": "#1d1b1b"
-    },
-    {
-      "name": "minecraft:moving_piston",
+      "id": 34,
+      "name": "Piston Head",
       "color": "#b4905a"
     },
     {
-      "name": "minecraft:dandelion",
+      "id": 35,
+      "name": "White Wool",
+      "color": "#eaeaea",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Orange Wool",
+          "color": "#db7b3b"
+        },
+        {
+          "data": 2,
+          "name": "Magenta Wool",
+          "color": "#af44b8"
+        },
+        {
+          "data": 3,
+          "name": "Light Blue Wool",
+          "color": "#7e99d0"
+        },
+        {
+          "data": 4,
+          "name": "Yellow Wool",
+          "color": "#bcb02a"
+        },
+        {
+          "data": 5,
+          "name": "Lime Wool",
+          "color": "#44b93b"
+        },
+        {
+          "data": 6,
+          "name": "Pink Wool",
+          "color": "#d28a9e"
+        },
+        {
+          "data": 7,
+          "name": "Gray Wool",
+          "color": "#454545"
+        },
+        {
+          "data": 8,
+          "name": "Light Gray Wool",
+          "color": "#909898"
+        },
+        {
+          "data": 9,
+          "name": "Cyan Wool",
+          "color": "#30728e"
+        },
+        {
+          "data": 10,
+          "name": "Purple Wool",
+          "color": "#7737ad"
+        },
+        {
+          "data": 11,
+          "name": "Blue Wool",
+          "color": "#2b3585"
+        },
+        {
+          "data": 12,
+          "name": "Brown Wool",
+          "color": "#563822"
+        },
+        {
+          "data": 13,
+          "name": "Green Wool",
+          "color": "#314119"
+        },
+        {
+          "data": 14,
+          "name": "Red Wool",
+          "color": "#91312f"
+        },
+        {
+          "data": 15,
+          "name": "Black Wool",
+          "color": "#1d1b1b"
+        }
+      ]
+    },
+    {
+      "id": 36,
+      "name": "Piston Extension",
+      "color": "#b4905a"
+    },
+    {
+      "id": 37,
+      "name": "Dandelion",
       "color": "#f1f902",
       "transparent": true,
       "spawninside": true,
       "alpha": 0.3
     },
     {
-      "name": "minecraft:poppy",
+      "id": 38,
+      "name": "Poppy",
       "color": "#ba050b",
       "transparent": true,
       "spawninside": true,
-      "alpha": 0.3
+      "alpha": 0.3,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Blue Orchid",
+          "color": "#29aefb"
+        },
+        {
+          "data": 2,
+          "name": "Allium",
+          "color": "#b865fb"
+        },
+        {
+          "data": 3,
+          "name": "Azure Bluet",
+          "color": "#e4eaf2"
+        },
+        {
+          "data": 4,
+          "name": "Red Tulip",
+          "color": "#d33a17"
+        },
+        {
+          "data": 5,
+          "name": "Orange Tulip",
+          "color": "#de731f"
+        },
+        {
+          "data": 6,
+          "name": "White Tulip",
+          "color": "#e7e7e7"
+        },
+        {
+          "data": 7,
+          "name": "Pink Tulip",
+          "color": "#eabeea"
+        },
+        {
+          "data": 8,
+          "name": "Oxeye Daisy",
+          "color": "#eae6ad"
+        }
+      ]
     },
     {
-      "name": "minecraft:blue_orchid",
-      "color": "#29aefb"
-    },
-    {
-      "name": "minecraft:allium",
-      "color": "#b865fb"
-    },
-    {
-      "name": "minecraft:azure_bluet",
-      "color": "#e4eaf2"
-    },
-    {
-      "name": "minecraft:red_tulip",
-      "color": "#d33a17"
-    },
-    {
-      "name": "minecraft:orange_tulip",
-      "color": "#de731f"
-    },
-    {
-      "name": "minecraft:white_tulip",
-      "color": "#e7e7e7"
-    },
-    {
-      "name": "minecraft:pink_tulip",
-      "color": "#eabeea"
-    },
-    {
-      "name": "minecraft:oxeye_daisy",
-      "color": "#eae6ad"
-    },
-    {
-      "name": "minecraft:brown_mushroom",
+      "id": 39,
+      "name": "Brown Mushroom",
       "color": "#916d55",
       "transparent": true,
       "spawninside": true,
       "alpha": 0.3
     },
     {
-      "name": "minecraft:red_mushroom",
+      "id": 40,
+      "name": "Red Mushroom",
       "color": "#e21212",
       "transparent": true,
       "spawninside": true,
       "alpha": 0.3
     },
     {
-      "name": "minecraft:gold_block",
+      "id": 41,
+      "name": "Block of Gold",
       "color": "#fdfb4f"
     },
     {
-      "name": "minecraft:iron_block",
+      "id": 42,
+      "name": "Block of Iron",
       "color": "#e6e6e6"
     },
     {
-      "name": "minecraft:double_stone_slab",
-      "color": "#a3a3a3"
-    },
-    {
-      "name": "minecraft:double_sandstone_slab",
-      "color": "#d7ce95"
-    },
-    {
-      "name": "minecraft:double_wooden_slab",
-      "color": "#b4905a"
-    },
-    {
-      "name": "minecraft:double_cobblestone_slab",
-      "color": "#8f8f8f"
-    },
-    {
-      "name": "minecraft:double_bricks_slab",
-      "color": "#7c4536"
-    },
-    {
-      "name": "minecraft:double_stone_brick_slab",
-      "color": "#797979"
-    },
-    {
-      "name": "minecraft:double_nether_brick_slab",
-      "color": "#30181c"
-    },
-    {
-      "name": "minecraft:double_quartz_slab",
-      "color": "#f0eee8"
-    },
-    {
-      "name": "minecraft:full_stone_slab",
-      "color": "#9c9c9c"
-    },
-    {
-      "name": "minecraft:full_sandstone_slab",
-      "color": "#d7cf9c"
-    },
-    {
-      "name": "minecraft:stone_slab",
+      "id": 43,
+      "name": "Double Stone Slab",
       "color": "#a3a3a3",
-      "transparent": true
+      "variants": [
+        {
+          "data": 1,
+          "name": "Double Sandstone Slab",
+          "color": "#d7ce95"
+        },
+        {
+          "data": 2,
+          "name": "Double Wooden Slab",
+          "color": "#b4905a"
+        },
+        {
+          "data": 3,
+          "name": "Double Cobblestone Slab",
+          "color": "#8f8f8f"
+        },
+        {
+          "data": 4,
+          "name": "Double Bricks Slab",
+          "color": "#7c4536"
+        },
+        {
+          "data": 5,
+          "name": "Double Stone Brick Slab",
+          "color": "#797979"
+        },
+        {
+          "data": 6,
+          "name": "Double Nether Brick Slab",
+          "color": "#30181c"
+        },
+        {
+          "data": 7,
+          "name": "Double Quartz Slab",
+          "color": "#f0eee8"
+        },
+        {
+          "data": 8,
+          "name": "Full Stone Slab",
+          "color": "#9c9c9c"
+        },
+        {
+          "data": 9,
+          "name": "Full Sandstone Slab",
+          "color": "#d7cf9c"
+        }
+      ]
     },
     {
-      "name": "minecraft:sandstone_slab",
-      "color": "#d7ce95"
+      "id": 44,
+      "name": "Stone Slab",
+      "color": "#a3a3a3",
+      "transparent": true,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Sandstone Slab",
+          "color": "#d7ce95"
+        },
+        {
+          "data": 2,
+          "name": "Wooden Slab",
+          "color": "#b4905a"
+        },
+        {
+          "data": 3,
+          "name": "Cobblestone Slab",
+          "color": "#8f8f8f"
+        },
+        {
+          "data": 4,
+          "name": "Brick Slab",
+          "color": "#7c4536"
+        },
+        {
+          "data": 5,
+          "name": "Stone Brick Slab",
+          "color": "#797979"
+        },
+        {
+          "data": 6,
+          "name": "Nether Brick Slab",
+          "color": "#30181c"
+        },
+        {
+          "data": 7,
+          "name": "Quartz Slab",
+          "color": "#f0eee8"
+        },
+        {
+          "data": 8,
+          "name": "Upper Stone Slab",
+          "color": "#a3a3a3"
+        },
+        {
+          "data": 9,
+          "name": "Upper Sandstone Slab",
+          "color": "#d7ce95"
+        },
+        {
+          "data": 10,
+          "name": "Upper Wooden Slab",
+          "color": "#b4905a"
+        },
+        {
+          "data": 11,
+          "name": "Upper Cobblestone Slab",
+          "color": "#8f8f8f"
+        },
+        {
+          "data": 12,
+          "name": "Upper Brick Slab",
+          "color": "#7c4536"
+        },
+        {
+          "data": 13,
+          "name": "Upper Stone Brick Slab",
+          "color": "#797979"
+        },
+        {
+          "data": 14,
+          "name": "Upper Nether Brick Slab",
+          "color": "#30181c"
+        },
+        {
+          "data": 15,
+          "name": "Upper Quartz Slab",
+          "color": "#f0eee8"
+        }
+      ]
     },
     {
-      "name": "minecraft:wooden_slab",
-      "color": "#b4905a"
-    },
-    {
-      "name": "minecraft:cobblestone_slab",
-      "color": "#8f8f8f"
-    },
-    {
-      "name": "minecraft:brick_slab",
-      "color": "#7c4536"
-    },
-    {
-      "name": "minecraft:stone_brick_slab",
-      "color": "#797979"
-    },
-    {
-      "name": "minecraft:nether_brick_slab",
-      "color": "#30181c"
-    },
-    {
-      "name": "minecraft:quartz_slab",
-      "color": "#f0eee8"
-    },
-    {
-      "name": "minecraft:upper_stone_slab",
-      "color": "#a3a3a3"
-    },
-    {
-      "name": "minecraft:upper_sandstone_slab",
-      "color": "#d7ce95"
-    },
-    {
-      "name": "minecraft:upper_wooden_slab",
-      "color": "#b4905a"
-    },
-    {
-      "name": "minecraft:upper_cobblestone_slab",
-      "color": "#8f8f8f"
-    },
-    {
-      "name": "minecraft:upper_brick_slab",
-      "color": "#7c4536"
-    },
-    {
-      "name": "minecraft:upper_stone_brick_slab",
-      "color": "#797979"
-    },
-    {
-      "name": "minecraft:upper_nether_brick_slab",
-      "color": "#30181c"
-    },
-    {
-      "name": "minecraft:upper_quartz_slab",
-      "color": "#f0eee8"
-    },
-    {
-      "name": "minecraft:bricks",
+      "id": 45,
+      "name": "Bricks",
       "color": "#6a3b2e"
     },
     {
-      "name": "minecraft:tnt",
+      "id": 46,
+      "name": "TNT",
       "color": "#a83414",
       "transparent": true
     },
     {
-      "name": "minecraft:bookshelf",
+      "id": 47,
+      "name": "Bookshelf",
       "color": "#9f844d"
     },
     {
-      "name": "minecraft:mossy_cobblestone",
+      "id": 48,
+      "name": "Moss Stone",
       "color": "#3a623a"
     },
     {
-      "name": "minecraft:obsidian",
+      "id": 49,
+      "name": "Obsidian",
       "color": "#0e0e16"
     },
     {
-      "name": "minecraft:torch",
+      "id": 50,
+      "name": "Torch",
       "color": "#ffd800",
       "transparent": true
     },
     {
-      "name": "minecraft:wall_torch",
-      "color": "#ffd800",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:fire",
+      "id": 51,
+      "name": "Fire",
       "color": "#ff8f00",
       "transparent": true
     },
     {
-      "name": "minecraft:mob_spawner",
+      "id": 52,
+      "name": "Monster Spawner",
       "color": "#1b2a35",
       "transparent": true,
       "rendercube": true
     },
     {
-      "name": "minecraft:oak_stairs",
+      "id": 53,
+      "name": "Oak Wood Stairs",
       "color": "#9f844d",
       "transparent": true
     },
     {
-      "name": "minecraft:chest",
+      "id": 54,
+      "name": "Chest",
       "color": "#976b20",
       "transparent": true
     },
     {
-      "name": "minecraft:redstone_wire",
+      "id": 55,
+      "name": "Redstone Wire",
       "color": "#d60000",
       "transparent": true
     },
     {
-      "name": "minecraft:diamond_ore",
+      "id": 56,
+      "name": "Diamond Ore",
       "color": "#5decf5"
     },
     {
-      "name": "minecraft:diamond_block",
+      "id": 57,
+      "name": "Block of Diamond",
       "color": "#91e8e4"
     },
     {
-      "name": "minecraft:crafting_table",
+      "id": 58,
+      "name": "Crafting Table",
       "color": "#a0693c"
     },
     {
-      "name": "minecraft:immature_wheat",
+      "id": 59,
+      "name": "Immature Wheat",
       "color": "#8ba803",
-      "transparent": true
+      "transparent": true,
+      "variants": [
+        {
+          "data": 7,
+          "name": "Grown Wheat",
+          "color": "#8e7c10"
+        }
+      ]
     },
     {
-      "name": "minecraft:wheat",
-      "color": "#8e7c10"
-    },
-    {
-      "name": "minecraft:wet_farmland",
+      "id": 60,
+      "name": "Wet Farmland",
       "color": "#43240b",
-      "transparent": true
+      "transparent": true,
+      "variants": [
+        {
+          "data": 0,
+          "name": "Dry Farmland",
+          "color": "#633f24"
+        }
+      ]
     },
     {
-      "name": "minecraft:farmland",
-      "color": "#633f24"
-    },
-    {
-      "name": "minecraft:furnace",
+      "id": 61,
+      "name": "Furnace",
       "color": "#535353"
     },
     {
-      "name": "minecraft:burning_furnace",
+      "id": 62,
+      "name": "Burning Furnace",
       "color": "#535353"
     },
     {
-      "name": "minecraft:standing_sign",
+      "id": 63,
+      "name": "Sign Post",
       "color": "#9f844d",
       "transparent": true,
       "spawninside": true
     },
     {
-      "name": "minecraft:wooden_door",
+      "id": 64,
+      "name": "Oak Door",
       "color": "#b0572a",
       "transparent": true
     },
     {
-      "name": "minecraft:ladder",
+      "id": 65,
+      "name": "Ladder",
       "color": "#8e733c",
       "transparent": true,
       "spawninside": true
     },
     {
-      "name": "minecraft:rail",
+      "id": 66,
+      "name": "Rail",
       "color": "#a4a4a4",
       "transparent": true,
       "spawninside": true
     },
     {
-      "name": "minecraft:cobblestone_stairs",
+      "id": 67,
+      "name": "Cobblestone Stairs",
       "color": "#565656",
       "transparent": true
     },
     {
-      "name": "minecraft:wall_sign",
+      "id": 68,
+      "name": "Wall Sign",
       "color": "#b4905a",
       "transparent": true,
       "spawninside": true
     },
     {
-      "name": "minecraft:lever",
+      "id": 69,
+      "name": "Lever",
       "color": "#735e39",
       "transparent": true,
       "spawninside": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:stone_pressure_plate",
+      "id": 70,
+      "name": "Stone Pressure Plate",
       "color": "#8f8f8f",
       "transparent": true,
       "spawninside": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:iron_door",
+      "id": 71,
+      "name": "Iron Door",
       "color": "#b6b6b6",
       "transparent": true
     },
     {
-      "name": "minecraft:oak_pressure_plate",
+      "id": 72,
+      "name": "Wooden Pressure Plate",
       "color": "#bc9862",
       "transparent": true,
       "spawninside": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:redstone_ore",
+      "id": 73,
+      "name": "Redstone Ore",
       "color": "#8f0303"
     },
     {
-      "name": "minecraft:redstone_ore_(glowing)",
+      "id": 74,
+      "name": "Redstone Ore (glowing)",
       "color": "#8f0303"
     },
     {
-      "name": "minecraft:unlit_redstone_torch",
+      "id": 75,
+      "name": "Redstone Torch (off)",
       "color": "#480000",
       "transparent": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:redstone_torch",
+      "id": 76,
+      "name": "Redstone Torch (on)",
       "color": "#fd0000",
       "transparent": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:stone_button",
+      "id": 77,
+      "name": "Stone Button",
       "color": "#a8a8a8",
       "transparent": true,
       "spawninside": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:snow",
+      "id": 78,
+      "name": "Snow",
       "color": "#eeffff",
       "spawninside": true,
       "transparent": true
     },
     {
-      "name": "minecraft:ice",
+      "id": 79,
+      "name": "Ice",
       "color": "#77a9ff",
       "alpha": 0.62,
       "transparent": true,
       "rendercube": true
     },
     {
-      "name": "minecraft:snow_block",
+      "id": 80,
+      "name": "Snow Block",
       "color": "#eeffff"
     },
     {
-      "name": "minecraft:cactus",
+      "id": 81,
+      "name": "Cactus",
       "color": "#107e1d",
       "transparent": true
     },
     {
-      "name": "minecraft:clay",
+      "id": 82,
+      "name": "Clay Block",
       "color": "#9da3ae"
     },
     {
-      "name": "minecraft:sugar_cane",
+      "id": 83,
+      "name": "Sugar Cane",
       "color": "#97c06b",
       "spawninside": true,
       "transparent": true,
       "biomeGrass": true
     },
     {
-      "name": "minecraft:jukebox",
+      "id": 84,
+      "name": "Jukebox",
       "color": "#945f44"
     },
     {
-      "name": "minecraft:oak_fence",
+      "id": 85,
+      "name": "Oak Fence",
       "color": "#b4905a",
       "alpha": 0.75,
       "transparent": true
     },
     {
-      "name": "minecraft:pumpkin",
+      "id": 86,
+      "name": "Pumpkin",
       "color": "#e3901d"
     },
     {
-      "name": "minecraft:carved_pumpkin",
-      "color": "#e3901d"
-    },
-    {
-      "name": "minecraft:netherrack",
+      "id": 87,
+      "name": "Netherrack",
       "color": "#955744"
     },
     {
-      "name": "minecraft:soul_sand",
+      "id": 88,
+      "name": "Soul Sand",
       "color": "#554134"
     },
     {
-      "name": "minecraft:glowstone",
+      "id": 89,
+      "name": "Glowstone Block",
       "color": "#f9d49c"
     },
     {
-      "name": "minecraft:nether_portal",
+      "id": 90,
+      "name": "Nether Portal",
       "color": "#d67fff",
       "transparent": true
     },
     {
-      "name": "minecraft:jack_o'lantern",
+      "id": 91,
+      "name": "Jack o'Lantern",
       "color": "#e9b416"
     },
     {
-      "name": "minecraft:cake",
+      "id": 92,
+      "name": "Cake",
       "color": "#eae9eb",
       "transparent": true
     },
     {
-      "name": "minecraft:powered_repeater",
+      "id": 93,
+      "name": "Redstone Repeater (off)",
       "color": "#2a0002",
       "transparent": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:redstone_repeater_(on)",
+      "id": 94,
+      "name": "Redstone Repeater (on)",
       "color": "#fd0101",
       "transparent": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:white_stained_glass",
+      "id": 95,
+      "name": "White Stained Glass",
       "color": "#ffffff",
       "transparent": true,
-      "alpha": 0.5
+      "alpha": 0.5,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Orange Stained Glass",
+          "color": "#d87f33"
+        },
+        {
+          "data": 2,
+          "name": "Magenta Stained Glass",
+          "color": "#b24cd8"
+        },
+        {
+          "data": 3,
+          "name": "Light Blue Stained Glass",
+          "color": "#6699d8"
+        },
+        {
+          "data": 4,
+          "name": "Yellow Stained Glass",
+          "color": "#e5e533"
+        },
+        {
+          "data": 5,
+          "name": "Lime Stained Glass",
+          "color": "#7fcc19"
+        },
+        {
+          "data": 6,
+          "name": "Pink Stained Glass",
+          "color": "#f27fa5"
+        },
+        {
+          "data": 7,
+          "name": "Gray Stained Glass",
+          "color": "#4c4c4c"
+        },
+        {
+          "data": 8,
+          "name": "Silver Stained Glass",
+          "color": "#999999"
+        },
+        {
+          "data": 9,
+          "name": "Cyan Stained Glass",
+          "color": "#4c7f99"
+        },
+        {
+          "data": 10,
+          "name": "Purple Stained Glass",
+          "color": "#7f3fb2"
+        },
+        {
+          "data": 11,
+          "name": "Blue Stained Glass",
+          "color": "#334cb2"
+        },
+        {
+          "data": 12,
+          "name": "Brown Stained Glass",
+          "color": "#664c33"
+        },
+        {
+          "data": 13,
+          "name": "Green Stained Glass",
+          "color": "#667f33"
+        },
+        {
+          "data": 14,
+          "name": "Red Stained Glass",
+          "color": "#993333"
+        },
+        {
+          "data": 15,
+          "name": "Black Stained Glass",
+          "color": "#191919"
+        }
+      ]
     },
     {
-      "name": "minecraft:orange_stained_glass",
-      "color": "#d87f33",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:magenta_stained_glass",
-      "color": "#b24cd8",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:light_blue_stained_glass",
-      "color": "#6699d8",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:yellow_stained_glass",
-      "color": "#e5e533",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:lime_stained_glass",
-      "color": "#7fcc19",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:pink_stained_glass",
-      "color": "#f27fa5",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:gray_stained_glass",
-      "color": "#4c4c4c",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:silver_stained_glass",
-      "color": "#999999",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:cyan_stained_glass",
-      "color": "#4c7f99",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:purple_stained_glass",
-      "color": "#7f3fb2",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:blue_stained_glass",
-      "color": "#334cb2",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:brown_stained_glass",
-      "color": "#664c33",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:green_stained_glass",
-      "color": "#667f33",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:red_stained_glass",
-      "color": "#993333",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:black_stained_glass",
-      "color": "#191919",
-      "transparent": true,
-      "alpha": 0.5
-    },
-    {
-      "name": "minecraft:oak_trapdoor",
+      "id": 96,
+      "name": "Wooden Trapdoor",
       "color": "#7c5a2a",
       "transparent": true
     },
     {
-      "name": "minecraft:infested_stone",
-      "color": "#7a7a7a"
+      "id": 97,
+      "name": "Stone Monster Egg",
+      "color": "#7a7a7a",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Cobblestone Monster Egg",
+          "color": "#787878"
+        },
+        {
+          "data": 2,
+          "name": "Stone Brick Monster Egg",
+          "color": "#777777"
+        },
+        {
+          "data": 3,
+          "name": "Mossy Stone Brick Monster Egg",
+          "color": "#707467"
+        },
+        {
+          "data": 4,
+          "name": "Cracked Stone Brick Monster Egg",
+          "color": "#747474"
+        },
+        {
+          "data": 5,
+          "name": "Chiseled Stone Brick Monster Egg",
+          "color": "#747474"
+        }
+      ]
     },
     {
-      "name": "minecraft:infested_cobblestone",
-      "color": "#787878"
+      "id": 98,
+      "name": "Stone Brick",
+      "color": "#797979",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Mossy Stone Brick",
+          "color": "#637049"
+        },
+        {
+          "data": 2,
+          "name": "Cracked Stone Brick",
+          "color": "#656565"
+        },
+        {
+          "data": 3,
+          "name": "Chiseled Stone Brick",
+          "color": "#9c9c9c"
+        }
+      ]
     },
     {
-      "name": "minecraft:infested_stone_bricks",
-      "color": "#777777"
+      "id": 99,
+      "name": "Huge Brown Mushroom",
+      "color": "#d2b17d",
+      "variants": [
+        {
+          "data": 1,
+          "color": "#8f6b53"
+        },
+        {
+          "data": 2,
+          "color": "#8f6b53"
+        },
+        {
+          "data": 3,
+          "color": "#8f6b53"
+        },
+        {
+          "data": 4,
+          "color": "#8f6b53"
+        },
+        {
+          "data": 5,
+          "color": "#8f6b53"
+        },
+        {
+          "data": 6,
+          "color": "#8f6b53"
+        },
+        {
+          "data": 7,
+          "color": "#8f6b53"
+        },
+        {
+          "data": 8,
+          "color": "#8f6b53"
+        },
+        {
+          "data": 9,
+          "color": "#8f6b53"
+        },
+        {
+          "data": 10,
+          "color": "#d2b17d"
+        },
+        {
+          "data": 14,
+          "color": "#8f6b53"
+        },
+        {
+          "data": 15,
+          "color": "#cdc9bf"
+        }
+      ]
     },
     {
-      "name": "minecraft:infested_mossy_stone_bricks",
-      "color": "#707467"
+      "id": 100,
+      "name": "Huge Red Mushroom",
+      "color": "#d2b17d",
+      "variants": [
+        {
+          "data": 1,
+          "color": "#b51d1b"
+        },
+        {
+          "data": 2,
+          "color": "#b51d1b"
+        },
+        {
+          "data": 3,
+          "color": "#b51d1b"
+        },
+        {
+          "data": 4,
+          "color": "#b51d1b"
+        },
+        {
+          "data": 5,
+          "color": "#b51d1b"
+        },
+        {
+          "data": 6,
+          "color": "#b51d1b"
+        },
+        {
+          "data": 7,
+          "color": "#b51d1b"
+        },
+        {
+          "data": 8,
+          "color": "#b51d1b"
+        },
+        {
+          "data": 9,
+          "color": "#b51d1b"
+        },
+        {
+          "data": 10,
+          "color": "#d2b17d"
+        },
+        {
+          "data": 14,
+          "color": "#b51d1b"
+        },
+        {
+          "data": 15,
+          "color": "#cdc9bf"
+        }
+      ]
     },
     {
-      "name": "minecraft:infested_cracked_stone_bricks",
-      "color": "#747474"
-    },
-    {
-      "name": "minecraft:infested_chiseled_stone_bricks",
-      "color": "#747474"
-    },
-    {
-      "name": "minecraft:stone_bricks",
-      "color": "#797979"
-    },
-    {
-      "name": "minecraft:mossy_stone_bricks",
-      "color": "#637049"
-    },
-    {
-      "name": "minecraft:cracked_stone_bricks",
-      "color": "#656565"
-    },
-    {
-      "name": "minecraft:chiseled_stone_bricks",
-      "color": "#9c9c9c"
-    },
-    {
-      "name": "minecraft:brown_mushroom_block",
-      "color": "#8f6b53"
-    },
-    {
-      "name": "minecraft:red_mushroom_block",
-      "color": "#b51d1b"
-    },
-    {
-      "name": "minecraft:iron_bars",
+      "id": 101,
+      "name": "Iron Bars",
       "color": "#6d6e6e",
       "transparent": true
     },
     {
-      "name": "minecraft:glass_pane",
+      "id": 102,
+      "name": "Glass Pane",
       "color": "#c0f5fe",
       "alpha": 0.5,
       "transparent": true
     },
     {
-      "name": "minecraft:melon",
+      "id": 103,
+      "name": "Melon",
       "color": "#adb82c"
     },
     {
-      "name": "minecraft:pumpkin_stem",
+      "id": 104,
+      "name": "Pumpkin Stem",
       "color": "#6b6b0b",
       "transparent": true
     },
     {
-      "name": "minecraft:melon_stem",
+      "id": 105,
+      "name": "Melon Stem",
       "color": "#6b6b0b",
       "transparent": true
     },
     {
-      "name": "minecraft:vine",
+      "id": 106,
+      "name": "Vines",
       "color": "#6f6f6f",
       "transparent": true,
       "spawninside": true,
       "biomeFoliage": true
     },
     {
-      "name": "minecraft:oak_fence_gate",
+      "id": 107,
+      "name": "Oak Fence Gate",
       "color": "#b4905a",
       "alpha": 0.75,
       "transparent": true
     },
     {
-      "name": "minecraft:brick_stairs",
+      "id": 108,
+      "name": "Brick Stairs",
       "color": "#7c4536",
       "transparent": true
     },
     {
-      "name": "minecraft:stone_brick_stairs",
+      "id": 109,
+      "name": "Stone Brick Stairs",
       "color": "#727272",
       "transparent": true
     },
     {
-      "name": "minecraft:mycelium",
+      "id": 110,
+      "name": "Mycelium",
       "color": "#806b6f"
     },
     {
-      "name": "minecraft:lily_pad",
+      "id": 111,
+      "name": "Lily Pad",
       "color": "#88bf54",
       "transparent": true
     },
     {
-      "name": "minecraft:nether_bricks",
+      "id": 112,
+      "name": "Nether Brick",
       "color": "#30181c"
     },
     {
-      "name": "minecraft:nether_brick_fence",
+      "id": 113,
+      "name": "Nether Brick Fence",
       "color": "#1c0e10",
       "transparent": true
     },
     {
-      "name": "minecraft:nether_brick_stairs",
+      "id": 114,
+      "name": "Nether Brick Stairs",
       "color": "#381a1f",
       "transparent": true
     },
     {
-      "name": "minecraft:immature_nether_wart",
+      "id": 115,
+      "name": "Immature Nether Wart",
       "color": "#70081c",
-      "transparent": true
+      "transparent": true,
+      "variants": [
+        {
+          "data": 3,
+          "name": "Mature Nether Wart",
+          "color": "#8e181b"
+        }
+      ]
     },
     {
-      "name": "minecraft:mature_nether_wart",
-      "color": "#8e181b"
-    },
-    {
-      "name": "minecraft:enchanting_table",
+      "id": 116,
+      "name": "Enchantment Table",
       "color": "#3c3056",
       "transparent": true
     },
     {
-      "name": "minecraft:brewing_stand",
+      "id": 117,
+      "name": "Brewing Stand",
       "color": "#bea84a",
       "transparent": true
     },
     {
-      "name": "minecraft:cauldron",
+      "id": 118,
+      "name": "Cauldron",
       "color": "#4d4d4d",
       "transparent": true
     },
     {
-      "name": "minecraft:end_portal",
+      "id": 119,
+      "name": "End Portal",
       "color": "#0c0b0a",
       "transparent": true
     },
     {
-      "name": "minecraft:end_portal_frame",
+      "id": 120,
+      "name": "End Portal Frame",
       "color": "#2f5754",
       "mask": 4,
       "transparent": true,
-      "rendercube": true
+      "rendercube": true,
+      "variants": [
+        {
+          "data": 4,
+          "name": "End Portal Frame (on)",
+          "color": "#406852"
+        }
+      ]
     },
     {
-      "name": "minecraft:end_portal_frame_(on)",
-      "color": "#406852"
-    },
-    {
-      "name": "minecraft:end_stone",
+      "id": 121,
+      "name": "End Stone",
       "color": "#d9dc9e"
     },
     {
-      "name": "minecraft:dragon_egg",
+      "id": 122,
+      "name": "Dragon Egg",
       "color": "#2d0133"
     },
     {
-      "name": "minecraft:redstone_lamp",
+      "id": 123,
+      "name": "Redstone Lamp (off)",
       "color": "#b0744c"
     },
     {
-      "name": "minecraft:redstone_lamp_(on)",
+      "id": 124,
+      "name": "Redstone Lamp (on)",
       "color": "#f1d1af",
       "transparent": true
     },
     {
-      "name": "minecraft:double_oak_wood_slab",
-      "color": "#b4905a"
-    },
-    {
-      "name": "minecraft:double_spruce_wood_slab",
-      "color": "#664f2f"
-    },
-    {
-      "name": "minecraft:double_birch_wood_slab",
-      "color": "#d7cb8d"
-    },
-    {
-      "name": "minecraft:double_jungle_wood_slab",
-      "color": "#b1805c"
-    },
-    {
-      "name": "minecraft:double_acacia_wood_slab",
-      "color": "#ad5d32"
-    },
-    {
-      "name": "minecraft:double_dark_oak_wood_slab",
-      "color": "#462d15"
-    },
-    {
-      "name": "minecraft:oak_slab",
+      "id": 125,
+      "name": "Double Oak Wood Slab",
       "color": "#b4905a",
-      "transparent": true
+      "variants": [
+        {
+          "data": 1,
+          "name": "Double Spruce Wood Slab",
+          "color": "#664f2f"
+        },
+        {
+          "data": 2,
+          "name": "Double Birch Wood Slab",
+          "color": "#d7cb8d"
+        },
+        {
+          "data": 3,
+          "name": "Double Jungle Wood Slab",
+          "color": "#b1805c"
+        },
+        {
+          "data": 4,
+          "name": "Double Acacia Wood Slab",
+          "color": "#ad5d32"
+        },
+        {
+          "data": 5,
+          "name": "Double Dark Oak Wood Slab",
+          "color": "#462d15"
+        }
+      ]
     },
     {
-      "name": "minecraft:spruce_slab",
-      "color": "#664f2f"
+      "id": 126,
+      "name": "Oak Wood Slab",
+      "color": "#b4905a",
+      "transparent": true,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Spruce Wood Slab",
+          "color": "#664f2f"
+        },
+        {
+          "data": 2,
+          "name": "Birch Wood Slab",
+          "color": "#d7cb8d"
+        },
+        {
+          "data": 3,
+          "name": "Jungle Wood Slab",
+          "color": "#b1805c"
+        },
+        {
+          "data": 4,
+          "name": "Acacia Wood Slab",
+          "color": "#ba6337"
+        },
+        {
+          "data": 5,
+          "name": "Dark Oak Wood Slab",
+          "color": "#462d15"
+        },
+        {
+          "data": 8,
+          "name": "Upper Oak Wood Slab",
+          "color": "#b4905a"
+        },
+        {
+          "data": 9,
+          "name": "Upper Spruce Wood Slab",
+          "color": "#664f2f"
+        },
+        {
+          "data": 10,
+          "name": "Upper Birch Wood Slab",
+          "color": "#d7cb8d"
+        },
+        {
+          "data": 11,
+          "name": "Upper Jungle Wood Slab",
+          "color": "#b1805c"
+        },
+        {
+          "data": 12,
+          "name": "Upper Acacia Wood Slab",
+          "color": "#ba6337"
+        },
+        {
+          "data": 13,
+          "name": "Upper Dark Oak Wood Slab",
+          "color": "#462d15"
+        }
+      ]
     },
     {
-      "name": "minecraft:birch_slab",
-      "color": "#d7cb8d"
-    },
-    {
-      "name": "minecraft:jungle_slab",
-      "color": "#b1805c"
-    },
-    {
-      "name": "minecraft:acacia_slab",
-      "color": "#ba6337"
-    },
-    {
-      "name": "minecraft:dark_oak_slab",
-      "color": "#462d15"
-    },
-    {
-      "name": "minecraft:upper_oak_wood_slab",
-      "color": "#b4905a"
-    },
-    {
-      "name": "minecraft:upper_spruce_wood_slab",
-      "color": "#664f2f"
-    },
-    {
-      "name": "minecraft:upper_birch_wood_slab",
-      "color": "#d7cb8d"
-    },
-    {
-      "name": "minecraft:upper_jungle_wood_slab",
-      "color": "#b1805c"
-    },
-    {
-      "name": "minecraft:upper_acacia_wood_slab",
-      "color": "#ba6337"
-    },
-    {
-      "name": "minecraft:upper_dark_oak_wood_slab",
-      "color": "#462d15"
-    },
-    {
-      "name": "minecraft:immature_cocoa_pod",
+      "id": 127,
+      "name": "Immature Cocoa Pod",
       "color": "#929943",
       "transparent": true,
       "spawninside": true,
-      "mask": 12
+      "mask": 12,
+      "variants": [
+        {
+          "data": 8,
+          "name": "Mature Cocoa Pod",
+          "color": "#d4924c"
+        }
+      ]
     },
     {
-      "name": "minecraft:cocoa",
-      "color": "#d4924c"
-    },
-    {
-      "name": "minecraft:sandstone_stairs",
+      "id": 128,
+      "name": "Sandstone Stairs",
       "color": "#e9e0b3",
       "transparent": true
     },
     {
-      "name": "minecraft:emerald_ore",
+      "id": 129,
+      "name": "Emerald Ore",
       "color": "#17dd62"
     },
     {
-      "name": "minecraft:ender_chest",
+      "id": 130,
+      "name": "Ender Chest",
       "color": "#2d4042",
       "transparent": true
     },
     {
-      "name": "minecraft:tripwire_hook",
+      "id": 131,
+      "name": "Tripwire Hook",
       "color": "#6e6e6e",
       "transparent": true,
       "spawninside": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:tripwire",
+      "id": 132,
+      "name": "Tripwire",
       "color": "#ebebeb",
       "transparent": true
     },
     {
-      "name": "minecraft:emerald_block",
+      "id": 133,
+      "name": "Block of Emerald",
       "color": "#64ea8a"
     },
     {
-      "name": "minecraft:spruce_stairs",
+      "id": 134,
+      "name": "Spruce Wood Stairs",
       "color": "#664f2f",
       "transparent": true
     },
     {
-      "name": "minecraft:birch_stairs",
+      "id": 135,
+      "name": "Birch Wood Stairs",
       "color": "#d7cb8d",
       "transparent": true
     },
     {
-      "name": "minecraft:jungle_stairs",
+      "id": 136,
+      "name": "Jungle Wood Stairs",
       "color": "#b1805c",
       "transparent": true
     },
     {
-      "name": "minecraft:command_block",
+      "id": 137,
+      "name": "Command Block",
       "color": "#b18972"
     },
     {
-      "name": "minecraft:beacon",
+      "id": 138,
+      "name": "Beacon",
       "color": "#c4fffe"
     },
     {
-      "name": "minecraft:cobblestone_wall",
+      "id": 139,
+      "name": "Cobblestone Wall",
       "color": "#505050",
       "transparent": true
     },
     {
-      "name": "minecraft:flower_pot",
+      "id": 140,
+      "name": "Flower Pot (empty)",
       "color": "#7c4536",
-      "transparent": true
+      "transparent": true,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Flower Pot (poppy)",
+          "color": "#910205"
+        },
+        {
+          "data": 2,
+          "name": "Flower Pot (dandelion)",
+          "color": "#f1f902"
+        },
+        {
+          "data": 3,
+          "name": "Flower Pot (oak)",
+          "color": "#408f2f"
+        },
+        {
+          "data": 4,
+          "name": "Flower Pot (spruce)",
+          "color": "#395a39"
+        },
+        {
+          "data": 5,
+          "name": "Flower Pot (birch)",
+          "color": "#cfe3ba"
+        },
+        {
+          "data": 6,
+          "name": "Flower Pot (jungle)",
+          "color": "#2c6c18"
+        },
+        {
+          "data": 7,
+          "name": "Flower Pot (red mushroom)",
+          "color": "#9a171c"
+        },
+        {
+          "data": 8,
+          "name": "Flower Pot (brown mushroom)",
+          "color": "#725643"
+        },
+        {
+          "data": 9,
+          "name": "Flower Pot (cactus)",
+          "color": "#128a20"
+        },
+        {
+          "data": 10,
+          "name": "Flower Pot (dead bush)",
+          "color": "#946428"
+        },
+        {
+          "data": 11,
+          "name": "Flower Pot (fern)",
+          "color": "#315e05"
+        },
+        {
+          "data": 12,
+          "name": "Flower Pot (acacia)",
+          "color": "#946428"
+        },
+        {
+          "data": 13,
+          "name": "Flower Pot (dark oak)",
+          "color": "#315e05"
+        }
+      ]
     },
     {
-      "name": "minecraft:potted_poppy",
-      "color": "#910205"
-    },
-    {
-      "name": "minecraft:potted_dandelion",
-      "color": "#f1f902"
-    },
-    {
-      "name": "minecraft:potted_oak_sapling",
-      "color": "#408f2f"
-    },
-    {
-      "name": "minecraft:potted_spruce_sapling",
-      "color": "#395a39"
-    },
-    {
-      "name": "minecraft:potted_birch_sapling",
-      "color": "#cfe3ba"
-    },
-    {
-      "name": "minecraft:potted_jungle_sapling",
-      "color": "#2c6c18"
-    },
-    {
-      "name": "minecraft:potted_red_mushroom",
-      "color": "#9a171c"
-    },
-    {
-      "name": "minecraft:potted_brown_mushroom",
-      "color": "#725643"
-    },
-    {
-      "name": "minecraft:potted_cactus",
-      "color": "#128a20"
-    },
-    {
-      "name": "minecraft:potted_dead_bush",
-      "color": "#946428"
-    },
-    {
-      "name": "minecraft:potted_fern",
-      "color": "#315e05"
-    },
-    {
-      "name": "minecraft:potted_acacia_sapling",
-      "color": "#946428"
-    },
-    {
-      "name": "minecraft:potted_dark_oak_sapling",
-      "color": "#315e05"
-    },
-    {
-      "name": "minecraft:immature_carrots",
+      "id": 141,
+      "name": "Immature Carrots",
       "color": "#00c617",
-      "transparent": true
+      "transparent": true,
+      "variants": [
+        {
+          "data": 7,
+          "name": "Mature Carrots",
+          "color": "#004e00"
+        }
+      ]
     },
     {
-      "name": "minecraft:carrots",
-      "color": "#004e00"
-    },
-    {
-      "name": "minecraft:immature_potatoes",
+      "id": 142,
+      "name": "Immature Potatoes",
       "color": "#00c617",
-      "transparent": true
+      "transparent": true,
+      "variants": [
+        {
+          "data": 7,
+          "name": "Mature Potatoes",
+          "color": "#3aa649"
+        }
+      ]
     },
     {
-      "name": "minecraft:potatoes",
-      "color": "#3aa649"
-    },
-    {
-      "name": "minecraft:oak_button",
+      "id": 143,
+      "name": "Wooden Button",
       "color": "#b4905a",
       "transparent": true,
       "spawninside": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:skull",
+      "id": 144,
+      "name": "Mob Head",
       "color": "#1a1a1a",
       "transparent": true
     },
     {
-      "name": "minecraft:anvil",
+      "id": 145,
+      "name": "Anvil",
       "color": "#474747",
       "transparent": true,
-      "mask": 12
+      "mask": 12,
+      "variants": [
+        {
+          "data": 4,
+          "name": "Slightly Damaged Anvil"
+        },
+        {
+          "data": 8,
+          "name": "Very Damaged Anvil"
+        }
+      ]
     },
     {
-      "name": "minecraft:chipped_anvil",
-      "color": "#474747",
-      "transparent": true,
-      "mask": 12
-    },
-    {
-      "name": "minecraft:damaged_anvil",
-      "color": "#474747",
-      "transparent": true,
-      "mask": 12
-    },
-    {
-      "name": "minecraft:trapped_chest",
+      "id": 146,
+      "name": "Trapped Chest",
       "color": "#ab792d",
       "transparent": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:light_weighted_pressure_plate",
+      "id": 147,
+      "name": "Weighted Pressure Plate (Light)",
       "color": "#fdfb4f",
       "transparent": true,
       "spawninside": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:heavy_weighted_pressure_plate",
+      "id": 148,
+      "name": "Weighted Pressure Plate (Heavy)",
       "color": "#e6e6e6",
       "transparent": true,
       "spawninside": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:redstone_comparator_(off)",
+      "id": 149,
+      "name": "Redstone Comparator (off)",
       "color": "#4f1010",
       "transparent": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:powered_comparator",
+      "id": 150,
+      "name": "Redstone Comparator (on)",
       "color": "#fd1010",
       "transparent": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:daylight_detector",
+      "id": 151,
+      "name": "Daylight Sensor",
       "color": "#d2c1ab",
       "transparent": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:redstone_block",
+      "id": 152,
+      "name": "Block of Redstone",
       "color": "#bb1c0a",
       "transparent": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:nether_quartz_ore",
+      "id": 153,
+      "name": "Nether Quartz Ore",
       "color": "#ddcbbe"
     },
     {
-      "name": "minecraft:hopper",
+      "id": 154,
+      "name": "Hopper",
       "color": "#444444",
       "transparent": true
     },
     {
-      "name": "minecraft:quartz_block",
-      "color": "#edebe5"
+      "id": 155,
+      "name": "Block of Quartz",
+      "color": "#edebe5",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Chiseled Quartz Block",
+          "color": "#e3dfd5"
+        },
+        {
+          "data": 2,
+          "name": "Pillar Quartz Block",
+          "color": "#e1dcd3"
+        },
+        {
+          "data": 3,
+          "name": "Pillar Quartz Block",
+          "color": "#e1dcd3"
+        },
+        {
+          "data": 4,
+          "name": "Pillar Quartz Block",
+          "color": "#e1dcd3"
+        }
+      ]
     },
     {
-      "name": "minecraft:chiseled_quartz_block",
-      "color": "#e3dfd5"
-    },
-    {
-      "name": "minecraft:quartz_pillar",
-      "color": "#e1dcd3"
-    },
-    {
-      "name": "minecraft:quartz_stairs",
+      "id": 156,
+      "name": "Quartz Stairs",
       "color": "#dfdacf",
       "transparent": true
     },
     {
-      "name": "minecraft:activator_rail",
+      "id": 157,
+      "name": "Activator Rail",
       "color": "#ab0301",
       "transparent": true,
       "spawninside": true
     },
     {
-      "name": "minecraft:dropper",
+      "id": 158,
+      "name": "Dropper",
       "color": "#848484"
     },
     {
-      "name": "minecraft:white_terracotta",
-      "color": "#d1b1a1"
+      "id": 159,
+      "name": "White Terracotta",
+      "color": "#d1b1a1",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Orange Terracotta",
+          "color": "#a55728"
+        },
+        {
+          "data": 2,
+          "name": "Magenta Terracotta",
+          "color": "#95586d"
+        },
+        {
+          "data": 3,
+          "name": "Light Blue Terracotta",
+          "color": "#6f6b89"
+        },
+        {
+          "data": 4,
+          "name": "Yellow Terracotta",
+          "color": "#b9821f"
+        },
+        {
+          "data": 5,
+          "name": "Lime Terracotta",
+          "color": "#667330"
+        },
+        {
+          "data": 6,
+          "name": "Pink Terracotta",
+          "color": "#a04b4e"
+        },
+        {
+          "data": 7,
+          "name": "Gray Terracotta",
+          "color": "#3a2a24"
+        },
+        {
+          "data": 8,
+          "name": "Silver Terracotta",
+          "color": "#876b62"
+        },
+        {
+          "data": 9,
+          "name": "Cyan Terracotta",
+          "color": "#565a5b"
+        },
+        {
+          "data": 10,
+          "name": "Purple Terracotta",
+          "color": "#734454"
+        },
+        {
+          "data": 11,
+          "name": "Blue Terracotta",
+          "color": "#4a3b5b"
+        },
+        {
+          "data": 12,
+          "name": "Brown Terracotta",
+          "color": "#4d3324"
+        },
+        {
+          "data": 13,
+          "name": "Green Terracotta",
+          "color": "#4e562c"
+        },
+        {
+          "data": 14,
+          "name": "Red Terracotta",
+          "color": "#8e3d2f"
+        },
+        {
+          "data": 15,
+          "name": "Black Terracotta",
+          "color": "#271912"
+        }
+      ]
     },
     {
-      "name": "minecraft:orange_terracotta",
-      "color": "#a55728"
-    },
-    {
-      "name": "minecraft:magenta_terracotta",
-      "color": "#95586d"
-    },
-    {
-      "name": "minecraft:light_blue_terracotta",
-      "color": "#6f6b89"
-    },
-    {
-      "name": "minecraft:yellow_terracotta",
-      "color": "#b9821f"
-    },
-    {
-      "name": "minecraft:lime_terracotta",
-      "color": "#667330"
-    },
-    {
-      "name": "minecraft:pink_terracotta",
-      "color": "#a04b4e"
-    },
-    {
-      "name": "minecraft:gray_terracotta",
-      "color": "#3a2a24"
-    },
-    {
-      "name": "minecraft:light_gray_terracotta",
-      "color": "#876b62"
-    },
-    {
-      "name": "minecraft:cyan_terracotta",
-      "color": "#565a5b"
-    },
-    {
-      "name": "minecraft:purple_terracotta",
-      "color": "#734454"
-    },
-    {
-      "name": "minecraft:blue_terracotta",
-      "color": "#4a3b5b"
-    },
-    {
-      "name": "minecraft:brown_terracotta",
-      "color": "#4d3324"
-    },
-    {
-      "name": "minecraft:green_terracotta",
-      "color": "#4e562c"
-    },
-    {
-      "name": "minecraft:red_terracotta",
-      "color": "#8e3d2f"
-    },
-    {
-      "name": "minecraft:black_terracotta",
-      "color": "#271912"
-    },
-    {
-      "name": "minecraft:white_stained_glass_pane",
+      "id": 160,
+      "name": "White Stained Glass Pane",
       "color": "#ededed",
       "alpha": 0.5,
-      "transparent": true
+      "transparent": true,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Orange Stained Glass Pane",
+          "color": "#c9762f"
+        },
+        {
+          "data": 2,
+          "name": "Magenta Stained Glass Pane",
+          "color": "#aa49cf"
+        },
+        {
+          "data": 3,
+          "name": "Light Blue Stained Glass Pane",
+          "color": "#5e8ec9"
+        },
+        {
+          "data": 4,
+          "name": "Yellow Stained Glass Pane",
+          "color": "#e4e432"
+        },
+        {
+          "data": 5,
+          "name": "Lime Stained Glass Pane",
+          "color": "#76bd17"
+        },
+        {
+          "data": 6,
+          "name": "Pink Stained Glass Pane",
+          "color": "#e1769a"
+        },
+        {
+          "data": 7,
+          "name": "Gray Stained Glass Pane",
+          "color": "#4c4c4c"
+        },
+        {
+          "data": 8,
+          "name": "Silver Stained Glass Pane",
+          "color": "#929292"
+        },
+        {
+          "data": 9,
+          "name": "Cyan Stained Glass Pane",
+          "color": "#4c7f98"
+        },
+        {
+          "data": 10,
+          "name": "Purple Stained Glass Pane",
+          "color": "#7f3fb1"
+        },
+        {
+          "data": 11,
+          "name": "Blue Stained Glass Pane",
+          "color": "#324cb1"
+        },
+        {
+          "data": 12,
+          "name": "Brown Stained Glass Pane",
+          "color": "#654c32"
+        },
+        {
+          "data": 13,
+          "name": "Green Stained Glass Pane",
+          "color": "#617a30"
+        },
+        {
+          "data": 14,
+          "name": "Red Stained Glass Pane",
+          "color": "#923030"
+        },
+        {
+          "data": 15,
+          "name": "Black Stained Glass Pane",
+          "color": "#191919"
+        }
+      ]
     },
     {
-      "name": "minecraft:orange_stained_glass_pane",
-      "color": "#c9762f",
-      "alpha": 0.5,
-      "transparent": true
+      "id": 161,
+      "name": "Acacia Leaves",
+      "color": "#515151",
+      "transparent": true,
+      "rendercube": true,
+      "biomeFoliage": true,
+      "mask": 1,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Dark Oak Leaves",
+          "color": "#515151",
+          "biomeFoliage": true
+        }
+      ]
     },
     {
-      "name": "minecraft:magenta_stained_glass_pane",
-      "color": "#aa49cf",
-      "alpha": 0.5,
-      "transparent": true
+      "id": 162,
+      "name": "Acacia Wood",
+      "color": "#b25b3b",
+      "mask": 1,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Dark Oak Wood",
+          "color": "#5d4931"
+        }
+      ]
     },
     {
-      "name": "minecraft:light_blue_stained_glass_pane",
-      "color": "#5e8ec9",
-      "alpha": 0.5,
-      "transparent": true
-    },
-    {
-      "name": "minecraft:yellow_stained_glass_pane",
-      "color": "#e4e432",
-      "alpha": 0.5,
-      "transparent": true
-    },
-    {
-      "name": "minecraft:lime_stained_glass_pane",
-      "color": "#76bd17",
-      "alpha": 0.5,
-      "transparent": true
-    },
-    {
-      "name": "minecraft:pink_stained_glass_pane",
-      "color": "#e1769a",
-      "alpha": 0.5,
-      "transparent": true
-    },
-    {
-      "name": "minecraft:gray_stained_glass_pane",
-      "color": "#4c4c4c",
-      "alpha": 0.5,
-      "transparent": true
-    },
-    {
-      "name": "minecraft:silver_stained_glass_pane",
-      "color": "#929292",
-      "alpha": 0.5,
-      "transparent": true
-    },
-    {
-      "name": "minecraft:cyan_stained_glass_pane",
-      "color": "#4c7f98",
-      "alpha": 0.5,
-      "transparent": true
-    },
-    {
-      "name": "minecraft:purple_stained_glass_pane",
-      "color": "#7f3fb1",
-      "alpha": 0.5,
-      "transparent": true
-    },
-    {
-      "name": "minecraft:blue_stained_glass_pane",
-      "color": "#324cb1",
-      "alpha": 0.5,
-      "transparent": true
-    },
-    {
-      "name": "minecraft:brown_stained_glass_pane",
-      "color": "#654c32",
-      "alpha": 0.5,
-      "transparent": true
-    },
-    {
-      "name": "minecraft:green_stained_glass_pane",
-      "color": "#617a30",
-      "alpha": 0.5,
-      "transparent": true
-    },
-    {
-      "name": "minecraft:red_stained_glass_pane",
-      "color": "#923030",
-      "alpha": 0.5,
-      "transparent": true
-    },
-    {
-      "name": "minecraft:black_stained_glass_pane",
-      "color": "#191919",
-      "alpha": 0.5,
-      "transparent": true
-    },
-    {
-      "name": "minecraft:acacia_stairs",
+      "id": 163,
+      "name": "Acacia Stairs",
       "color": "#a15730",
       "transparent": true
     },
     {
-      "name": "minecraft:dark_oak_stairs",
+      "id": 164,
+      "name": "Dark Oak Stairs",
       "color": "#492f17",
       "transparent": true
     },
     {
-      "name": "minecraft:slime_block",
+      "id": 165,
+      "name": "Slime Block",
       "color": "#59994a"
     },
     {
-      "name": "minecraft:barrier",
+      "id": 166,
+      "name": "Barrier",
       "color": "#000000",
-      "alpha": 0
+      "alpha": 0.0
     },
     {
-      "name": "minecraft:iron_trapdoor",
+      "id": 167,
+      "name": "Iron Trapdoor",
       "color": "#c7c7c7",
       "transparent": true
     },
     {
-      "name": "minecraft:prismarine",
-      "color": "#6baa97"
+      "id": 168,
+      "name": "Prismarine",
+      "color": "#6baa97",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Prismarine Bricks",
+          "color": "#64a08f"
+        },
+        {
+          "data": 2,
+          "name": "Dark Prismarine",
+          "color": "#3c584b"
+        }
+      ]
     },
     {
-      "name": "minecraft:prismarine_bricks",
-      "color": "#64a08f"
-    },
-    {
-      "name": "minecraft:dark_prismarine",
-      "color": "#3c584b"
-    },
-    {
-      "name": "minecraft:sea_lantern",
+      "id": 169,
+      "name": "Sea Lantern",
       "color": "#abc8be"
     },
     {
-      "name": "minecraft:hay_block",
+      "id": 170,
+      "name": "Hay Bale",
       "color": "#af9711"
     },
     {
-      "name": "minecraft:white_carpet",
+      "id": 171,
+      "name": "White Carpet",
       "color": "#dddddd",
-      "transparent": true
+      "transparent": true,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Orange Carpet",
+          "color": "#dd8143"
+        },
+        {
+          "data": 2,
+          "name": "Magenta Carpet",
+          "color": "#b650c0"
+        },
+        {
+          "data": 3,
+          "name": "Light Blue Carpet",
+          "color": "#8ea6d6"
+        },
+        {
+          "data": 4,
+          "name": "Yellow Carpet",
+          "color": "#c4b82e"
+        },
+        {
+          "data": 5,
+          "name": "Lime Carpet",
+          "color": "#53c347"
+        },
+        {
+          "data": 6,
+          "name": "Pink Carpet",
+          "color": "#cb778d"
+        },
+        {
+          "data": 7,
+          "name": "Gray Carpet",
+          "color": "#3b3b3b"
+        },
+        {
+          "data": 8,
+          "name": "Silver Carpet",
+          "color": "#aab0b0"
+        },
+        {
+          "data": 9,
+          "name": "Cyan Carpet",
+          "color": "#2d6a83"
+        },
+        {
+          "data": 10,
+          "name": "Purple Carpet",
+          "color": "#7537a9"
+        },
+        {
+          "data": 11,
+          "name": "Blue Carpet",
+          "color": "#323e9a"
+        },
+        {
+          "data": 12,
+          "name": "Brown Carpet",
+          "color": "#482e1c"
+        },
+        {
+          "data": 13,
+          "name": "Green Carpet",
+          "color": "#314119"
+        },
+        {
+          "data": 14,
+          "name": "Red Carpet",
+          "color": "#963330"
+        },
+        {
+          "data": 15,
+          "name": "Black Carpet",
+          "color": "#151111"
+        }
+      ]
     },
     {
-      "name": "minecraft:orange_carpet",
-      "color": "#dd8143",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:magenta_carpet",
-      "color": "#b650c0",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:light_blue_carpet",
-      "color": "#8ea6d6",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:yellow_carpet",
-      "color": "#c4b82e",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:lime_carpet",
-      "color": "#53c347",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:pink_carpet",
-      "color": "#cb778d",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:gray_carpet",
-      "color": "#3b3b3b",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:silver_carpet",
-      "color": "#aab0b0",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:cyan_carpet",
-      "color": "#2d6a83",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:purple_carpet",
-      "color": "#7537a9",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:blue_carpet",
-      "color": "#323e9a",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:brown_carpet",
-      "color": "#482e1c",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:green_carpet",
-      "color": "#314119",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:red_carpet",
-      "color": "#963330",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:black_carpet",
-      "color": "#151111",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:terracotta",
+      "id": 172,
+      "name": "Terracotta",
       "color": "#945a41"
     },
     {
-      "name": "minecraft:coal_block",
+      "id": 173,
+      "name": "Block of Coal",
       "color": "#2b2b2b"
     },
     {
-      "name": "minecraft:packed_ice",
+      "id": 174,
+      "name": "Packed Ice",
       "color": "#bfcee8"
     },
     {
-      "name": "minecraft:blue_ice",
-      "color": "#85b2ff"
-    },
-    {
-      "name": "minecraft:sunflower",
+      "id": 175,
+      "name": "Sunflower",
       "color": "#f1e424",
       "transparent": true,
-      "spawninside": true
+      "spawninside": true,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Lilac",
+          "color": "#9f78a4"
+        },
+        {
+          "data": 2,
+          "name": "Double Tallgrass",
+          "color": "#969696",
+          "biomeGrass": true
+        },
+        {
+          "data": 3,
+          "name": "Large Fern",
+          "color": "#828282",
+          "biomeGrass": true
+        },
+        {
+          "data": 4,
+          "name": "Rose Bush",
+          "color": "#ba050b"
+        },
+        {
+          "data": 5,
+          "name": "Peony",
+          "color": "#e6bff7"
+        },
+        {
+          "data": 8,
+          "name": "Large Flower (top part)",
+          "color": "#ffffff",
+          "alpha": 0.0
+        },
+        {
+          "data": 10,
+          "name": "Large Flower (top part)",
+          "color": "#ffffff",
+          "alpha": 0.0
+        }
+      ]
     },
     {
-      "name": "minecraft:lilac",
-      "color": "#9f78a4",
-      "transparent": true,
-      "spawninside": true
-    },
-    {
-      "name": "minecraft:tall_grass",
-      "color": "#969696",
-      "biomeGrass": true,
-      "transparent": true,
-      "spawninside": true
-    },
-    {
-      "name": "minecraft:large_fern",
-      "color": "#828282",
-      "biomeGrass": true,
-      "transparent": true,
-      "spawninside": true
-    },
-    {
-      "name": "minecraft:rose_bush",
-      "color": "#ba050b",
-      "transparent": true,
-      "spawninside": true
-    },
-    {
-      "name": "minecraft:peony",
-      "color": "#e6bff7",
-      "transparent": true,
-      "spawninside": true
-    },
-    {
-      "name": "minecraft:large_flower_(top_part)",
-      "color": "#ffffff",
-      "alpha": 0
-    },
-    {
-      "name": "minecraft:large_flower_(top_part)",
-      "color": "#ffffff",
-      "alpha": 0
-    },
-    {
-      "name": "minecraft:standing_banner",
-      "color": "#ffffff",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:wall_banner",
+      "id": 176,
+      "name": "Standing Banner",
       "color": "#ffffff",
       "transparent": true
     },
     {
-      "name": "minecraft:inverted_daylight_sensor",
+      "id": 177,
+      "name": "Wall Banner",
+      "color": "#ffffff",
+      "transparent": true
+    },
+    {
+      "id": 178,
+      "name": "Inverted Daylight Sensor",
       "color": "#d2c1ab",
       "transparent": true,
-      "canprovidepower": true
+      "canProvidePower": true
     },
     {
-      "name": "minecraft:red_sandstone",
-      "color": "#a6551e"
+      "id": 179,
+      "name": "Red Sandstone",
+      "color": "#a6551e",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Chiseled Red Sandstone",
+          "color": "#a2531c"
+        },
+        {
+          "data": 2,
+          "name": "Smooth Red Sandstone",
+          "color": "#a8561e"
+        }
+      ]
     },
     {
-      "name": "minecraft:chiseled_red_sandstone",
-      "color": "#a2531c"
-    },
-    {
-      "name": "minecraft:smooth_red_sandstone",
-      "color": "#a8561e"
-    },
-    {
-      "name": "minecraft:red_sandstone_stairs",
+      "id": 180,
+      "name": "Red Sandstone Stairs",
       "color": "#a6551e",
       "transparent": true
     },
     {
-      "name": "minecraft:double_red_sandstone_slab",
-      "color": "#a6551e"
+      "id": 181,
+      "name": "Double Red Sandstone Slab",
+      "color": "#a6551e",
+      "variants": [
+        {
+          "data": 8,
+          "name": "Full Red Sandstone Slab",
+          "color": "#a7551e"
+        }
+      ]
     },
     {
-      "name": "minecraft:full_red_sandstone_slab",
-      "color": "#a7551e"
-    },
-    {
-      "name": "minecraft:red_sandstone_slab",
+      "id": 182,
+      "name": "Red Sandstone Slab",
       "color": "#a7551e",
-      "transparent": true
+      "transparent": true,
+      "variants": [
+        {
+          "data": 8,
+          "name": "Upper Red Sandstone Slab",
+          "color": "#a7551e"
+        }
+      ]
     },
     {
-      "name": "minecraft:upper_red_sandstone_slab",
-      "color": "#a7551e"
-    },
-    {
-      "name": "minecraft:spruce_fence_gate",
+      "id": 183,
+      "name": "Spruce Fence Gate",
       "color": "#805e36",
       "alpha": 0.75,
       "transparent": true
     },
     {
-      "name": "minecraft:birch_fence_gate",
+      "id": 184,
+      "name": "Birch Fence Gate",
       "color": "#c8b77a",
       "alpha": 0.75,
       "transparent": true
     },
     {
-      "name": "minecraft:jungle_fence_gate",
+      "id": 185,
+      "name": "Jungle Fence Gate",
       "color": "#b1805c",
       "alpha": 0.75,
       "transparent": true
     },
     {
-      "name": "minecraft:dark_oak_fence_gate",
+      "id": 186,
+      "name": "Dark Oak Fence Gate",
       "color": "#462d15",
       "alpha": 0.75,
       "transparent": true
     },
     {
-      "name": "minecraft:acacia_fence_gate",
+      "id": 187,
+      "name": "Acacia Fence Gate",
       "color": "#ba6337",
       "alpha": 0.75,
       "transparent": true
     },
     {
-      "name": "minecraft:spruce_fence",
+      "id": 188,
+      "name": "Spruce Fence",
       "color": "#805e36",
       "alpha": 0.75,
       "transparent": true
     },
     {
-      "name": "minecraft:birch_fence",
+      "id": 189,
+      "name": "Birch Fence",
       "color": "#c8b77a",
       "alpha": 0.75,
       "transparent": true
     },
     {
-      "name": "minecraft:jungle_fence",
+      "id": 190,
+      "name": "Jungle Fence",
       "color": "#b1805c",
       "alpha": 0.75,
       "transparent": true
     },
     {
-      "name": "minecraft:dark_oak_fence",
+      "id": 191,
+      "name": "Dark Oak Fence",
       "color": "#462d15",
       "alpha": 0.75,
       "transparent": true
     },
     {
-      "name": "minecraft:acacia_fence",
+      "id": 192,
+      "name": "Acacia Fence",
       "color": "#ba6337",
       "alpha": 0.75,
       "transparent": true
     },
     {
-      "name": "minecraft:spruce_door",
+      "id": 193,
+      "name": "Spruce Door",
       "color": "#6e563b",
       "transparent": true
     },
     {
-      "name": "minecraft:birch_door",
+      "id": 194,
+      "name": "Birch Door",
       "color": "#d2caa3",
       "transparent": true
     },
     {
-      "name": "minecraft:jungle_door",
+      "id": 195,
+      "name": "Jungle Door",
       "color": "#ac7da3",
       "transparent": true
     },
     {
-      "name": "minecraft:acacia_door",
+      "id": 196,
+      "name": "Acacia Door",
       "color": "#a5615b",
       "transparent": true
     },
     {
-      "name": "minecraft:dark_oak_door",
+      "id": 197,
+      "name": "Dark Oak Door",
       "color": "#4a3118",
       "transparent": true
     },
     {
-      "name": "minecraft:end_rod",
+      "id": 198,
+      "name": "End Rod",
       "color": "#dcc5ce"
     },
     {
-      "name": "minecraft:chorus_plant",
+      "id": 199,
+      "name": "Chorus Plant",
       "color": "#603c60",
       "transparent": true
     },
     {
-      "name": "minecraft:chorus_flower",
+      "id": 200,
+      "name": "Chorus Flower",
       "color": "#866886",
-      "transparent": true
+      "transparent": true,
+      "variants": [
+        {
+          "data": 5,
+          "name": "Chorus Flower (fully grown)",
+          "color": "#624060"
+        }
+      ]
     },
     {
-      "name": "minecraft:chorus_flower_(fully_grown)",
-      "color": "#624060"
-    },
-    {
-      "name": "minecraft:purpur_block",
+      "id": 201,
+      "name": "Purpur Block",
       "color": "#a67aa6"
     },
     {
-      "name": "minecraft:purpur_pillar",
+      "id": 202,
+      "name": "Purpur Pillar",
       "color": "#ab80ab"
     },
     {
-      "name": "minecraft:purpur_stairs",
+      "id": 203,
+      "name": "Purpur Stairs",
       "color": "#a67aa6"
     },
     {
-      "name": "minecraft:purpur_double_slab",
+      "id": 204,
+      "name": "Double Purpur Slab",
       "color": "#a67aa6"
     },
     {
-      "name": "minecraft:purpur_slab",
+      "id": 205,
+      "name": "Purpur Slab",
       "color": "#a67aa6"
     },
     {
-      "name": "minecraft:end_stone_bricks",
+      "id": 206,
+      "name": "End Stone Bricks",
       "color": "#e2e7ab"
     },
     {
-      "name": "minecraft:immature_beetroot",
+      "id": 207,
+      "name": "Immature Beetroot",
       "color": "#02ab10",
-      "transparent": true
+      "transparent": true,
+      "variants": [
+        {
+          "data": 3,
+          "name": "Mature Beetroot",
+          "color": "#517136"
+        }
+      ]
     },
     {
-      "name": "minecraft:beetroots",
-      "color": "#517136"
-    },
-    {
-      "name": "minecraft:grass_path",
+      "id": 208,
+      "name": "Grass Path",
       "color": "#967d47"
     },
     {
-      "name": "minecraft:end_gateway",
+      "id": 209,
+      "name": "End Gateway Block",
       "color": "#000000"
     },
     {
-      "name": "minecraft:repeating_command_block",
+      "id": 210,
+      "name": "Repeating Command Block",
       "color": "#8170b0"
     },
     {
-      "name": "minecraft:chain_command_block",
+      "id": 211,
+      "name": "Chain Command Block",
       "color": "#87a398"
     },
     {
-      "name": "minecraft:frosted_ice",
+      "id": 212,
+      "name": "Frosted Ice",
       "color": "#77a9ff",
       "alpha": 0.62,
       "transparent": true,
       "rendercube": true
     },
     {
-      "name": "minecraft:magma_block",
+      "id": 213,
+      "name": "Magma Block",
       "color": "#87421a"
     },
     {
-      "name": "minecraft:nether_wart_block",
+      "id": 214,
+      "name": "Nether Wart Block",
       "color": "#750607"
     },
     {
-      "name": "minecraft:red_nether_bricks",
+      "id": 215,
+      "name": "Red Nether Brick",
       "color": "#440407"
     },
     {
-      "name": "minecraft:bone_block",
+      "id": 216,
+      "name": "Bone Block",
       "color": "#cec9b2"
     },
     {
-      "name": "minecraft:structure_void",
+      "id": 217,
+      "name": "Structure Void",
       "color": "#ffffff",
-      "alpha": 0,
+      "alpha": 0.0,
       "transparent": true,
       "spawninside": true
     },
     {
-      "name": "minecraft:observer",
+      "id": 218,
+      "name": "Observer",
       "color": "#535353"
     },
     {
-      "name": "minecraft:white_shulker_box",
+      "id": 219,
+      "name": "White Shulker Box",
       "color": "#dedbdb"
     },
     {
-      "name": "minecraft:orange_shulker_box",
+      "id": 220,
+      "name": "Orange Shulker Box",
       "color": "#ce7438"
     },
     {
-      "name": "minecraft:magenta_shulker_box",
+      "id": 221,
+      "name": "Magenta Shulker Box",
       "color": "#ba64c2"
     },
     {
-      "name": "minecraft:light_blue_shulker_box",
+      "id": 222,
+      "name": "Light Blue Shulker Box",
       "color": "#658ecb"
     },
     {
-      "name": "minecraft:yellow_shulker_box",
+      "id": 223,
+      "name": "Yellow Shulker Box",
       "color": "#c1b73d"
     },
     {
-      "name": "minecraft:lime_shulker_box",
+      "id": 224,
+      "name": "Lime Shulker Box",
       "color": "#47b73b"
     },
     {
-      "name": "minecraft:pink_shulker_box",
+      "id": 225,
+      "name": "Pink Shulker Box",
       "color": "#d08ca1"
     },
     {
-      "name": "minecraft:gray_shulker_box",
+      "id": 226,
+      "name": "Gray Shulker Box",
       "color": "#535151"
     },
     {
-      "name": "minecraft:light_gray_shulker_box",
+      "id": 227,
+      "name": "Light Gray Shulker Box",
       "color": "#a4a2a2"
     },
     {
-      "name": "minecraft:cyan_shulker_box",
+      "id": 228,
+      "name": "Cyan Shulker Box",
       "color": "#4488a4"
     },
     {
-      "name": "minecraft:purple_shulker_box",
+      "id": 229,
+      "name": "Purple Shulker Box",
       "color": "#976797"
     },
     {
-      "name": "minecraft:blue_shulker_box",
+      "id": 230,
+      "name": "Blue Shulker Box",
       "color": "#6571c9"
     },
     {
-      "name": "minecraft:brown_shulker_box",
+      "id": 231,
+      "name": "Brown Shulker Box",
       "color": "#8d705d"
     },
     {
-      "name": "minecraft:green_shulker_box",
+      "id": 232,
+      "name": "Green Shulker Box",
       "color": "#6f8254"
     },
     {
-      "name": "minecraft:red_shulker_box",
+      "id": 233,
+      "name": "Red Shulker Box",
       "color": "#c25855"
     },
     {
-      "name": "minecraft:black_shulker_box",
+      "id": 234,
+      "name": "Black Shulker Box",
       "color": "#383737"
     },
     {
-      "name": "minecraft:white_glazed_terracotta",
+      "id": 235,
+      "name": "White Glazed Terracotta",
       "color": "#ede8b2"
     },
     {
-      "name": "minecraft:orange_glazed_terracotta",
+      "id": 236,
+      "name": "Orange Glazed Terracotta",
       "color": "#be984e"
     },
     {
-      "name": "minecraft:magenta_glazed_terracotta",
+      "id": 237,
+      "name": "Magenta Glazed Terracotta",
       "color": "#cd61bb"
     },
     {
-      "name": "minecraft:light_blue_glazed_terracotta",
+      "id": 238,
+      "name": "Light Blue Glazed Terracotta",
       "color": "#458cc4"
     },
     {
-      "name": "minecraft:yellow_glazed_terracotta",
+      "id": 239,
+      "name": "Yellow Glazed Terracotta",
       "color": "#fbd972"
     },
     {
-      "name": "minecraft:lime_glazed_terracotta",
+      "id": 240,
+      "name": "Lime Glazed Terracotta",
       "color": "#8ac430"
     },
     {
-      "name": "minecraft:pink_glazed_terracotta",
+      "id": 241,
+      "name": "Pink Glazed Terracotta",
       "color": "#e89bb4"
     },
     {
-      "name": "minecraft:gray_glazed_terracotta",
+      "id": 242,
+      "name": "Gray Glazed Terracotta",
       "color": "#596063"
     },
     {
-      "name": "minecraft:light_gray_glazed_terracotta",
+      "id": 243,
+      "name": "Light Gray Glazed Terracotta",
       "color": "#a3acaf"
     },
     {
-      "name": "minecraft:cyan_glazed_terracotta",
+      "id": 244,
+      "name": "Cyan Glazed Terracotta",
       "color": "#3d8285"
     },
     {
-      "name": "minecraft:purple_glazed_terracotta",
+      "id": 245,
+      "name": "Purple Glazed Terracotta",
       "color": "#7c3fa7"
     },
     {
-      "name": "minecraft:blue_glazed_terracotta",
+      "id": 246,
+      "name": "Blue Glazed Terracotta",
       "color": "#31458f"
     },
     {
-      "name": "minecraft:brown_glazed_terracotta",
+      "id": 247,
+      "name": "Brown Glazed Terracotta",
       "color": "#956741"
     },
     {
-      "name": "minecraft:green_glazed_terracotta",
+      "id": 248,
+      "name": "Green Glazed Terracotta",
       "color": "#92a278"
     },
     {
-      "name": "minecraft:red_glazed_terracotta",
+      "id": 249,
+      "name": "Red Glazed Terracotta",
       "color": "#a92f2b"
     },
     {
-      "name": "minecraft:black_glazed_terracotta",
+      "id": 250,
+      "name": "Black Glazed Terracotta",
       "color": "#582528"
     },
     {
-      "name": "minecraft:white_concrete",
-      "color": "#d0d6d7"
+      "id": 251,
+      "name": "White Concrete",
+      "color": "#d0d6d7",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Orange Concrete",
+          "color": "#e16201"
+        },
+        {
+          "data": 2,
+          "name": "Magenta Concrete",
+          "color": "#aa31a0"
+        },
+        {
+          "data": 3,
+          "name": "Light Blue Concrete",
+          "color": "#2489c7"
+        },
+        {
+          "data": 4,
+          "name": "Yellow Concrete",
+          "color": "#f2b016"
+        },
+        {
+          "data": 5,
+          "name": "Lime Concrete",
+          "color": "#5fa919"
+        },
+        {
+          "data": 6,
+          "name": "Pink Concrete",
+          "color": "#d6658f"
+        },
+        {
+          "data": 7,
+          "name": "Gray Concrete",
+          "color": "#373a3e"
+        },
+        {
+          "data": 8,
+          "name": "Light Gray Concrete",
+          "color": "#7d7d73"
+        },
+        {
+          "data": 9,
+          "name": "Cyan Concrete",
+          "color": "#167788"
+        },
+        {
+          "data": 10,
+          "name": "Purple Concrete",
+          "color": "#65209d"
+        },
+        {
+          "data": 11,
+          "name": "Blue Concrete",
+          "color": "#2d2f90"
+        },
+        {
+          "data": 12,
+          "name": "Brown Concrete",
+          "color": "#613c20"
+        },
+        {
+          "data": 13,
+          "name": "Green Concrete",
+          "color": "#4a5c25"
+        },
+        {
+          "data": 14,
+          "name": "Red Concrete",
+          "color": "#8f2121"
+        },
+        {
+          "data": 15,
+          "name": "Black Concrete",
+          "color": "#080a0f"
+        }
+      ]
     },
     {
-      "name": "minecraft:orange_concrete",
-      "color": "#e16201"
+      "id": 252,
+      "name": "White Concrete Powder",
+      "color": "#e3e5e5",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Orange Concrete Powder",
+          "color": "#e48521"
+        },
+        {
+          "data": 2,
+          "name": "Magenta Concrete Powder",
+          "color": "#c154b8"
+        },
+        {
+          "data": 3,
+          "name": "Light Blue Concrete Powder",
+          "color": "#4bb6d6"
+        },
+        {
+          "data": 4,
+          "name": "Yellow Concrete Powder",
+          "color": "#e9c735"
+        },
+        {
+          "data": 5,
+          "name": "Lime Concrete Powder",
+          "color": "#7dbd2a"
+        },
+        {
+          "data": 6,
+          "name": "Pink Concrete Powder",
+          "color": "#e599b5"
+        },
+        {
+          "data": 7,
+          "name": "Gray Concrete Powder",
+          "color": "#4e5256"
+        },
+        {
+          "data": 8,
+          "name": "Light Gray Concrete Powder",
+          "color": "#9b9b94"
+        },
+        {
+          "data": 9,
+          "name": "Cyan Concrete Powder",
+          "color": "#25929c"
+        },
+        {
+          "data": 10,
+          "name": "Purple Concrete Powder",
+          "color": "#8438b2"
+        },
+        {
+          "data": 11,
+          "name": "Blue Concrete Powder",
+          "color": "#4649a7"
+        },
+        {
+          "data": 12,
+          "name": "Brown Concrete Powder",
+          "color": "#7d5536"
+        },
+        {
+          "data": 13,
+          "name": "Green Concrete Powder",
+          "color": "#61762e"
+        },
+        {
+          "data": 14,
+          "name": "Red Concrete Powder",
+          "color": "#a83633"
+        },
+        {
+          "data": 15,
+          "name": "Black Concrete Powder",
+          "color": "#1a1c21"
+        }
+      ]
     },
     {
-      "name": "minecraft:magenta_concrete",
-      "color": "#aa31a0"
-    },
-    {
-      "name": "minecraft:light_blue_concrete",
-      "color": "#2489c7"
-    },
-    {
-      "name": "minecraft:yellow_concrete",
-      "color": "#f2b016"
-    },
-    {
-      "name": "minecraft:lime_concrete",
-      "color": "#5fa919"
-    },
-    {
-      "name": "minecraft:pink_concrete",
-      "color": "#d6658f"
-    },
-    {
-      "name": "minecraft:gray_concrete",
-      "color": "#373a3e"
-    },
-    {
-      "name": "minecraft:light_gray_concrete",
-      "color": "#7d7d73"
-    },
-    {
-      "name": "minecraft:cyan_concrete",
-      "color": "#167788"
-    },
-    {
-      "name": "minecraft:purple_concrete",
-      "color": "#65209d"
-    },
-    {
-      "name": "minecraft:blue_concrete",
-      "color": "#2d2f90"
-    },
-    {
-      "name": "minecraft:brown_concrete",
-      "color": "#613c20"
-    },
-    {
-      "name": "minecraft:green_concrete",
-      "color": "#4a5c25"
-    },
-    {
-      "name": "minecraft:red_concrete",
-      "color": "#8f2121"
-    },
-    {
-      "name": "minecraft:black_concrete",
-      "color": "#080a0f"
-    },
-    {
-      "name": "minecraft:white_concrete_powder",
-      "color": "#e3e5e5"
-    },
-    {
-      "name": "minecraft:orange_concrete_powder",
-      "color": "#e48521"
-    },
-    {
-      "name": "minecraft:magenta_concrete_powder",
-      "color": "#c154b8"
-    },
-    {
-      "name": "minecraft:light_blue_concrete_powder",
-      "color": "#4bb6d6"
-    },
-    {
-      "name": "minecraft:yellow_concrete_powder",
-      "color": "#e9c735"
-    },
-    {
-      "name": "minecraft:lime_concrete_powder",
-      "color": "#7dbd2a"
-    },
-    {
-      "name": "minecraft:pink_concrete_powder",
-      "color": "#e599b5"
-    },
-    {
-      "name": "minecraft:gray_concrete_powder",
-      "color": "#4e5256"
-    },
-    {
-      "name": "minecraft:light_gray_concrete_powder",
-      "color": "#9b9b94"
-    },
-    {
-      "name": "minecraft:cyan_concrete_powder",
-      "color": "#25929c"
-    },
-    {
-      "name": "minecraft:purple_concrete_powder",
-      "color": "#8438b2"
-    },
-    {
-      "name": "minecraft:blue_concrete_powder",
-      "color": "#4649a7"
-    },
-    {
-      "name": "minecraft:brown_concrete_powder",
-      "color": "#7d5536"
-    },
-    {
-      "name": "minecraft:green_concrete_powder",
-      "color": "#61762e"
-    },
-    {
-      "name": "minecraft:red_concrete_powder",
-      "color": "#a83633"
-    },
-    {
-      "name": "minecraft:black_concrete_powder",
-      "color": "#1a1c21"
-    },
-    {
-      "name": "minecraft:tube_coral",
-      "color": "#3f5be2"
-    },
-    {
-      "name": "minecraft:brain_coral",
-      "color": "#e78dc0"
-    },
-    {
-      "name": "minecraft:bubble_coral",
-      "color": "#c819ba"
-    },
-    {
-      "name": "minecraft:fire_coral",
-      "color": "#e34036"
-    },
-    {
-      "name": "minecraft:horn_coral",
-      "color": "#e4da4a"
-    },
-    {
-      "name": "minecraft:tube_coral_fan",
-      "color": "#3f5be2"
-    },
-    {
-      "name": "minecraft:brain_coral_fan",
-      "color": "#e78dc0"
-    },
-    {
-      "name": "minecraft:bubble_coral_fan",
-      "color": "#c819ba"
-    },
-    {
-      "name": "minecraft:fire_coral_fan",
-      "color": "#e34036"
-    },
-    {
-      "name": "minecraft:horn_coral_fan",
-      "color": "#e4da4a"
-    },
-    {
-      "name": "minecraft:tube_coral_block",
-      "color": "#2642c9"
-    },
-    {
-      "name": "minecraft:brain_coral_block",
-      "color": "#ce74a7"
-    },
-    {
-      "name": "minecraft:bubble_coral_block",
-      "color": "#af00a1"
-    },
-    {
-      "name": "minecraft:fire_coral_block",
-      "color": "#ca271d"
-    },
-    {
-      "name": "minecraft:horn_coral_block",
-      "color": "#cbc131"
-    },
-    {
-      "name": "minecraft:sea_pickle",
-      "color": "#56644a"
-    },
-    {
-      "name": "minecraft:structure_block_save",
-      "color": "#564757"
-    },
-    {
-      "name": "minecraft:structure_block_load",
-      "color": "#453946"
-    },
-    {
-      "name": "minecraft:structure_block_corner",
-      "color": "#443945"
-    },
-    {
-      "name": "minecraft:structure_block_id",
-      "color": "#4f4150"
+      "id": 255,
+      "name": "Structure Block Save",
+      "color": "#564757",
+      "variants": [
+        {
+          "data": 1,
+          "name": "Structure Block Load",
+          "color": "#453946"
+        },
+        {
+          "data": 2,
+          "name": "Structure Block Corner",
+          "color": "#443945"
+        },
+        {
+          "data": 3,
+          "name": "Structure Block Data",
+          "color": "#4f4150"
+        }
+      ]
     }
   ],
   "update": "https://github.com/mrkite/minutor/raw/master/definitions/vanilla_ids.json"

--- a/flatteningconverter.cpp
+++ b/flatteningconverter.cpp
@@ -1,0 +1,89 @@
+/** Copyright (c) 2018, EtlamGit */
+
+#include <QDebug>
+#include <assert.h>
+#include <cmath>
+
+#include "./FlatteningConverter.h"
+#include "./json.h"
+
+
+
+FlatteningConverter::FlatteningConverter() {}
+
+FlatteningConverter::~FlatteningConverter() {}
+
+FlatteningConverter& FlatteningConverter::Instance() {
+  static FlatteningConverter singleton;
+  return singleton;
+}
+
+const BlockData * FlatteningConverter::getPalette() {
+  return palette;
+}
+
+void FlatteningConverter::enableDefinitions(int pack) {
+//  if (pack < 0) return;
+//  int len = packs[pack].length();
+//  for (int i = 0; i < len; i++)
+//    packs[pack][i]->enabled = true;
+}
+
+void FlatteningConverter::disableDefinitions(int pack) {
+//  if (pack < 0) return;
+//  int len = packs[pack].length();
+//  for (int i = 0; i < len; i++)
+//    packs[pack][i]->enabled = false;
+}
+
+int FlatteningConverter::addDefinitions(JSONArray *defs, int pack) {
+//  if (pack == -1) {
+//    pack = packs.length();
+//    packs.append(QList<BlockInfo*>());
+//  }
+  int len = defs->length();
+  for (int i = 0; i < len; i++)
+    parseDefinition(dynamic_cast<JSONObject *>(defs->at(i)), NULL, pack);
+  return pack;
+}
+
+void FlatteningConverter::parseDefinition(
+        JSONObject *b,
+        int *parentID,
+        int pack) {
+
+  // get the ancient block ID
+  int bid;
+  if (parentID == NULL) {
+    bid = b->at("id")->asNumber();
+  } else {
+    bid = *parentID;
+    int data = b->at("data")->asNumber();
+    bid |= data << 8;
+  }
+
+  // try to translate old block name into new flatname
+  QString flatname;
+  if (b->has("name")) {
+    flatname = "minecraft:" + b->at("name")->asString().toLower().replace(" ", "_");
+  } else if (parentID != NULL) {
+    flatname = palette[*parentID].name;
+  } else {
+    flatname = "Unknown";
+  }
+
+  // or use provided flatname instead
+  if (b->has("flatname"))
+    flatname = b->at("flatname")->asString();
+
+  palette[bid].name = flatname;
+  //  packs[pack].append(block);
+
+  // recursive parsing of variants (with data)
+  if (b->has("variants")) {
+    JSONArray *variants = dynamic_cast<JSONArray *>(b->at("variants"));
+    int vlen = variants->length();
+    for (int j = 0; j < vlen; j++)
+      parseDefinition(dynamic_cast<JSONObject *>(variants->at(j)), &bid, pack);
+  }
+}

--- a/flatteningconverter.cpp
+++ b/flatteningconverter.cpp
@@ -18,7 +18,8 @@ FlatteningConverter& FlatteningConverter::Instance() {
   return singleton;
 }
 
-const BlockData * FlatteningConverter::getPalette() {
+//const BlockData * FlatteningConverter::getPalette() {
+BlockData * FlatteningConverter::getPalette() {
   return palette;
 }
 
@@ -53,12 +54,12 @@ void FlatteningConverter::parseDefinition(
         int pack) {
 
   // get the ancient block ID
-  int bid;
+  int bid, data(0);
   if (parentID == NULL) {
     bid = b->at("id")->asNumber();
   } else {
     bid = *parentID;
-    int data = b->at("data")->asNumber();
+    data = b->at("data")->asNumber();
     bid |= data << 8;
   }
 
@@ -77,6 +78,12 @@ void FlatteningConverter::parseDefinition(
     flatname = b->at("flatname")->asString();
 
   palette[bid].name = flatname;
+  if ((parentID == NULL) && (data == 0)) {
+    // spread main block type for data == 0
+    for (int d=1; d<16; d++) {
+      palette[bid|d<<8].name = flatname;
+    }
+  }
   //  packs[pack].append(block);
 
   // recursive parsing of variants (with data)

--- a/flatteningconverter.h
+++ b/flatteningconverter.h
@@ -1,0 +1,33 @@
+/** Copyright (c) 2018, EtlamGit */
+#ifndef FLATTENINGCONVERTER_H_
+#define FLATTENINGCONVERTER_H_
+
+#include "./blockdata.h"
+
+class JSONArray;
+class JSONObject;
+
+
+class FlatteningConverter {
+public:
+  // singleton: access to global usable instance
+  static FlatteningConverter &Instance();
+
+  int addDefinitions(JSONArray *, int pack = -1);
+  void enableDefinitions(int id);
+  void disableDefinitions(int id);
+  const BlockData * getPalette();
+
+private:
+  // singleton: prevent access to constructor and copyconstructor
+  FlatteningConverter();
+  ~FlatteningConverter();
+  FlatteningConverter(const FlatteningConverter &);
+  FlatteningConverter &operator=(const FlatteningConverter &);
+
+  void parseDefinition(JSONObject *block, int *parentID, int pack);
+  BlockData palette[16*256];  // 4 bit data + 8 bit ID
+//  QList<QList<BlockInfo*> > packs;
+};
+
+#endif  // FLATTENINGCONVERTER_H_

--- a/flatteningconverter.h
+++ b/flatteningconverter.h
@@ -16,7 +16,8 @@ public:
   int addDefinitions(JSONArray *, int pack = -1);
   void enableDefinitions(int id);
   void disableDefinitions(int id);
-  const BlockData * getPalette();
+//  const BlockData * getPalette();
+  BlockData * getPalette();
 
 private:
   // singleton: prevent access to constructor and copyconstructor

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -450,8 +450,7 @@ void MapView::renderChunk(Chunk *chunk) {
         //int data = section->getData(offset, y);
 
         // get BlockInfo from block value
-        BlockInfo &block = blocks->getBlock(section->getBlock(offset, y), 0);
-                                            // data);
+        BlockInfo &block = blocks->getBlock(section->getBlock(offset, y));
         if (block.alpha == 0.0) continue;
 
         // get light value from one block above
@@ -525,33 +524,33 @@ void MapView::renderChunk(Chunk *chunk) {
             blidB = sectionB->getBlock(offset, y-1);
             // dataB = sectionB->getData(offset, y-1);
           }
-          BlockInfo &block2 = blocks->getBlock(blid2, 0);//data2);
-          BlockInfo &block1 = blocks->getBlock(blid1, 0);//data1);
+          BlockInfo &block2 = blocks->getBlock(blid2);
+          BlockInfo &block1 = blocks->getBlock(blid1);
           BlockInfo &block0 = block;
-          BlockInfo &blockB = blocks->getBlock(blidB, 0);//dataB);
+          BlockInfo &blockB = blocks->getBlock(blidB);
           int light0 = section->getBlockLight(offset, y);
 
-          // // spawn check #1: on top of solid block
-          // if (block0.doesBlockHaveSolidTopSurface(data) &&
-          //     !block0.isBedrock() && light1 < 8 &&
-          //     !block1.isBlockNormalCube() && block1.spawninside &&
-          //     !block1.isLiquid() &&
-          //     !block2.isBlockNormalCube() && block2.spawninside) {
-          //   colr = (colr + 256) / 2;
-          //   colg = (colg + 0) / 2;
-          //   colb = (colb + 192) / 2;
-          // }
-          // // spawn check #2: current block is transparent,
-          // // but mob can spawn through (e.g. snow)
-          // if (blockB.doesBlockHaveSolidTopSurface(dataB) &&
-          //     !blockB.isBedrock() && light0 < 8 &&
-          //     !block0.isBlockNormalCube() && block0.spawninside &&
-          //     !block0.isLiquid() &&
-          //     !block1.isBlockNormalCube() && block1.spawninside) {
-          //   colr = (colr + 192) / 2;
-          //   colg = (colg + 0) / 2;
-          //   colb = (colb + 256) / 2;
-          // }
+           // spawn check #1: on top of solid block
+           if (block0.doesBlockHaveSolidTopSurface() &&
+               !block0.isBedrock() && light1 < 8 &&
+               !block1.isBlockNormalCube() && block1.spawninside &&
+               !block1.isLiquid() &&
+               !block2.isBlockNormalCube() && block2.spawninside) {
+             colr = (colr + 256) / 2;
+             colg = (colg + 0) / 2;
+             colb = (colb + 192) / 2;
+           }
+           // spawn check #2: current block is transparent,
+           // but mob can spawn through (e.g. snow)
+           if (blockB.doesBlockHaveSolidTopSurface() &&
+               !blockB.isBedrock() && light0 < 8 &&
+               !block0.isBlockNormalCube() && block0.spawninside &&
+               !block0.isLiquid() &&
+               !block1.isBlockNormalCube() && block1.spawninside) {
+             colr = (colr + 192) / 2;
+             colg = (colg + 0) / 2;
+             colb = (colb + 256) / 2;
+           }
         }
         if (flags & flgBiomeColors) {
           colr = biome.colors[light].red();
@@ -590,7 +589,7 @@ void MapView::renderChunk(Chunk *chunk) {
           // get data value
           // int data = section->getData(offset, y);
           // get BlockInfo from block value
-          BlockInfo &block = blocks->getBlock(section->getBlock(offset, y), 0);//data);
+          BlockInfo &block = blocks->getBlock(section->getBlock(offset, y));
           if (block.transparent) {
             cave_factor -= caveshade[cave_test];
           }
@@ -636,8 +635,7 @@ void MapView::getToolTip(int x, int z) {
       int yoffset = (y & 0xf) << 8;
       //int data = section->data[(offset + yoffset) / 2];
       //if (x & 1) data >>= 4;
-      auto &block = blocks->getBlock(section->getBlock(offset, y), 0);
-                                     // data & 0xf);
+      auto &block = blocks->getBlock(section->getBlock(offset, y));
       if (block.alpha == 0.0) continue;
       // found block
       name = block.getName();

--- a/minutor.pro
+++ b/minutor.pro
@@ -43,7 +43,9 @@ HEADERS += \
     zipreader.h \
     clamp.h \
     jumpto.h \
-    pngexport.h
+    pngexport.h \
+    flatteningconverter.h \
+    blockdata.h
 SOURCES += \
 	  labelledslider.cpp \
     biomeidentifier.cpp \
@@ -68,7 +70,8 @@ SOURCES += \
     worldsave.cpp \
     zipreader.cpp \
     jumpto.cpp \
-    pngexport.cpp
+    pngexport.cpp \
+    flatteningconverter.cpp
 RESOURCES = minutor.qrc
 
 win32:SOURCES += zlib/adler32.c \

--- a/minutor.qrc
+++ b/minutor.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/">
         <file>definitions/vanilla_biomes.json</file>
         <file>definitions/vanilla_ids.json</file>
+        <file>definitions/vanilla_blocks.json</file>
         <file>definitions/vanilla_dims.json</file>
         <file>definitions/vanilla_entity.json</file>
     </qresource>


### PR DESCRIPTION
This is the first approach to be able to load old and 1.13 version maps with the same version of Minutor.

At least here it is working with different maps. Some trillion block definitions are still missing, as Mojang renamed also a lot of blocks: https://minecraft.gamepedia.com/1.13/Flattening#Block_and_Item_IDs
I have added them for grass_block, tall_grass and vine just for test purpose. As they are highlighted and named in Minutor it should be easy to rule that out.

There are several other drawbacks in the new 1.13 definitions and code. I will try to address some of them in the rest of the year, but for now we have same starting point.
* definitions are way from complete, also colors for added blocks are wrong
* performance is very slow, this is probably because of all that strings. I will try to replace that with hashes.

(now pulling to correct branch)