### PR TITLE
add definitions for missing 1.13 Blocks

### DIFF
--- a/blockdata.h
+++ b/blockdata.h
@@ -7,6 +7,7 @@
 
 class BlockData {
  public:
+  uint    hid;   // we use hashed name as ID
   QString name;
   QMap<QString, QVariant> properties;
 };

--- a/blockidentifier.h
+++ b/blockidentifier.h
@@ -73,10 +73,10 @@ class BlockIdentifier {
   int addDefinitions(JSONArray *, int pack = -1);
   void enableDefinitions(int id);
   void disableDefinitions(int id);
-  BlockInfo &getBlock(QString name);
+  BlockInfo &getBlockInfo(uint hid);
  private:
   void parseDefinition(JSONObject *block, BlockInfo *parent, int pack);
-  QMap<QString, BlockInfo*> blocks;
+  QMap<uint, BlockInfo*> blocks;
   QList<QList<BlockInfo*> > packs;
 };
 

--- a/chunk.cpp
+++ b/chunk.cpp
@@ -147,6 +147,7 @@ void Chunk::loadSection1519(ChunkSection *cs, const Tag *section) {
   cs->palette = new BlockData[cs->paletteLength];
   for (int j = 0; j < rawPalette->length(); j++) {
     cs->palette[j].name = rawPalette->at(j)->at("Name")->toString();
+    cs->palette[j].hid  = qHash(cs->palette[j].name);
     if (rawPalette->at(j)->has("Properties"))
       cs->palette[j].properties = rawPalette->at(j)->at("Properties")->getData().toMap();
   }
@@ -173,10 +174,10 @@ Chunk::~Chunk() {
       if (sections[i]) {
         if (sections[i]->paletteLength > 0) {
           delete[] sections[i]->palette;
-          sections[i]->paletteLength = 0;
-        } else {
-          sections[i]->palette = NULL;
         }
+        sections[i]->paletteLength = 0;
+        sections[i]->palette = NULL;
+
         delete sections[i];
         sections[i] = NULL;
       }
@@ -184,16 +185,16 @@ Chunk::~Chunk() {
 }
 
 
-QString ChunkSection::getBlock(int x, int y, int z) {
+uint ChunkSection::getBlock(int x, int y, int z) {
   int xoffset = x;
   int yoffset = (y & 0x0f) << 8;
   int zoffset = z << 4;
-  return palette[blocks[xoffset + yoffset + zoffset]].name;
+  return palette[blocks[xoffset + yoffset + zoffset]].hid;
 }
 
-QString ChunkSection::getBlock(int offset, int y) {
+uint ChunkSection::getBlock(int offset, int y) {
   int yoffset = (y & 0x0f) << 8;
-  return palette[blocks[offset + yoffset]].name;
+  return palette[blocks[offset + yoffset]].hid;
 }
 
 quint8 ChunkSection::getSkyLight(int x, int y, int z) {

--- a/chunk.cpp
+++ b/chunk.cpp
@@ -185,16 +185,16 @@ Chunk::~Chunk() {
 }
 
 
-uint ChunkSection::getBlock(int x, int y, int z) {
+const BlockData & ChunkSection::getBlockData(int x, int y, int z) {
   int xoffset = x;
   int yoffset = (y & 0x0f) << 8;
   int zoffset = z << 4;
-  return palette[blocks[xoffset + yoffset + zoffset]].hid;
+  return palette[blocks[xoffset + yoffset + zoffset]];
 }
 
-uint ChunkSection::getBlock(int offset, int y) {
+const BlockData & ChunkSection::getBlockData(int offset, int y) {
   int yoffset = (y & 0x0f) << 8;
-  return palette[blocks[offset + yoffset]].hid;
+  return palette[blocks[offset + yoffset]];
 }
 
 quint8 ChunkSection::getSkyLight(int x, int y, int z) {

--- a/chunk.cpp
+++ b/chunk.cpp
@@ -32,7 +32,9 @@ void Chunk::load(const NBT &nbt) {
     this->sections[i] = NULL;
   highest = 0;
 
-  int version = nbt.at("DataVersion")->toInt();
+  int version = 0;
+  if (nbt.has("DataVersion"))
+    version = nbt.at("DataVersion")->toInt();
   const Tag * level = nbt.at("Level");
   chunkX = level->at("xPos")->toInt();
   chunkZ = level->at("zPos")->toInt();
@@ -58,7 +60,7 @@ void Chunk::load(const NBT &nbt) {
     if (version >= 1519)
       loadSection1519(cs, section);
     else
-      loadSection1000(cs, section);
+      loadSection1343(cs, section);
 
     int idx = section->at("Y")->toInt();
     this->sections[idx] = cs;
@@ -88,27 +90,49 @@ void Chunk::load(const NBT &nbt) {
   }
 }
 
-void Chunk::loadSection1000(ChunkSection *cs, const Tag *section) {
+// supported DataVersions:
+//    0 = 1.8 and below
+//
+//  169 = 1.9
+//  175 = 1.9.1
+//  176 = 1.9.2
+//  183 = 1.9.3
+//  184 = 1.9.4
+//
+//  510 = 1.10
+//  511 = 1.10.1
+//  512 = 1.10.2
+//
+//  819 = 1.11
+//  921 = 1.11.1
+//  922 = 1.11.2
+//
+// 1139 = 1.12
+// 1241 = 1.12.1
+// 1343 = 1.12.2
+void Chunk::loadSection1343(ChunkSection *cs, const Tag *section) {
+  // copy raw data
   quint8 blocks[4096];
   quint8 data[2048];
   memcpy(blocks, section->at("Blocks")->toByteArray(), 4096);
   memcpy(data,   section->at("Data")->toByteArray(),   2048);
   memcpy(cs->blockLight, section->at("BlockLight")->toByteArray(), 2048);
+
   // convert old BlockID + data into virtual ID
   for (int i = 0; i < 4096; i++) {
-    int d = data[i>>1];
-    if (i & 1) d >>= 4;
-    int bid = blocks[i];
+    int d = data[i>>1];         // get raw data (two nibbles)
+    if (i & 1) d >>= 4;         // get one nibble of data
     cs->blocks[i] = blocks[i] | ((d & 0x0f) << 8);
   }
-// todo: identify this even more ancient stuff ???
-//  if (section->has("Add")) {
-//    raw = section->at("Add")->toByteArray();
-//    for (int i = 0; i < 2048; i++) {
-//      cs->blocks[i * 2] |= (raw[i] & 0xf) << 8;
-//      cs->blocks[i * 2 + 1] |= (raw[i] & 0xf0) << 4;
-//    }
-//  }
+
+  // parse optional "Add" part for higher block IDs in mod packs
+  if (section->has("Add")) {
+    auto raw = section->at("Add")->toByteArray();
+    for (int i = 0; i < 2048; i++) {
+      cs->blocks[i * 2] |= (raw[i] & 0xf) << 8;
+      cs->blocks[i * 2 + 1] |= (raw[i] & 0xf0) << 4;
+    }
+  }
 
   // link to Converter palette
   cs->paletteLength = 0;

--- a/chunk.h
+++ b/chunk.h
@@ -12,8 +12,8 @@
 
 class ChunkSection {
  public:
-  uint   getBlock(int x, int y, int z);
-  uint   getBlock(int offset, int y);
+  const BlockData & getBlockData(int x, int y, int z);
+  const BlockData & getBlockData(int offset, int y);
   quint8 getSkyLight(int x, int y, int z);
   quint8 getSkyLight(int offset, int y);
   quint8 getBlockLight(int x, int y, int z);

--- a/chunk.h
+++ b/chunk.h
@@ -34,7 +34,7 @@ class Chunk {
   void load(const NBT &nbt);
   ~Chunk();
  protected:
-  void loadSection1000(ChunkSection *cs, const Tag *section);
+  void loadSection1343(ChunkSection *cs, const Tag *section);
   void loadSection1519(ChunkSection *cs, const Tag *section);
 
 

--- a/chunk.h
+++ b/chunk.h
@@ -9,20 +9,19 @@
 #include "./entity.h"
 #include "./blockdata.h"
 
-class BlockIdentifier;
-
 
 class ChunkSection {
  public:
-  QString getBlock(int x, int y, int z);
-  QString getBlock(int offset, int y);
-  quint8  getSkyLight(int x, int y, int z);
-  quint8  getSkyLight(int offset, int y);
-  quint8  getBlockLight(int x, int y, int z);
-  quint8  getBlockLight(int offset, int y);
+  uint   getBlock(int x, int y, int z);
+  uint   getBlock(int offset, int y);
+  quint8 getSkyLight(int x, int y, int z);
+  quint8 getSkyLight(int offset, int y);
+  quint8 getBlockLight(int x, int y, int z);
+  quint8 getBlockLight(int offset, int y);
 
   BlockData *palette;
-  int paletteLength;
+  int        paletteLength;
+
   quint16 blocks[16*16*16];
   quint8  skyLight[16*16*16/2];
   quint8  blockLight[16*16*16/2];

--- a/definitions/vanilla_biomes.json
+++ b/definitions/vanilla_biomes.json
@@ -282,63 +282,63 @@
     {
       "id": 40,
       "name": "Small End Islands",
-      "color": "#282898"
+      "color": "#8080ff"
     },
     {
       "id": 41,
       "name": "End Midlands",
-      "color": "#282898"
+      "color": "#8080ff"
     },
     {
       "id": 42,
       "name": "End Highlands",
-      "color": "#282898"
+      "color": "#8080ff"
     },
     {
       "id": 43,
       "name": "End Barrens",
-      "color": "#282898"
+      "color": "#8080ff"
     },
     {
       "id": 44,
       "name": "Warm Ocean",
-      "color": "#000070",
+      "color": "#0000ac",
       "watermodifier": "#cfc9f8"
     },
     {
       "id": 45,
       "name": "Lukewarm Ocean",
-      "color": "#000070",
+      "color": "#000090",
       "watermodifier": "#d7caef"
     },
     {
       "id": 46,
       "name": "Cold Ocean",
-      "color": "#000070",
+      "color": "#202070",
       "watermodifier": "#e9cddd"
     },
     {
       "id": 47,
       "name": "Deep Warm Ocean",
-      "color": "#000070",
+      "color": "#000050",
       "watermodifier": "#d3c9f3"
     },
     {
       "id": 48,
       "name": "Deep Lukewarm Ocean",
-      "color": "#000070",
+      "color": "#000040",
       "watermodifier": "#dccbea"
     },
     {
       "id": 49,
       "name": "Deep Cold Ocean",
-      "color": "#000070",
+      "color": "#202038",
       "watermodifier": "#edced8"
     },
     {
       "id": 50,
       "name": "Deep Frozen Ocean",
-      "color": "#000070",
+      "color": "#404090",
       "watermodifier": "#f6d0d0"
     },
     {

--- a/definitions/vanilla_blocks.json
+++ b/definitions/vanilla_blocks.json
@@ -391,41 +391,51 @@
     {
       "name": "minecraft:tall_seagrass",
       "color": "#006428",
-      "biomeGrass": true
-    },
-    {
-      "name": "minecraft:seagrass",
-      "color": "#006428",
-      "biomeGrass": true
-    },
-    {
-      "name": "minecraft:tall_grass",
-      "color": "#946428",
       "alpha": 0.3,
       "transparent": true,
       "spawninside": true
     },
     {
-      "name": "minecraft:tallgrass",
+      "name": "minecraft:seagrass",
+      "color": "#006428",
+      "alpha": 0.3,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:grass",
       "color": "#909090",
-      "biomeGrass": true
+      "biomeGrass": true,
+      "alpha": 0.3,
+      "transparent": true,
+      "spawninside": true
     },
     {
       "name": "minecraft:kelp",
-      "color": "#003013"
+      "color": "#003013",
+      "alpha": 0.3,
+      "transparent": true,
+      "spawninside": true
     },
     {
       "name": "minecraft:kelp_plant",
-      "color": "#003013"
+      "color": "#003013",
+      "alpha": 0.3,
+      "transparent": true,
+      "spawninside": true
     },
     {
       "name": "minecraft:fern",
       "color": "#828282",
-      "biomeGrass": true
+      "biomeGrass": true,
+      "alpha": 0.3,
+      "transparent": true,
+      "spawninside": true
     },
     {
       "name": "minecraft:dead_bush",
       "color": "#946428",
+      "alpha": 0.3,
       "transparent": true,
       "spawninside": true,
       "alpha": 0.3
@@ -642,7 +652,7 @@
       "transparent": true
     },
     {
-      "name": "minecraft:mob_spawner",
+      "name": "minecraft:spawner",
       "color": "#1b2a35",
       "transparent": true,
       "rendercube": true
@@ -757,6 +767,41 @@
       "canprovidepower": true
     },
     {
+      "name": "minecraft:spruce_pressure_plate",
+      "color": "#bc9862",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:birch_pressure_plate",
+      "color": "#bc9862",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:jungle_pressure_plate",
+      "color": "#bc9862",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:acacia_pressure_plate",
+      "color": "#bc9862",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:dark_oak_pressure_plate",
+      "color": "#bc9862",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
       "name": "minecraft:redstone_ore",
       "color": "#8f0303"
     },
@@ -802,9 +847,9 @@
     {
       "name": "minecraft:sugar_cane",
       "color": "#97c06b",
+      "biomeGrass": true,
       "spawninside": true,
-      "transparent": true,
-      "biomeGrass": true
+      "transparent": true
     },
     {
       "name": "minecraft:jukebox",
@@ -986,12 +1031,12 @@
       "color": "#797979"
     },
     {
-      "name": "minecraft:mossy_stone_bricks",
-      "color": "#637049"
-    },
-    {
       "name": "minecraft:cracked_stone_bricks",
       "color": "#656565"
+    },
+    {
+      "name": "minecraft:mossy_stone_bricks",
+      "color": "#637049"
     },
     {
       "name": "minecraft:chiseled_stone_bricks",
@@ -1227,12 +1272,44 @@
       "transparent": true
     },
     {
+      "name": "minecraft:potted_dandelion",
+      "color": "#f1f902"
+    },
+    {
       "name": "minecraft:potted_poppy",
       "color": "#910205"
     },
     {
-      "name": "minecraft:potted_dandelion",
-      "color": "#f1f902"
+      "name": "minecraft:potted_blue_orchid",
+      "color": "#29aefb"
+    },
+    {
+      "name": "minecraft:potted_allium",
+      "color": "#b865fb"
+    },
+    {
+      "name": "minecraft:potted_azure_bluet",
+      "color": "#e4eaf2"
+    },
+    {
+      "name": "minecraft:potted_red_tulip",
+      "color": "#d33a17"
+    },
+    {
+      "name": "minecraft:potted_orange_tulip",
+      "color": "#de731f"
+    },
+    {
+      "name": "minecraft:potted_white_tulip",
+      "color": "#e7e7e7"
+    },
+    {
+      "name": "minecraft:potted_pink_tulip",
+      "color": "#eabeea"
+    },
+    {
+      "name": "minecraft:potted_oxeye_daisy",
+      "color": "#eae6ad"
     },
     {
       "name": "minecraft:potted_oak_sapling",
@@ -1251,6 +1328,22 @@
       "color": "#2c6c18"
     },
     {
+      "name": "minecraft:potted_acacia_sapling",
+      "color": "#946428"
+    },
+    {
+      "name": "minecraft:potted_dark_oak_sapling",
+      "color": "#315e05"
+    },
+    {
+      "name": "minecraft:potted_fern",
+      "color": "#315e05"
+    },
+    {
+      "name": "minecraft:potted_dead_bush",
+      "color": "#946428"
+    },
+    {
       "name": "minecraft:potted_red_mushroom",
       "color": "#9a171c"
     },
@@ -1263,34 +1356,8 @@
       "color": "#128a20"
     },
     {
-      "name": "minecraft:potted_dead_bush",
-      "color": "#946428"
-    },
-    {
-      "name": "minecraft:potted_fern",
-      "color": "#315e05"
-    },
-    {
-      "name": "minecraft:potted_acacia_sapling",
-      "color": "#946428"
-    },
-    {
-      "name": "minecraft:potted_dark_oak_sapling",
-      "color": "#315e05"
-    },
-    {
-      "name": "minecraft:immature_carrots",
-      "color": "#00c617",
-      "transparent": true
-    },
-    {
       "name": "minecraft:carrots",
       "color": "#004e00"
-    },
-    {
-      "name": "minecraft:immature_potatoes",
-      "color": "#00c617",
-      "transparent": true
     },
     {
       "name": "minecraft:potatoes",
@@ -1903,12 +1970,7 @@
       "color": "#e2e7ab"
     },
     {
-      "name": "minecraft:immature_beetroot",
-      "color": "#02ab10",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:beetroots",
+      "name": "minecraft:beetroot",
       "color": "#517136"
     },
     {

--- a/definitions/vanilla_blocks.json
+++ b/definitions/vanilla_blocks.json
@@ -369,12 +369,16 @@
       "color": "#dfd7a5"
     },
     {
+      "name": "minecraft:cut_sandstone",
+      "color": "#d9d29a"
+    },
+    {
       "name": "minecraft:chiseled_sandstone",
       "color": "#ddd8ab"
     },
     {
-      "name": "minecraft:cut_sandstone",
-      "color": "#d9d29a"
+      "name": "minecraft:smooth_stone",
+      "color": "#d9d9d9"
     },
     {
       "name": "minecraft:smooth_sandstone",
@@ -387,6 +391,86 @@
     {
       "name": "minecraft:bed",
       "color": "#8c1616",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:white_bed",
+      "color": "#eaeaea",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:orange_bed",
+      "color": "#db7b3b",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:magenta_bed",
+      "color": "#af44b8",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:light_blue_bed",
+      "color": "#7e99d0",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:yellow_bed",
+      "color": "#bcb02a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:lime_bed",
+      "color": "#44b93b",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:pink_bed",
+      "color": "#d28a9e",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:gray_bed",
+      "color": "#454545",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:light_gray_bed",
+      "color": "#909898",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:cyan_bed",
+      "color": "#30728e",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:purple_bed",
+      "color": "#7737ad",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:blue_bed",
+      "color": "#2b3585",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:brown_bed",
+      "color": "#563822",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:green_bed",
+      "color": "#314119",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:red_bed",
+      "color": "#91312f",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:black_bed",
+      "color": "#1d1b1b",
       "transparent": true
     },
     {
@@ -436,13 +520,20 @@
     },
     {
       "name": "minecraft:kelp",
-      "color": "#003013",
+      "color": "#59ab30",
       "alpha": 0.3,
       "transparent": true,
       "spawninside": true
     },
     {
       "name": "minecraft:kelp_plant",
+      "color": "#59ab30",
+      "alpha": 0.3,
+      "transparent": true,
+      "spawninside": true
+    },
+    {
+      "name": "minecraft:dried_kelp_block",
       "color": "#003013",
       "alpha": 0.3,
       "transparent": true,
@@ -622,6 +713,11 @@
     {
       "name": "minecraft:cobblestone_slab",
       "color": "#8f8f8f"
+    },
+    {
+      "name": "minecraft:petrified_oak_slab",
+      "color": "#a48050",
+      "transparent": true
     },
     {
       "name": "minecraft:brick_slab",
@@ -836,6 +932,12 @@
       "canprovidepower": true
     },
     {
+      "name": "minecraft:redstone_wall_torch",
+      "color": "#fd0000",
+      "transparent": true,
+      "canprovidepower": true
+    },
+    {
       "name": "minecraft:stone_button",
       "color": "#a8a8a8",
       "transparent": true,
@@ -1027,6 +1129,31 @@
       "transparent": true
     },
     {
+      "name": "minecraft:spruce_trapdoor",
+      "color": "#7c5a2a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:birch_trapdoor",
+      "color": "#7c5a2a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:jungle_trapdoor",
+      "color": "#7c5a2a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:acacia_trapdoor",
+      "color": "#7c5a2a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:dark_oak_trapdoor",
+      "color": "#7c5a2a",
+      "transparent": true
+    },
+    {
       "name": "minecraft:infested_stone",
       "color": "#7a7a7a"
     },
@@ -1075,6 +1202,10 @@
       "color": "#b51d1b"
     },
     {
+      "name": "minecraft:mushroom_stem",
+      "color": "#d2b17d"
+    },
+    {
       "name": "minecraft:iron_bars",
       "color": "#6d6e6e",
       "transparent": true
@@ -1095,7 +1226,17 @@
       "transparent": true
     },
     {
+      "name": "minecraft:attached_pumpkin_stem",
+      "color": "#6b6b0b",
+      "transparent": true
+    },
+    {
       "name": "minecraft:melon_stem",
+      "color": "#6b6b0b",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:attached_melon_stem",
       "color": "#6b6b0b",
       "transparent": true
     },
@@ -1146,12 +1287,7 @@
       "transparent": true
     },
     {
-      "name": "minecraft:immature_nether_wart",
-      "color": "#70081c",
-      "transparent": true
-    },
-    {
-      "name": "minecraft:mature_nether_wart",
+      "name": "minecraft:nether_wart",
       "color": "#8e181b"
     },
     {
@@ -1191,6 +1327,10 @@
     {
       "name": "minecraft:dragon_egg",
       "color": "#2d0133"
+    },
+    {
+      "name": "minecraft:turtle_egg",
+      "color": "#8d6193"
     },
     {
       "name": "minecraft:redstone_lamp",
@@ -1399,6 +1539,50 @@
       "spawninside": true,
       "canprovidepower": true
     },
+    {
+      "name": "minecraft:spruce_button",
+      "color": "#664f2f",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:birch_button",
+      "color": "#d7cb8d",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:jungle_button",
+      "color": "#b1805c",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:acacia_button",
+      "color": "#ba6337",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+    {
+      "name": "minecraft:dark_oak_button",
+      "color": "#462d15",
+      "transparent": true,
+      "spawninside": true,
+      "canprovidepower": true
+    },
+
+
+
+
+
+
+
+
+
     {
       "name": "minecraft:mob_head",
       "color": "#1a1a1a",
@@ -1754,6 +1938,30 @@
       "color": "#3c584b"
     },
     {
+      "name": "minecraft:prismarine_stairs",
+      "color": "#6baa97"
+    },
+    {
+      "name": "minecraft:prismarine_brick_stairs",
+      "color": "#64a08f"
+    },
+    {
+      "name": "minecraft:dark_prismarine_stairs",
+      "color": "#3c584b"
+    },
+    {
+      "name": "minecraft:prismarine_slab",
+      "color": "#6baa97"
+    },
+    {
+      "name": "minecraft:prismarine_brick_slab",
+      "color": "#64a08f"
+    },
+    {
+      "name": "minecraft:dark_prismarine_slab",
+      "color": "#3c584b"
+    },
+    {
       "name": "minecraft:sea_lantern",
       "color": "#abc8be"
     },
@@ -1901,18 +2109,164 @@
       "alpha": 0
     },
     {
-      "name": "minecraft:large_flower_(top_part)",
-      "color": "#ffffff",
-      "alpha": 0
+      "name": "minecraft:white_banner",
+      "color": "#eaeaea",
+      "transparent": true
     },
     {
-      "name": "minecraft:white_banner",
-      "color": "#ffffff",
+      "name": "minecraft:orange_banner",
+      "color": "#db7b3b",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:magenta_banner",
+      "color": "#af44b8",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:light_blue_banner",
+      "color": "#7e99d0",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:yellow_banner",
+      "color": "#bcb02a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:lime_banner",
+      "color": "#44b93b",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:pink_banner",
+      "color": "#d28a9e",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:gray_banner",
+      "color": "#454545",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:light_gray_banner",
+      "color": "#909898",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:cyan_banner",
+      "color": "#30728e",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:purple_banner",
+      "color": "#7737ad",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:blue_banner",
+      "color": "#2b3585",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:brown_banner",
+      "color": "#563822",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:green_banner",
+      "color": "#314119",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:red_banner",
+      "color": "#91312f",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:black_banner",
+      "color": "#1d1b1b",
       "transparent": true
     },
     {
       "name": "minecraft:white_wall_banner",
-      "color": "#ffffff",
+      "color": "#eaeaea",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:orange_wall_banner",
+      "color": "#db7b3b",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:magenta_wall_banner",
+      "color": "#af44b8",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:light_blue_wall_banner",
+      "color": "#7e99d0",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:yellow_wall_banner",
+      "color": "#bcb02a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:lime_wall_banner",
+      "color": "#44b93b",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:pink_wall_banner",
+      "color": "#d28a9e",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:gray_wall_banner",
+      "color": "#454545",
+      "transparent": true
+    },
+
+    {
+      "name": "minecraft:light_gray_wall_banner",
+      "color": "#909898",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:cyan_wall_banner",
+      "color": "#30728e",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:purple_wall_banner",
+      "color": "#7737ad",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:blue_wall_banner",
+      "color": "#2b3585",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:brown_wall_banner",
+      "color": "#563822",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:green_wall_banner",
+      "color": "#314119",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:red_wall_banner",
+      "color": "#91312f",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:black_wall_banner",
+      "color": "#1d1b1b",
       "transparent": true
     },
     {
@@ -1924,6 +2278,10 @@
     {
       "name": "minecraft:red_sandstone",
       "color": "#a6551e"
+    },
+    {
+      "name": "minecraft:cut_red_sandstone",
+      "color": "#a8561e"
     },
     {
       "name": "minecraft:chiseled_red_sandstone",
@@ -2063,7 +2421,7 @@
       "color": "#e2e7ab"
     },
     {
-      "name": "minecraft:beetroot",
+      "name": "minecraft:beetroots",
       "color": "#517136"
     },
     {
@@ -2115,6 +2473,10 @@
     {
       "name": "minecraft:observer",
       "color": "#535353"
+    },
+    {
+      "name": "minecraft:shulker_box",
+      "color": "#a777a7"
     },
     {
       "name": "minecraft:white_shulker_box",
@@ -2393,6 +2755,26 @@
       "color": "#e4da4a"
     },
     {
+      "name": "minecraft:dead_tube_coral",
+      "color": "#7e7e7e"
+    },
+    {
+      "name": "minecraft:dead_brain_coral",
+      "color": "#bcbcbc"
+    },
+    {
+      "name": "minecraft:dead_bubble_coral",
+      "color": "#898989"
+    },
+    {
+      "name": "minecraft:dead_fire_coral",
+      "color": "#737373"
+    },
+    {
+      "name": "minecraft:dead_horn_coral",
+      "color": "#adadad"
+    },
+    {
       "name": "minecraft:tube_coral_fan",
       "color": "#3f5be2"
     },
@@ -2411,6 +2793,66 @@
     {
       "name": "minecraft:horn_coral_fan",
       "color": "#e4da4a"
+    },
+    {
+      "name": "minecraft:dead_tube_coral_fan",
+      "color": "#7e7e7e"
+    },
+    {
+      "name": "minecraft:dead_brain_coral_fan",
+      "color": "#bcbcbc"
+    },
+    {
+      "name": "minecraft:dead_bubble_coral_fan",
+      "color": "#898989"
+    },
+    {
+      "name": "minecraft:dead_fire_coral_fan",
+      "color": "#737373"
+    },
+    {
+      "name": "minecraft:dead_horn_coral_fan",
+      "color": "#adadad"
+    },
+    {
+      "name": "minecraft:tube_coral_wall_fan",
+      "color": "#3f5be2"
+    },
+    {
+      "name": "minecraft:brain_coral_wall_fan",
+      "color": "#e78dc0"
+    },
+    {
+      "name": "minecraft:bubble_coral_wall_fan",
+      "color": "#c819ba"
+    },
+    {
+      "name": "minecraft:fire_coral_wall_fan",
+      "color": "#e34036"
+    },
+    {
+      "name": "minecraft:horn_coral_wall_fan",
+      "color": "#e4da4a"
+    },
+    {
+      "name": "minecraft:dead_tube_coral_wall_fan",
+      "color": "#7e7e7e"
+    },
+    {
+      "name": "minecraft:dead_brain_coral_wall_fan",
+      "color": "#bcbcbc"
+    },
+    {
+      "name": "minecraft:dead_bubble_coral_wall_fan",
+      "color": "#898989"
+    },
+    {
+      "name": "minecraft:dead_fire_coral_wall_fan",
+      "color": "#737373"
+    },
+    {
+      "name": "minecraft:dead_horn_coral_wall_fan",
+      "color": "#adadad"
     },
     {
       "name": "minecraft:tube_coral_block",
@@ -2433,8 +2875,32 @@
       "color": "#cbc131"
     },
     {
+      "name": "minecraft:dead_tube_coral_block",
+      "color": "#7e7e7e"
+    },
+    {
+      "name": "minecraft:dead_brain_coral_block",
+      "color": "#bcbcbc"
+    },
+    {
+      "name": "minecraft:dead_bubble_coral_block",
+      "color": "#898989"
+    },
+    {
+      "name": "minecraft:dead_fire_coral_block",
+      "color": "#737373"
+    },
+    {
+      "name": "minecraft:dead_horn_coral_block",
+      "color": "#adadad"
+    },
+    {
       "name": "minecraft:sea_pickle",
       "color": "#56644a"
+    },
+    {
+      "name": "minecraft:conduit",
+      "color": "#b4886b"
     },
     {
       "name": "minecraft:structure_block_save",

--- a/definitions/vanilla_blocks.json
+++ b/definitions/vanilla_blocks.json
@@ -53,11 +53,6 @@
       "color": "#838385"
     },
     {
-      "name": "minecraft:grass",
-      "color": "#939393",
-      "biomeGrass": true
-    },
-    {
       "name": "minecraft:grass_block",
       "color": "#939393",
       "biomeGrass": true
@@ -207,8 +202,7 @@
     },
     {
       "name": "minecraft:oak_log",
-      "color": "#665130",
-      "mask": 3
+      "color": "#665130"
     },
     {
       "name": "minecraft:spruce_log",
@@ -224,8 +218,7 @@
     },
     {
       "name": "minecraft:acacia_log",
-      "color": "#b25b3b",
-      "mask": 1
+      "color": "#b25b3b"
     },
     {
       "name": "minecraft:dark_oak_log",
@@ -233,8 +226,7 @@
     },
     {
       "name": "minecraft:oak_wood",
-      "color": "#665130",
-      "mask": 3
+      "color": "#665130"
     },
     {
       "name": "minecraft:spruce_wood",
@@ -250,8 +242,7 @@
     },
     {
       "name": "minecraft:acacia_wood",
-      "color": "#b25b3b",
-      "mask": 1
+      "color": "#b25b3b"
     },
     {
       "name": "minecraft:dark_oak_wood",
@@ -259,8 +250,7 @@
     },
     {
       "name": "minecraft:stripped_oak_wood",
-      "color": "#665130",
-      "mask": 3
+      "color": "#665130"
     },
     {
       "name": "minecraft:stripped_spruce_wood",
@@ -276,8 +266,7 @@
     },
     {
       "name": "minecraft:stripped_acacia_wood",
-      "color": "#b25b3b",
-      "mask": 1
+      "color": "#b25b3b"
     },
     {
       "name": "minecraft:stripped_dark_oak_wood",
@@ -288,35 +277,41 @@
       "color": "#515151",
       "transparent": true,
       "rendercube": true,
-      "biomeFoliage": true,
-      "mask": 3
+      "biomeFoliage": true
     },
     {
       "name": "minecraft:spruce_leaves",
       "color": "#619961",
+      "transparent": true,
+      "rendercube": true,
       "biomeFoliage": false
     },
     {
       "name": "minecraft:birch_leaves",
       "color": "#80a755",
+      "transparent": true,
+      "rendercube": true,
       "biomeFoliage": false
     },
     {
       "name": "minecraft:jungle_leaves",
       "color": "#727069",
-      "biomeFoliage": true,
+      "transparent": true,
+      "rendercube": true,
+      "biomeFoliage": true
     },
     {
       "name": "minecraft:acacia_leaves",
       "color": "#515151",
       "transparent": true,
       "rendercube": true,
-      "biomeFoliage": true,
-      "mask": 1
+      "biomeFoliage": true
     },
     {
       "name": "minecraft:dark_oak_leaves",
       "color": "#515151",
+      "transparent": true,
+      "rendercube": true,
       "biomeFoliage": true
     },
     {
@@ -582,46 +577,6 @@
       "color": "#e6e6e6"
     },
     {
-      "name": "minecraft:double_stone_slab",
-      "color": "#a3a3a3"
-    },
-    {
-      "name": "minecraft:double_sandstone_slab",
-      "color": "#d7ce95"
-    },
-    {
-      "name": "minecraft:double_wooden_slab",
-      "color": "#b4905a"
-    },
-    {
-      "name": "minecraft:double_cobblestone_slab",
-      "color": "#8f8f8f"
-    },
-    {
-      "name": "minecraft:double_bricks_slab",
-      "color": "#7c4536"
-    },
-    {
-      "name": "minecraft:double_stone_brick_slab",
-      "color": "#797979"
-    },
-    {
-      "name": "minecraft:double_nether_brick_slab",
-      "color": "#30181c"
-    },
-    {
-      "name": "minecraft:double_quartz_slab",
-      "color": "#f0eee8"
-    },
-    {
-      "name": "minecraft:full_stone_slab",
-      "color": "#9c9c9c"
-    },
-    {
-      "name": "minecraft:full_sandstone_slab",
-      "color": "#d7cf9c"
-    },
-    {
       "name": "minecraft:stone_slab",
       "color": "#a3a3a3",
       "transparent": true
@@ -629,10 +584,6 @@
     {
       "name": "minecraft:sandstone_slab",
       "color": "#d7ce95"
-    },
-    {
-      "name": "minecraft:wooden_slab",
-      "color": "#b4905a"
     },
     {
       "name": "minecraft:cobblestone_slab",
@@ -652,38 +603,6 @@
     },
     {
       "name": "minecraft:quartz_slab",
-      "color": "#f0eee8"
-    },
-    {
-      "name": "minecraft:upper_stone_slab",
-      "color": "#a3a3a3"
-    },
-    {
-      "name": "minecraft:upper_sandstone_slab",
-      "color": "#d7ce95"
-    },
-    {
-      "name": "minecraft:upper_wooden_slab",
-      "color": "#b4905a"
-    },
-    {
-      "name": "minecraft:upper_cobblestone_slab",
-      "color": "#8f8f8f"
-    },
-    {
-      "name": "minecraft:upper_brick_slab",
-      "color": "#7c4536"
-    },
-    {
-      "name": "minecraft:upper_stone_brick_slab",
-      "color": "#797979"
-    },
-    {
-      "name": "minecraft:upper_nether_brick_slab",
-      "color": "#30181c"
-    },
-    {
-      "name": "minecraft:upper_quartz_slab",
       "color": "#f0eee8"
     },
     {
@@ -778,17 +697,13 @@
       "color": "#535353"
     },
     {
-      "name": "minecraft:burning_furnace",
-      "color": "#535353"
-    },
-    {
-      "name": "minecraft:standing_sign",
+      "name": "minecraft:sign",
       "color": "#9f844d",
       "transparent": true,
       "spawninside": true
     },
     {
-      "name": "minecraft:wooden_door",
+      "name": "minecraft:oak_door",
       "color": "#b0572a",
       "transparent": true
     },
@@ -844,16 +759,6 @@
     {
       "name": "minecraft:redstone_ore",
       "color": "#8f0303"
-    },
-    {
-      "name": "minecraft:redstone_ore_(glowing)",
-      "color": "#8f0303"
-    },
-    {
-      "name": "minecraft:unlit_redstone_torch",
-      "color": "#480000",
-      "transparent": true,
-      "canprovidepower": true
     },
     {
       "name": "minecraft:redstone_torch",
@@ -937,7 +842,7 @@
       "transparent": true
     },
     {
-      "name": "minecraft:jack_o'lantern",
+      "name": "minecraft:jack_o_lantern",
       "color": "#e9b416"
     },
     {
@@ -946,13 +851,7 @@
       "transparent": true
     },
     {
-      "name": "minecraft:powered_repeater",
-      "color": "#2a0002",
-      "transparent": true,
-      "canprovidepower": true
-    },
-    {
-      "name": "minecraft:redstone_repeater_(on)",
+      "name": "minecraft:repeater",
       "color": "#fd0101",
       "transparent": true,
       "canprovidepower": true
@@ -1006,7 +905,7 @@
       "alpha": 0.5
     },
     {
-      "name": "minecraft:silver_stained_glass",
+      "name": "minecraft:light_gray_stained_glass",
       "color": "#999999",
       "transparent": true,
       "alpha": 0.5
@@ -1209,7 +1108,6 @@
     {
       "name": "minecraft:end_portal_frame",
       "color": "#2f5754",
-      "mask": 4,
       "transparent": true,
       "rendercube": true
     },
@@ -1227,36 +1125,8 @@
     },
     {
       "name": "minecraft:redstone_lamp",
-      "color": "#b0744c"
-    },
-    {
-      "name": "minecraft:redstone_lamp_(on)",
       "color": "#f1d1af",
       "transparent": true
-    },
-    {
-      "name": "minecraft:double_oak_wood_slab",
-      "color": "#b4905a"
-    },
-    {
-      "name": "minecraft:double_spruce_wood_slab",
-      "color": "#664f2f"
-    },
-    {
-      "name": "minecraft:double_birch_wood_slab",
-      "color": "#d7cb8d"
-    },
-    {
-      "name": "minecraft:double_jungle_wood_slab",
-      "color": "#b1805c"
-    },
-    {
-      "name": "minecraft:double_acacia_wood_slab",
-      "color": "#ad5d32"
-    },
-    {
-      "name": "minecraft:double_dark_oak_wood_slab",
-      "color": "#462d15"
     },
     {
       "name": "minecraft:oak_slab",
@@ -1284,35 +1154,10 @@
       "color": "#462d15"
     },
     {
-      "name": "minecraft:upper_oak_wood_slab",
-      "color": "#b4905a"
-    },
-    {
-      "name": "minecraft:upper_spruce_wood_slab",
-      "color": "#664f2f"
-    },
-    {
-      "name": "minecraft:upper_birch_wood_slab",
-      "color": "#d7cb8d"
-    },
-    {
-      "name": "minecraft:upper_jungle_wood_slab",
-      "color": "#b1805c"
-    },
-    {
-      "name": "minecraft:upper_acacia_wood_slab",
-      "color": "#ba6337"
-    },
-    {
-      "name": "minecraft:upper_dark_oak_wood_slab",
-      "color": "#462d15"
-    },
-    {
       "name": "minecraft:immature_cocoa_pod",
       "color": "#929943",
       "transparent": true,
-      "spawninside": true,
-      "mask": 12
+      "spawninside": true
     },
     {
       "name": "minecraft:cocoa",
@@ -1466,20 +1311,17 @@
     {
       "name": "minecraft:anvil",
       "color": "#474747",
-      "transparent": true,
-      "mask": 12
+      "transparent": true
     },
     {
       "name": "minecraft:chipped_anvil",
       "color": "#474747",
-      "transparent": true,
-      "mask": 12
+      "transparent": true
     },
     {
       "name": "minecraft:damaged_anvil",
       "color": "#474747",
-      "transparent": true,
-      "mask": 12
+      "transparent": true
     },
     {
       "name": "minecraft:trapped_chest",
@@ -1502,13 +1344,7 @@
       "canprovidepower": true
     },
     {
-      "name": "minecraft:redstone_comparator_(off)",
-      "color": "#4f1010",
-      "transparent": true,
-      "canprovidepower": true
-    },
-    {
-      "name": "minecraft:powered_comparator",
+      "name": "minecraft:comparator",
       "color": "#fd1010",
       "transparent": true,
       "canprovidepower": true
@@ -1674,7 +1510,7 @@
       "transparent": true
     },
     {
-      "name": "minecraft:silver_stained_glass_pane",
+      "name": "minecraft:light_gray_stained_glass_pane",
       "color": "#929292",
       "alpha": 0.5,
       "transparent": true
@@ -1806,7 +1642,7 @@
       "transparent": true
     },
     {
-      "name": "minecraft:silver_carpet",
+      "name": "minecraft:light_gray_carpet",
       "color": "#aab0b0",
       "transparent": true
     },
@@ -1910,12 +1746,12 @@
       "alpha": 0
     },
     {
-      "name": "minecraft:standing_banner",
+      "name": "minecraft:white_banner",
       "color": "#ffffff",
       "transparent": true
     },
     {
-      "name": "minecraft:wall_banner",
+      "name": "minecraft:white_wall_banner",
       "color": "#ffffff",
       "transparent": true
     },
@@ -1943,21 +1779,9 @@
       "transparent": true
     },
     {
-      "name": "minecraft:double_red_sandstone_slab",
-      "color": "#a6551e"
-    },
-    {
-      "name": "minecraft:full_red_sandstone_slab",
-      "color": "#a7551e"
-    },
-    {
       "name": "minecraft:red_sandstone_slab",
       "color": "#a7551e",
       "transparent": true
-    },
-    {
-      "name": "minecraft:upper_red_sandstone_slab",
-      "color": "#a7551e"
     },
     {
       "name": "minecraft:spruce_fence_gate",
@@ -2059,10 +1883,6 @@
       "transparent": true
     },
     {
-      "name": "minecraft:chorus_flower_(fully_grown)",
-      "color": "#624060"
-    },
-    {
       "name": "minecraft:purpur_block",
       "color": "#a67aa6"
     },
@@ -2072,10 +1892,6 @@
     },
     {
       "name": "minecraft:purpur_stairs",
-      "color": "#a67aa6"
-    },
-    {
-      "name": "minecraft:purpur_double_slab",
       "color": "#a67aa6"
     },
     {

--- a/definitions/vanilla_blocks.json
+++ b/definitions/vanilla_blocks.json
@@ -249,6 +249,30 @@
       "color": "#5d4931"
     },
     {
+      "name": "minecraft:stripped_oak_log",
+      "color": "#665130"
+    },
+    {
+      "name": "minecraft:stripped_spruce_log",
+      "color": "#2e1d0a"
+    },
+    {
+      "name": "minecraft:stripped_birch_log",
+      "color": "#d6dad6"
+    },
+    {
+      "name": "minecraft:stripped_jungle_log",
+      "color": "#584219"
+    },
+    {
+      "name": "minecraft:stripped_acacia_log",
+      "color": "#b25b3b"
+    },
+    {
+      "name": "minecraft:stripped_dark_oak_log",
+      "color": "#5d4931"
+    },
+    {
       "name": "minecraft:stripped_oak_wood",
       "color": "#665130"
     },
@@ -1267,6 +1291,11 @@
       "transparent": true
     },
     {
+      "name": "minecraft:mossy_cobblestone_wall",
+      "color": "#508050",
+      "transparent": true
+    },
+    {
       "name": "minecraft:flower_pot",
       "color": "#7c4536",
       "transparent": true
@@ -1371,7 +1400,67 @@
       "canprovidepower": true
     },
     {
-      "name": "minecraft:skull",
+      "name": "minecraft:mob_head",
+      "color": "#1a1a1a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:skeleton_skull",
+      "color": "#1a1a1a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:skeleton_wall_skull",
+      "color": "#1a1a1a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:wither_skeleton_skull",
+      "color": "#1a1a1a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:wither_skeleton_wall_skull",
+      "color": "#1a1a1a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:zombie_head",
+      "color": "#1a1a1a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:zombie_wall_head",
+      "color": "#1a1a1a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:player_head",
+      "color": "#1a1a1a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:player_wall_head",
+      "color": "#1a1a1a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:creeper_head",
+      "color": "#1a1a1a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:creeper_wall_head",
+      "color": "#1a1a1a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:dragon_head",
+      "color": "#1a1a1a",
+      "transparent": true
+    },
+    {
+      "name": "minecraft:dragon_wall_head",
       "color": "#1a1a1a",
       "transparent": true
     },
@@ -1448,6 +1537,10 @@
     {
       "name": "minecraft:quartz_pillar",
       "color": "#e1dcd3"
+    },
+    {
+      "name": "minecraft:smooth_quartz",
+      "color": "#edebe5"
     },
     {
       "name": "minecraft:quartz_stairs",

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -79,32 +79,38 @@
     },
     {
       "id": 5,
-      "name": "Oak Wood Plank",
+      "name": "Oak Wood Planks",
+      "flatname": "minecraft:oak_planks",
       "color": "#b4905a",
       "variants": [
         {
           "data": 1,
-          "name": "Spruce Wood Plank",
+          "name": "Spruce Wood Planks",
+          "flatname": "minecraft:spruce_planks",
           "color": "#805e36"
         },
         {
           "data": 2,
-          "name": "Birch Wood Plank",
+          "name": "Birch Wood Planks",
+          "flatname": "minecraft:birch_planks",
           "color": "#c8b77a"
         },
         {
           "data": 3,
-          "name": "Jungle Wood Plank",
+          "name": "Jungle Wood Planks",
+          "flatname": "minecraft:jungle_planks",
           "color": "#b1805c"
         },
         {
           "data": 4,
-          "name": "Acacia Wood Plank",
+          "name": "Acacia Wood Planks",
+          "flatname": "minecraft:acacia_planks",
           "color": "#ba6337"
         },
         {
           "data": 5,
-          "name": "Dark Oak Wood Plank",
+          "name": "Dark Oak Wood Planks",
+          "flatname": "minecraft:dark_oak_planks",
           "color": "#462d15"
         }
       ]
@@ -215,22 +221,26 @@
     {
       "id": 17,
       "name": "Oak Wood",
+      "flatname": "minecraft:oak_log",
       "color": "#665130",
       "mask": 3,
       "variants": [
         {
           "data": 1,
           "name": "Spruce Wood",
+          "flatname": "minecraft:spruce_log",
           "color": "#2e1d0a"
         },
         {
           "data": 2,
           "name": "Birch Wood",
+          "flatname": "minecraft:birch_log",
           "color": "#d6dad6"
         },
         {
           "data": 3,
           "name": "Jungle Wood",
+          "flatname": "minecraft:jungle_log",
           "color": "#584219"
         }
       ]
@@ -286,11 +296,13 @@
     {
       "id": 21,
       "name": "Lapis Lazuli Ore",
+      "flatname": "minecraft:lapis_ore",
       "color": "#1b43ad"
     },
     {
       "id": 22,
       "name": "Lapis Lazuli Block",
+      "flatname": "minecraft:lapis_block",
       "color": "#0f26b8"
     },
     {
@@ -563,12 +575,12 @@
     },
     {
       "id": 41,
-      "name": "Block of Gold",
+      "name": "Gold Block",
       "color": "#fdfb4f"
     },
     {
       "id": 42,
-      "name": "Block of Iron",
+      "name": "Iron Block",
       "color": "#e6e6e6"
     },
     {
@@ -744,6 +756,7 @@
     {
       "id": 48,
       "name": "Moss Stone",
+      "flatname": "minecraft:mossy_cobblestone",
       "color": "#3a623a"
     },
     {
@@ -766,13 +779,14 @@
     {
       "id": 52,
       "name": "Monster Spawner",
+      "flatname": "minecraft:spawner",
       "color": "#1b2a35",
       "transparent": true,
       "rendercube": true
     },
     {
       "id": 53,
-      "name": "Oak Wood Stairs",
+      "name": "Oak Stairs",
       "color": "#9f844d",
       "transparent": true
     },
@@ -795,7 +809,7 @@
     },
     {
       "id": 57,
-      "name": "Block of Diamond",
+      "name": "Diamond Block",
       "color": "#91e8e4"
     },
     {
@@ -806,12 +820,14 @@
     {
       "id": 59,
       "name": "Immature Wheat",
+      "flatname": "minecraft:wheat",
       "color": "#8ba803",
       "transparent": true,
       "variants": [
         {
           "data": 7,
           "name": "Grown Wheat",
+          "flatname": "minecraft:wheat",
           "color": "#8e7c10"
         }
       ]
@@ -819,12 +835,14 @@
     {
       "id": 60,
       "name": "Wet Farmland",
+      "flatname": "minecraft:farmland",
       "color": "#43240b",
       "transparent": true,
       "variants": [
         {
           "data": 0,
           "name": "Dry Farmland",
+          "flatname": "minecraft:farmland",
           "color": "#633f24"
         }
       ]
@@ -979,6 +997,7 @@
     {
       "id": 82,
       "name": "Clay Block",
+      "flatname": "minecraft:clay",
       "color": "#9da3ae"
     },
     {
@@ -1019,6 +1038,7 @@
     {
       "id": 89,
       "name": "Glowstone Block",
+      "flatname": "minecraft:glowstone",
       "color": "#f9d49c"
     },
     {
@@ -1149,53 +1169,59 @@
     {
       "id": 97,
       "name": "Stone Monster Egg",
+      "flatname": "minecraft:infested_stone",
       "color": "#7a7a7a",
       "variants": [
         {
           "data": 1,
           "name": "Cobblestone Monster Egg",
+          "flatname": "minecraft:infested_cobblestone",
           "color": "#787878"
         },
         {
           "data": 2,
           "name": "Stone Brick Monster Egg",
+          "flatname": "minecraft:infested_stone_bricks",
           "color": "#777777"
         },
         {
           "data": 3,
           "name": "Mossy Stone Brick Monster Egg",
+          "flatname": "minecraft:infested_mossy_stone_bricks",
           "color": "#707467"
         },
         {
           "data": 4,
           "name": "Cracked Stone Brick Monster Egg",
+          "flatname": "minecraft:infested_cracked_stone_bricks",
           "color": "#747474"
         },
         {
           "data": 5,
           "name": "Chiseled Stone Brick Monster Egg",
+          "flatname": "minecraft:infested_chiseled_stone_bricks",
           "color": "#747474"
         }
       ]
     },
     {
       "id": 98,
-      "name": "Stone Brick",
+      "name": "Stone Bricks",
       "color": "#797979",
       "variants": [
         {
           "data": 1,
-          "name": "Mossy Stone Brick",
+          "name": "Mossy Stone Bricks",
           "color": "#637049"
         },
         {
           "data": 2,
-          "name": "Cracked Stone Brick",
+          "name": "Cracked Stone Bricks",
           "color": "#656565"
         },
         {
           "data": 3,
-          "name": "Chiseled Stone Brick",
+          "name": "Chiseled Stone Bricks",
           "color": "#9c9c9c"
         }
       ]
@@ -1203,6 +1229,7 @@
     {
       "id": 99,
       "name": "Huge Brown Mushroom",
+      "flatname": "minecraft:brown_mushroom_block",
       "color": "#d2b17d",
       "variants": [
         {
@@ -1258,6 +1285,7 @@
     {
       "id": 100,
       "name": "Huge Red Mushroom",
+      "flatname": "minecraft:red_mushroom_block",
       "color": "#d2b17d",
       "variants": [
         {
@@ -1413,6 +1441,7 @@
     {
       "id": 116,
       "name": "Enchantment Table",
+      "flatname": "minecraft:enchanting_table",
       "color": "#3c3056",
       "transparent": true
     },
@@ -1588,6 +1617,7 @@
     {
       "id": 127,
       "name": "Immature Cocoa Pod",
+      "flatname": "minecraft:cocoa",
       "color": "#929943",
       "transparent": true,
       "spawninside": true,
@@ -1596,6 +1626,7 @@
         {
           "data": 8,
           "name": "Mature Cocoa Pod",
+          "flatname": "minecraft:cocoa",
           "color": "#d4924c"
         }
       ]
@@ -1633,24 +1664,24 @@
     },
     {
       "id": 133,
-      "name": "Block of Emerald",
+      "name": "Emerald Block",
       "color": "#64ea8a"
     },
     {
       "id": 134,
-      "name": "Spruce Wood Stairs",
+      "name": "Spruce Stairs",
       "color": "#664f2f",
       "transparent": true
     },
     {
       "id": 135,
-      "name": "Birch Wood Stairs",
+      "name": "Birch Stairs",
       "color": "#d7cb8d",
       "transparent": true
     },
     {
       "id": 136,
-      "name": "Jungle Wood Stairs",
+      "name": "Jungle Stairs",
       "color": "#b1805c",
       "transparent": true
     },
@@ -1668,77 +1699,98 @@
       "id": 139,
       "name": "Cobblestone Wall",
       "color": "#505050",
-      "transparent": true
+      "transparent": true,
+      "variants": [
+        {
+          "data": 1,
+          "name": "Mossy Cobblestone Wall",
+          "color": "#3a623a"
+        }
+      ]
     },
     {
       "id": 140,
       "name": "Flower Pot (empty)",
+      "flatname": "minecraft:flower_pot",
       "color": "#7c4536",
       "transparent": true,
       "variants": [
         {
           "data": 1,
           "name": "Flower Pot (poppy)",
+          "flatname": "minecraft:potted_poppy",
           "color": "#910205"
         },
         {
           "data": 2,
           "name": "Flower Pot (dandelion)",
+          "flatname": "minecraft:potted_dandelion",
           "color": "#f1f902"
         },
         {
           "data": 3,
           "name": "Flower Pot (oak)",
+          "flatname": "minecraft:potted_oak_sapling",
           "color": "#408f2f"
         },
         {
           "data": 4,
           "name": "Flower Pot (spruce)",
+          "flatname": "minecraft:potted_spruce_sapling",
           "color": "#395a39"
         },
         {
           "data": 5,
           "name": "Flower Pot (birch)",
+          "flatname": "minecraft:potted_birch_sapling",
           "color": "#cfe3ba"
         },
         {
           "data": 6,
           "name": "Flower Pot (jungle)",
+          "flatname": "minecraft:potted_jungle_sapling",
           "color": "#2c6c18"
         },
         {
           "data": 7,
           "name": "Flower Pot (red mushroom)",
+          "flatname": "minecraft:potted_red_mushroom",
           "color": "#9a171c"
         },
         {
           "data": 8,
           "name": "Flower Pot (brown mushroom)",
+          "flatname": "minecraft:potted_brown_mushroom",
           "color": "#725643"
         },
         {
           "data": 9,
           "name": "Flower Pot (cactus)",
+          "flatname": "minecraft:potted_cactus",
           "color": "#128a20"
         },
         {
           "data": 10,
           "name": "Flower Pot (dead bush)",
+          "flatname": "minecraft:potted_dead_bush",
           "color": "#946428"
         },
         {
           "data": 11,
           "name": "Flower Pot (fern)",
+          "flatname": "minecraft:potted_fern",
           "color": "#315e05"
         },
         {
           "data": 12,
           "name": "Flower Pot (acacia)",
+          "flatname": "minecraft:potted_acacia_sapling",
           "color": "#946428"
         },
         {
           "data": 13,
           "name": "Flower Pot (dark oak)",
+          "flatname": "minecraft:potted_dark_oak_sapling",
           "color": "#315e05"
         }
       ]
@@ -1746,12 +1798,14 @@
     {
       "id": 141,
       "name": "Immature Carrots",
+      "flatname": "minecraft:carrots",
       "color": "#00c617",
       "transparent": true,
       "variants": [
         {
           "data": 7,
           "name": "Mature Carrots",
+          "flatname": "minecraft:carrots",
           "color": "#004e00"
         }
       ]
@@ -1759,12 +1813,14 @@
     {
       "id": 142,
       "name": "Immature Potatoes",
+      "flatname": "minecraft:potatoes",
       "color": "#00c617",
       "transparent": true,
       "variants": [
         {
           "data": 7,
           "name": "Mature Potatoes",
+          "flatname": "minecraft:potatoes",
           "color": "#3aa649"
         }
       ]
@@ -1787,17 +1843,20 @@
     {
       "id": 145,
       "name": "Anvil",
+      "flatname": "minecraft:anvil",
       "color": "#474747",
       "transparent": true,
       "mask": 12,
       "variants": [
         {
           "data": 4,
-          "name": "Slightly Damaged Anvil"
+          "name": "Slightly Damaged Anvil",
+          "flatname": "minecraft:chipped_anvil",
         },
         {
           "data": 8,
-          "name": "Very Damaged Anvil"
+          "name": "Very Damaged Anvil",
+          "flatname": "minecraft:damaged_anvil",
         }
       ]
     },
@@ -1810,7 +1869,7 @@
     },
     {
       "id": 147,
-      "name": "Weighted Pressure Plate (Light)",
+      "name": "Light Weighted Pressure Plate",
       "color": "#fdfb4f",
       "transparent": true,
       "spawninside": true,
@@ -1818,7 +1877,7 @@
     },
     {
       "id": 148,
-      "name": "Weighted Pressure Plate (Heavy)",
+      "name": "Heavy Weighted Pressure Plate",
       "color": "#e6e6e6",
       "transparent": true,
       "spawninside": true,
@@ -1850,7 +1909,7 @@
     },
     {
       "id": 152,
-      "name": "Block of Redstone",
+      "name": "Redstone Block",
       "color": "#bb1c0a",
       "transparent": true,
       "canProvidePower": true
@@ -1869,7 +1928,7 @@
     },
     {
       "id": 155,
-      "name": "Block of Quartz",
+      "name": "Quartz Block",
       "color": "#edebe5",
       "variants": [
         {
@@ -2098,12 +2157,14 @@
     {
       "id": 162,
       "name": "Acacia Wood",
+      "flatname": "minecraft:acacia_log",
       "color": "#b25b3b",
       "mask": 1,
       "variants": [
         {
           "data": 1,
           "name": "Dark Oak Wood",
+          "flatname": "minecraft:dark_oak_log",
           "color": "#5d4931"
         }
       ]
@@ -2163,6 +2224,7 @@
     {
       "id": 170,
       "name": "Hay Bale",
+      "flatname": "minecraft:hay_block",
       "color": "#af9711"
     },
     {
@@ -2255,7 +2317,7 @@
     },
     {
       "id": 173,
-      "name": "Block of Coal",
+      "name": "Coal Block",
       "color": "#2b2b2b"
     },
     {
@@ -2278,6 +2340,7 @@
         {
           "data": 2,
           "name": "Double Tallgrass",
+          "flatname": "minecraft:tall_grass",
           "color": "#969696",
           "biomeGrass": true
         },
@@ -2499,12 +2562,14 @@
     {
       "id": 200,
       "name": "Chorus Flower",
+      "flatname": "minecraft:chorus_flower",
       "color": "#866886",
       "transparent": true,
       "variants": [
         {
           "data": 5,
           "name": "Chorus Flower (fully grown)",
+          "flatname": "minecraft:chorus_flower",
           "color": "#624060"
         }
       ]
@@ -2527,13 +2592,13 @@
     {
       "id": 204,
       "name": "Double Purpur Slab",
-      "flatname": "minecraft:purpure_slab",
+      "flatname": "minecraft:purpur_slab",
       "color": "#a67aa6"
     },
     {
       "id": 205,
       "name": "Purpur Slab",
-      "flatname": "minecraft:purpure_slab",
+      "flatname": "minecraft:purpur_slab",
       "color": "#a67aa6"
     },
     {
@@ -2545,12 +2610,14 @@
     {
       "id": 207,
       "name": "Immature Beetroot",
+      "flatname": "minecraft:beetroot",
       "color": "#02ab10",
       "transparent": true,
       "variants": [
         {
           "data": 3,
           "name": "Mature Beetroot",
+          "flatname": "minecraft:beetroot",
           "color": "#517136"
         }
       ]

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -2617,14 +2617,14 @@
     {
       "id": 207,
       "name": "Immature Beetroot",
-      "flatname": "minecraft:beetroot",
+      "flatname": "minecraft:beetroots",
       "color": "#02ab10",
       "transparent": true,
       "variants": [
         {
           "data": 3,
           "name": "Mature Beetroot",
-          "flatname": "minecraft:beetroot",
+          "flatname": "minecraft:beetroots",
           "color": "#517136"
         }
       ]

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -318,6 +318,7 @@
     {
       "id": 25,
       "name": "Note Block",
+      "flatname": "minecraft:note_block",
       "color": "#915840"
     },
     {
@@ -329,6 +330,7 @@
     {
       "id": 27,
       "name": "Powered Rail",
+      "flatname": "minecraft:powered_rail",
       "color": "#ab0301",
       "transparent": true,
       "spawninside": true
@@ -350,6 +352,7 @@
     {
       "id": 30,
       "name": "Cobweb",
+      "flatname": "minecraft:cobweb",
       "color": "#ededed",
       "transparent": true
     },
@@ -481,6 +484,7 @@
     {
       "id": 36,
       "name": "Piston Extension",
+      "flatname": "minecraft:moving_piston",
       "color": "#b4905a"
     },
     {
@@ -570,51 +574,61 @@
     {
       "id": 43,
       "name": "Double Stone Slab",
+      "flatname": "minecraft:stone_slab",
       "color": "#a3a3a3",
       "variants": [
         {
           "data": 1,
           "name": "Double Sandstone Slab",
+          "flatname": "minecraft:sandstone_slab",
           "color": "#d7ce95"
         },
         {
           "data": 2,
           "name": "Double Wooden Slab",
+          "flatname": "minecraft:oak_slab",
           "color": "#b4905a"
         },
         {
           "data": 3,
           "name": "Double Cobblestone Slab",
+          "flatname": "minecraft:cobblestone_slab",
           "color": "#8f8f8f"
         },
         {
           "data": 4,
           "name": "Double Bricks Slab",
+          "flatname": "minecraft:brick_slab",
           "color": "#7c4536"
         },
         {
           "data": 5,
           "name": "Double Stone Brick Slab",
+          "flatname": "minecraft:stone_brick_slab",
           "color": "#797979"
         },
         {
           "data": 6,
           "name": "Double Nether Brick Slab",
+          "flatname": "minecraft:nether_brick_slab",
           "color": "#30181c"
         },
         {
           "data": 7,
           "name": "Double Quartz Slab",
+          "flatname": "minecraft:quartz_slab",
           "color": "#f0eee8"
         },
         {
           "data": 8,
           "name": "Full Stone Slab",
+          "flatname": "minecraft:stone_slab",
           "color": "#9c9c9c"
         },
         {
           "data": 9,
           "name": "Full Sandstone Slab",
+          "flatname": "minecraft:sandstone_slab",
           "color": "#d7cf9c"
         }
       ]
@@ -633,6 +647,7 @@
         {
           "data": 2,
           "name": "Wooden Slab",
+      "flatname": "minecraft:oak_slab",
           "color": "#b4905a"
         },
         {
@@ -663,41 +678,49 @@
         {
           "data": 8,
           "name": "Upper Stone Slab",
+          "flatname": "minecraft:stone_slab",
           "color": "#a3a3a3"
         },
         {
           "data": 9,
           "name": "Upper Sandstone Slab",
+          "flatname": "minecraft:sandstone_slab",
           "color": "#d7ce95"
         },
         {
           "data": 10,
           "name": "Upper Wooden Slab",
+          "flatname": "minecraft:oak_slab",
           "color": "#b4905a"
         },
         {
           "data": 11,
           "name": "Upper Cobblestone Slab",
+          "flatname": "minecraft:cobblestone_slab",
           "color": "#8f8f8f"
         },
         {
           "data": 12,
           "name": "Upper Brick Slab",
+          "flatname": "minecraft:brick_slab",
           "color": "#7c4536"
         },
         {
           "data": 13,
           "name": "Upper Stone Brick Slab",
+          "flatname": "minecraft:stone_brick_slab",
           "color": "#797979"
         },
         {
           "data": 14,
           "name": "Upper Nether Brick Slab",
+          "flatname": "minecraft:nether_brick_slab",
           "color": "#30181c"
         },
         {
           "data": 15,
           "name": "Upper Quartz Slab",
+          "flatname": "minecraft:quartz_slab",
           "color": "#f0eee8"
         }
       ]
@@ -814,11 +837,13 @@
     {
       "id": 62,
       "name": "Burning Furnace",
+      "flatname": "minecraft:furnace",
       "color": "#535353"
     },
     {
       "id": 63,
       "name": "Sign Post",
+      "flatname": "minecraft:sign",
       "color": "#9f844d",
       "transparent": true,
       "spawninside": true
@@ -881,6 +906,7 @@
     {
       "id": 72,
       "name": "Wooden Pressure Plate",
+      "flatname": "minecraft:oak_pressure_plate",
       "color": "#bc9862",
       "transparent": true,
       "spawninside": true,
@@ -889,16 +915,19 @@
     {
       "id": 73,
       "name": "Redstone Ore",
+      "flatname": "minecraft:redstone_ore",
       "color": "#8f0303"
     },
     {
       "id": 74,
       "name": "Redstone Ore (glowing)",
+      "flatname": "minecraft:redstone_ore",
       "color": "#8f0303"
     },
     {
       "id": 75,
       "name": "Redstone Torch (off)",
+      "flatname": "minecraft:redstone_torch",
       "color": "#480000",
       "transparent": true,
       "canProvidePower": true
@@ -906,6 +935,7 @@
     {
       "id": 76,
       "name": "Redstone Torch (on)",
+      "flatname": "minecraft:redstone_torch",
       "color": "#fd0000",
       "transparent": true,
       "canProvidePower": true
@@ -921,6 +951,7 @@
     {
       "id": 78,
       "name": "Snow",
+      "flatname": "minecraft:snow",
       "color": "#eeffff",
       "spawninside": true,
       "transparent": true
@@ -936,6 +967,7 @@
     {
       "id": 80,
       "name": "Snow Block",
+      "flatname": "minecraft:snow_block",
       "color": "#eeffff"
     },
     {
@@ -998,6 +1030,7 @@
     {
       "id": 91,
       "name": "Jack o'Lantern",
+      "flatname": "minecraft:jack_o_lantern",
       "color": "#e9b416"
     },
     {
@@ -1009,6 +1042,7 @@
     {
       "id": 93,
       "name": "Redstone Repeater (off)",
+      "flatname": "minecraft:repeater",
       "color": "#2a0002",
       "transparent": true,
       "canProvidePower": true
@@ -1016,6 +1050,7 @@
     {
       "id": 94,
       "name": "Redstone Repeater (on)",
+      "flatname": "minecraft:repeater",
       "color": "#fd0101",
       "transparent": true,
       "canProvidePower": true
@@ -1064,7 +1099,7 @@
         },
         {
           "data": 8,
-          "name": "Silver Stained Glass",
+          "name": "Light Gray Stained Glass",
           "color": "#999999"
         },
         {
@@ -1107,6 +1142,7 @@
     {
       "id": 96,
       "name": "Wooden Trapdoor",
+      "flatname": "minecraft:oak_trapdoor",
       "color": "#7c5a2a",
       "transparent": true
     },
@@ -1346,6 +1382,7 @@
     {
       "id": 112,
       "name": "Nether Brick",
+      "flatname": "minecraft:nether_bricks",
       "color": "#30181c"
     },
     {
@@ -1425,42 +1462,50 @@
     {
       "id": 123,
       "name": "Redstone Lamp (off)",
+      "flatname": "minecraft:redstone_lamp",
       "color": "#b0744c"
     },
     {
       "id": 124,
       "name": "Redstone Lamp (on)",
+      "flatname": "minecraft:redstone_lamp",
       "color": "#f1d1af",
       "transparent": true
     },
     {
       "id": 125,
       "name": "Double Oak Wood Slab",
+      "flatname": "minecraft:oak_slab",
       "color": "#b4905a",
       "variants": [
         {
           "data": 1,
           "name": "Double Spruce Wood Slab",
+          "flatname": "minecraft:spruce_slab",
           "color": "#664f2f"
         },
         {
           "data": 2,
           "name": "Double Birch Wood Slab",
+          "flatname": "minecraft:birch_slab",
           "color": "#d7cb8d"
         },
         {
           "data": 3,
           "name": "Double Jungle Wood Slab",
+          "flatname": "minecraft:jungle_slab",
           "color": "#b1805c"
         },
         {
           "data": 4,
           "name": "Double Acacia Wood Slab",
+          "flatname": "minecraft:acacia_slab",
           "color": "#ad5d32"
         },
         {
           "data": 5,
           "name": "Double Dark Oak Wood Slab",
+          "flatname": "minecraft:dark_oak_slab",
           "color": "#462d15"
         }
       ]
@@ -1468,62 +1513,74 @@
     {
       "id": 126,
       "name": "Oak Wood Slab",
+      "flatname": "minecraft:oak_slab",
       "color": "#b4905a",
       "transparent": true,
       "variants": [
         {
           "data": 1,
           "name": "Spruce Wood Slab",
+          "flatname": "minecraft:spruce_slab",
           "color": "#664f2f"
         },
         {
           "data": 2,
           "name": "Birch Wood Slab",
+          "flatname": "minecraft:birch_slab",
           "color": "#d7cb8d"
         },
         {
           "data": 3,
           "name": "Jungle Wood Slab",
+          "flatname": "minecraft:jungle_slab",
           "color": "#b1805c"
         },
         {
           "data": 4,
           "name": "Acacia Wood Slab",
+          "flatname": "minecraft:acacia_slab",
           "color": "#ba6337"
         },
         {
           "data": 5,
           "name": "Dark Oak Wood Slab",
+          "flatname": "minecraft:dark_oak_slab",
           "color": "#462d15"
         },
         {
           "data": 8,
           "name": "Upper Oak Wood Slab",
+          "flatname": "minecraft:oak_slab",
           "color": "#b4905a"
         },
         {
           "data": 9,
           "name": "Upper Spruce Wood Slab",
+          "flatname": "minecraft:spruce_slab",
           "color": "#664f2f"
         },
         {
           "data": 10,
           "name": "Upper Birch Wood Slab",
+          "flatname": "minecraft:birch_slab",
           "color": "#d7cb8d"
         },
         {
           "data": 11,
           "name": "Upper Jungle Wood Slab",
+          "flatname": "minecraft:jungle_slab",
           "color": "#b1805c"
         },
         {
           "data": 12,
           "name": "Upper Acacia Wood Slab",
+          "flatname": "minecraft:acacia_slab",
           "color": "#ba6337"
         },
         {
           "data": 13,
           "name": "Upper Dark Oak Wood Slab",
+          "flatname": "minecraft:dark_oak_slab",
           "color": "#462d15"
         }
       ]
@@ -1715,6 +1772,7 @@
     {
       "id": 143,
       "name": "Wooden Button",
+      "flatname": "minecraft:oak_button",
       "color": "#b4905a",
       "transparent": true,
       "spawninside": true,
@@ -1769,6 +1827,7 @@
     {
       "id": 149,
       "name": "Redstone Comparator (off)",
+      "flatname": "minecraft:comparator",
       "color": "#4f1010",
       "transparent": true,
       "canProvidePower": true
@@ -1776,6 +1835,7 @@
     {
       "id": 150,
       "name": "Redstone Comparator (on)",
+      "flatname": "minecraft:comparator",
       "color": "#fd1010",
       "transparent": true,
       "canProvidePower": true
@@ -1783,6 +1843,7 @@
     {
       "id": 151,
       "name": "Daylight Sensor",
+      "flatname": "minecraft:daylight_detector",
       "color": "#d2c1ab",
       "transparent": true,
       "canProvidePower": true
@@ -1797,6 +1858,7 @@
     {
       "id": 153,
       "name": "Nether Quartz Ore",
+      "flatname": "minecraft:nether_quartz_ore",
       "color": "#ddcbbe"
     },
     {
@@ -1892,7 +1954,7 @@
         },
         {
           "data": 8,
-          "name": "Silver Terracotta",
+          "name": "Light Gray Terracotta",
           "color": "#876b62"
         },
         {
@@ -1976,7 +2038,7 @@
         },
         {
           "data": 8,
-          "name": "Silver Stained Glass Pane",
+          "name": "Light Gray Stained Glass Pane",
           "color": "#929292"
         },
         {
@@ -2061,6 +2123,7 @@
     {
       "id": 165,
       "name": "Slime Block",
+      "flatname": "minecraft:slime_block",
       "color": "#59994a"
     },
     {
@@ -2145,7 +2208,7 @@
         },
         {
           "data": 8,
-          "name": "Silver Carpet",
+          "name": "Light Gray Carpet",
           "color": "#aab0b0"
         },
         {
@@ -2251,18 +2314,21 @@
     {
       "id": 176,
       "name": "Standing Banner",
+      "flatname": "minecraft:white_banner",
       "color": "#ffffff",
       "transparent": true
     },
     {
       "id": 177,
       "name": "Wall Banner",
+      "flatname": "minecraft:white_wall_banner",
       "color": "#ffffff",
       "transparent": true
     },
     {
       "id": 178,
       "name": "Inverted Daylight Sensor",
+      "flatname": "minecraft:daylight_detector",
       "color": "#d2c1ab",
       "transparent": true,
       "canProvidePower": true
@@ -2293,11 +2359,13 @@
     {
       "id": 181,
       "name": "Double Red Sandstone Slab",
+      "flatname": "minecraft:red_sandstone_slab",
       "color": "#a6551e",
       "variants": [
         {
           "data": 8,
           "name": "Full Red Sandstone Slab",
+          "flatname": "minecraft:red_sandstone_slab",
           "color": "#a7551e"
         }
       ]
@@ -2305,12 +2373,14 @@
     {
       "id": 182,
       "name": "Red Sandstone Slab",
+      "flatname": "minecraft:red_sandstone_slab",
       "color": "#a7551e",
       "transparent": true,
       "variants": [
         {
           "data": 8,
           "name": "Upper Red Sandstone Slab",
+          "flatname": "minecraft:red_sandstone_slab",
           "color": "#a7551e"
         }
       ]
@@ -2457,16 +2527,19 @@
     {
       "id": 204,
       "name": "Double Purpur Slab",
+      "flatname": "minecraft:purpure_slab",
       "color": "#a67aa6"
     },
     {
       "id": 205,
       "name": "Purpur Slab",
+      "flatname": "minecraft:purpure_slab",
       "color": "#a67aa6"
     },
     {
       "id": 206,
       "name": "End Stone Bricks",
+      "flatname": "minecraft:end_stone_bricks",
       "color": "#e2e7ab"
     },
     {
@@ -2523,6 +2596,7 @@
     {
       "id": 215,
       "name": "Red Nether Brick",
+      "flatname": "minecraft:red_nether_bricks",
       "color": "#440407"
     },
     {

--- a/definitions/vanilla_ids.json
+++ b/definitions/vanilla_ids.json
@@ -1,7 +1,7 @@
 {
-  "name": "Vanilla Flattening Converter",
+  "name": "Vanilla",
   "type": "block",
-  "version": "1.12.17w13a",
+  "version": "1.12.18w32",
   "data": [
     {
       "id": 0,
@@ -159,6 +159,7 @@
     {
       "id": 8,
       "name": "Water (flowing)",
+      "flatname": "minecraft:flowing_water",
       "color": "#1f55ff",
       "alpha": 0.53,
       "transparent": true,
@@ -175,6 +176,7 @@
     {
       "id": 10,
       "name": "Lava (flowing)",
+      "flatname": "minecraft:flowing_lava",
       "color": "#fc5700",
       "transparent": true,
       "liquid": true
@@ -628,7 +630,7 @@
         {
           "data": 7,
           "name": "Double Quartz Slab",
-          "flatname": "minecraft:quartz_slab",
+          "flatname": "minecraft:smooth_quartz",
           "color": "#f0eee8"
         },
         {
@@ -659,7 +661,7 @@
         {
           "data": 2,
           "name": "Wooden Slab",
-      "flatname": "minecraft:oak_slab",
+          "flatname": "minecraft:oak_slab",
           "color": "#b4905a"
         },
         {
@@ -1929,26 +1931,31 @@
     {
       "id": 155,
       "name": "Quartz Block",
+      "flatname": "minecraft:quartz_block",
       "color": "#edebe5",
       "variants": [
         {
           "data": 1,
           "name": "Chiseled Quartz Block",
+          "flatname": "minecraft:chiseled_quartz_block",
           "color": "#e3dfd5"
         },
         {
           "data": 2,
           "name": "Pillar Quartz Block",
+          "flatname": "minecraft:quartz_pillar",
           "color": "#e1dcd3"
         },
         {
           "data": 3,
           "name": "Pillar Quartz Block",
+          "flatname": "minecraft:quartz_pillar",
           "color": "#e1dcd3"
         },
         {
           "data": 4,
           "name": "Pillar Quartz Block",
+          "flatname": "minecraft:quartz_pillar",
           "color": "#e1dcd3"
         }
       ]
@@ -2630,6 +2637,7 @@
     {
       "id": 209,
       "name": "End Gateway Block",
+      "flatname": "minecraft:end_gateway",
       "color": "#000000"
     },
     {

--- a/flatteningconverter.cpp
+++ b/flatteningconverter.cpp
@@ -78,10 +78,13 @@ void FlatteningConverter::parseDefinition(
     flatname = b->at("flatname")->asString();
 
   palette[bid].name = flatname;
+  palette[bid].hid  = qHash(palette[bid].name);
   if ((parentID == NULL) && (data == 0)) {
     // spread main block type for data == 0
     for (int d=1; d<16; d++) {
-      palette[bid | (d<<8)].name = flatname;
+      int sid = bid | (d<<8);
+      palette[sid].name = flatname;
+      palette[sid].hid  = palette[bid].hid;
     }
   }
   //  packs[pack].append(block);
@@ -106,6 +109,7 @@ void FlatteningConverter::parseDefinition(
       int id  = bid | (j << 8);
       int mid = bid | ((j & mask) << 8);
       palette[id].name = palette[mid].name;
+      palette[id].hid  = palette[mid].hid;
     }
   }
 }

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -450,7 +450,7 @@ void MapView::renderChunk(Chunk *chunk) {
         //int data = section->getData(offset, y);
 
         // get BlockInfo from block value
-        BlockInfo &block = blocks->getBlockInfo(section->getBlock(offset, y));
+        BlockInfo &block = blocks->getBlockInfo(section->getBlockData(offset, y).hid);
         if (block.alpha == 0.0) continue;
 
         // get light value from one block above
@@ -512,13 +512,13 @@ void MapView::renderChunk(Chunk *chunk) {
           if (y > 0)
             sectionB = chunk->sections[(y-1) >> 4];
           if (section1) {
-            blid1 = section1->getBlock(offset, y+1);
+            blid1 = section1->getBlockData(offset, y+1).hid;
           }
           if (section2) {
-            blid2 = section2->getBlock(offset, y+2);
+            blid2 = section2->getBlockData(offset, y+2).hid;
           }
           if (sectionB) {
-            blidB = sectionB->getBlock(offset, y-1);
+            blidB = sectionB->getBlockData(offset, y-1).hid;
           }
           BlockInfo &block2 = blocks->getBlockInfo(blid2);
           BlockInfo &block1 = blocks->getBlockInfo(blid1);
@@ -585,7 +585,7 @@ void MapView::renderChunk(Chunk *chunk) {
           // get data value
           // int data = section->getData(offset, y);
           // get BlockInfo from block value
-          BlockInfo &block = blocks->getBlockInfo(section->getBlock(offset, y));
+          BlockInfo &block = blocks->getBlockInfo(section->getBlockData(offset, y).hid);
           if (block.transparent) {
             cave_factor -= caveshade[cave_test];
           }
@@ -628,15 +628,13 @@ void MapView::getToolTip(int x, int z) {
         y = (sec << 4) - 1;  // skip entire section
         continue;
       }
-      int yoffset = (y & 0xf) << 8;
-      //int data = section->data[(offset + yoffset) / 2];
-      //if (x & 1) data >>= 4;
-      auto &block = blocks->getBlockInfo(section->getBlock(offset, y));
+      // get information about block
+      const BlockData & bdata = section->getBlockData(offset, y);
+      name = bdata.name;
+      // in case of fully transparent blocks (meaning air)
+      // -> we continue downwards
+      auto & block = blocks->getBlockInfo(bdata.hid);
       if (block.alpha == 0.0) continue;
-      // found block
-      name = block.getName();
-      //id = section->blocks[offset + yoffset];
-      //bd = data & 0xf;
       break;
     }
     auto &bi = biomes->getBiome(chunk->biomes[(x & 0xf) + (z & 0xf) * 16]);

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -450,7 +450,7 @@ void MapView::renderChunk(Chunk *chunk) {
         //int data = section->getData(offset, y);
 
         // get BlockInfo from block value
-        BlockInfo &block = blocks->getBlock(section->getBlock(offset, y));
+        BlockInfo &block = blocks->getBlockInfo(section->getBlock(offset, y));
         if (block.alpha == 0.0) continue;
 
         // get light value from one block above
@@ -504,8 +504,7 @@ void MapView::renderChunk(Chunk *chunk) {
         }
         if (flags & flgMobSpawn) {
           // get block info from 1 and 2 above and 1 below
-          QString blid1(""), blid2(""), blidB("");  // default to air
-          int data1(0), data2(0), dataB(0);  // default variant
+          uint blid1(0), blid2(0), blidB(0);  // default to legacy air (todo: better handling of block above)
           ChunkSection *section2 = NULL;
           ChunkSection *sectionB = NULL;
           if (y < 254)
@@ -514,20 +513,17 @@ void MapView::renderChunk(Chunk *chunk) {
             sectionB = chunk->sections[(y-1) >> 4];
           if (section1) {
             blid1 = section1->getBlock(offset, y+1);
-            // data1 = section1->getData(offset, y+1);
           }
           if (section2) {
             blid2 = section2->getBlock(offset, y+2);
-            // data2 = section2->getData(offset, y+2);
           }
           if (sectionB) {
             blidB = sectionB->getBlock(offset, y-1);
-            // dataB = sectionB->getData(offset, y-1);
           }
-          BlockInfo &block2 = blocks->getBlock(blid2);
-          BlockInfo &block1 = blocks->getBlock(blid1);
+          BlockInfo &block2 = blocks->getBlockInfo(blid2);
+          BlockInfo &block1 = blocks->getBlockInfo(blid1);
           BlockInfo &block0 = block;
-          BlockInfo &blockB = blocks->getBlock(blidB);
+          BlockInfo &blockB = blocks->getBlockInfo(blidB);
           int light0 = section->getBlockLight(offset, y);
 
            // spawn check #1: on top of solid block
@@ -589,7 +585,7 @@ void MapView::renderChunk(Chunk *chunk) {
           // get data value
           // int data = section->getData(offset, y);
           // get BlockInfo from block value
-          BlockInfo &block = blocks->getBlock(section->getBlock(offset, y));
+          BlockInfo &block = blocks->getBlockInfo(section->getBlock(offset, y));
           if (block.transparent) {
             cave_factor -= caveshade[cave_test];
           }
@@ -635,7 +631,7 @@ void MapView::getToolTip(int x, int z) {
       int yoffset = (y & 0xf) << 8;
       //int data = section->data[(offset + yoffset) / 2];
       //if (x & 1) data >>= 4;
-      auto &block = blocks->getBlock(section->getBlock(offset, y));
+      auto &block = blocks->getBlockInfo(section->getBlock(offset, y));
       if (block.alpha == 0.0) continue;
       // found block
       name = block.getName();


### PR DESCRIPTION
I think now we are prepared for 1.13:
+ converter is available to automatically convert old worlds into the new storage format with palette
+ performance is back at previous level
+ definition file handling was improved to get no file clashes
+ all Blocks up to 1.13.1 are entered in the definition file

- not all new Blocks have the correct color, but that can be fixed via definition file updates