### PR TITLE
add Structure parsing inside 1.13 Chunks

### DIFF
--- a/chunk.cpp
+++ b/chunk.cpp
@@ -27,7 +27,6 @@ Chunk::Chunk() {
 void Chunk::load(const NBT &nbt) {
   renderedAt = -1;  // impossible.
   renderedFlags = 0;  // no flags
-  memset(this->biomes, 127, 256);  // init to unknown biome
   for (int i = 0; i < 16; i++)
     this->sections[i] = NULL;
   highest = 0;
@@ -42,6 +41,7 @@ void Chunk::load(const NBT &nbt) {
   // load Biome per column
   auto biomes = level->at("Biomes");
   if (version >= 1519) {
+    // raw copy Biome data
     memcpy(this->biomes, biomes->toIntArray(), sizeof(int)*biomes->length());
   } else {
     // convert quint8 to quint32
@@ -163,8 +163,8 @@ void Chunk::loadSection1519(ChunkSection *cs, const Tag *section) {
     cs->blocks[4095-i] = getBits(byteData, i*bitSize, bitSize);
   }
   delete byteData;
-  // copy Light data (todo: Skylight is not needed)
-  memcpy(cs->skyLight, section->at("SkyLight")->toByteArray(), 2048);
+  // copy Light data
+//memcpy(cs->skyLight, section->at("SkyLight")->toByteArray(), 2048);
   memcpy(cs->blockLight, section->at("BlockLight")->toByteArray(), 2048);
 }
 
@@ -197,21 +197,21 @@ const BlockData & ChunkSection::getBlockData(int offset, int y) {
   return palette[blocks[offset + yoffset]];
 }
 
-quint8 ChunkSection::getSkyLight(int x, int y, int z) {
-  int xoffset = x;
-  int yoffset = (y & 0x0f) << 8;
-  int zoffset = z << 4;
-  int value = skyLight[(xoffset + yoffset + zoffset) / 2];
-  if (x & 1) value >>= 4;
-  return value & 0x0f;
-}
+//quint8 ChunkSection::getSkyLight(int x, int y, int z) {
+//  int xoffset = x;
+//  int yoffset = (y & 0x0f) << 8;
+//  int zoffset = z << 4;
+//  int value = skyLight[(xoffset + yoffset + zoffset) / 2];
+//  if (x & 1) value >>= 4;
+//  return value & 0x0f;
+//}
 
-quint8 ChunkSection::getSkyLight(int offset, int y) {
-  int yoffset = (y & 0x0f) << 8;
-  int value = skyLight[(offset + yoffset) / 2];
-  if (offset & 1) value >>= 4;
-  return value & 0x0f;
-}
+//quint8 ChunkSection::getSkyLight(int offset, int y) {
+//  int yoffset = (y & 0x0f) << 8;
+//  int value = skyLight[(offset + yoffset) / 2];
+//  if (offset & 1) value >>= 4;
+//  return value & 0x0f;
+//}
 
 quint8 ChunkSection::getBlockLight(int x, int y, int z) {
   int xoffset = x;

--- a/chunk.h
+++ b/chunk.h
@@ -8,6 +8,7 @@
 #include "./nbt.h"
 #include "./entity.h"
 #include "./blockdata.h"
+#include "./generatedstructure.h"
 
 
 class ChunkSection {
@@ -27,11 +28,18 @@ class ChunkSection {
   quint8  blockLight[16*16*16/2];
 };
 
-class Chunk {
+
+class Chunk : public QObject {
+  Q_OBJECT
+
  public:
   Chunk();
-  void load(const NBT &nbt);
   ~Chunk();
+  void load(const NBT &nbt);
+
+ signals:
+  void structureFound(QSharedPointer<GeneratedStructure> structure);
+
  protected:
   void loadSection1343(ChunkSection *cs, const Tag *section);
   void loadSection1519(ChunkSection *cs, const Tag *section);

--- a/chunk.h
+++ b/chunk.h
@@ -23,7 +23,7 @@ class ChunkSection {
   int        paletteLength;
 
   quint16 blocks[16*16*16];
-  quint8  skyLight[16*16*16/2];
+//quint8  skyLight[16*16*16/2];   // not needed in Minutor
   quint8  blockLight[16*16*16/2];
 };
 
@@ -39,7 +39,7 @@ class Chunk {
 
   typedef QMap<QString, QSharedPointer<OverlayItem>> EntityMap;
 
-  quint32 biomes[256];
+  quint32 biomes[16*16];
   int highest;
   ChunkSection *sections[16];
   int renderedAt;

--- a/chunkcache.cpp
+++ b/chunkcache.cpp
@@ -35,6 +35,9 @@ ChunkCache::ChunkCache() {
 #endif
   cache.setMaxCost(chunks);
   maxcache = 2 * chunks;  // most chunks are less than half filled with sections
+
+
+  qRegisterMetaType<QSharedPointer<GeneratedStructure>>("QSharedPointer<GeneratedStructure>");
 }
 
 ChunkCache::~ChunkCache() {
@@ -66,6 +69,8 @@ Chunk *ChunkCache::fetch(int x, int z) {
   }
   // launch background process to load this chunk
   chunk = new Chunk();
+  connect(chunk, SIGNAL(structureFound(QSharedPointer<GeneratedStructure>)),
+          this,  SLOT  (routeStructure(QSharedPointer<GeneratedStructure>)));
   mutex.lock();
   cache.insert(id, chunk);
   mutex.unlock();
@@ -78,6 +83,10 @@ Chunk *ChunkCache::fetch(int x, int z) {
 
 void ChunkCache::gotChunk(int x, int z) {
   emit chunkLoaded(x, z);
+}
+
+void ChunkCache::routeStructure(QSharedPointer<GeneratedStructure> structure) {
+  emit structureFound(structure);
 }
 
 void ChunkCache::adaptCacheToWindow(int x, int y) {

--- a/chunkcache.h
+++ b/chunkcache.h
@@ -28,12 +28,14 @@ class ChunkCache : public QObject {
 
  signals:
   void chunkLoaded(int x, int z);
+  void structureFound(QSharedPointer<GeneratedStructure> structure);
 
  public slots:
   void adaptCacheToWindow(int x, int y);
 
  private slots:
   void gotChunk(int x, int z);
+  void routeStructure(QSharedPointer<GeneratedStructure> structure);
 
  private:
   QString path;

--- a/flatteningconverter.cpp
+++ b/flatteningconverter.cpp
@@ -4,7 +4,7 @@
 #include <assert.h>
 #include <cmath>
 
-#include "./FlatteningConverter.h"
+#include "./flatteningconverter.h"
 #include "./json.h"
 
 

--- a/generatedstructure.cpp
+++ b/generatedstructure.cpp
@@ -3,51 +3,92 @@
 #include "./generatedstructure.h"
 #include "./nbt.h"
 
+
+// parse structures in *.dat files
 QList<QSharedPointer<GeneratedStructure>>
-GeneratedStructure::tryParse(const Tag* data) {
+GeneratedStructure::tryParseDatFile(const Tag* data) {
+  // we will return a list of all found structures
   QList<QSharedPointer<GeneratedStructure>> ret;
+
+  // parse NBT data for "Features"
   if (data && data != &NBT::Null) {
     auto features = data->at("Features");
     if (features && features != &NBT::Null) {
       // convert the features to a qvariant here
       QVariant maybeFeatureMap = features->getData();
-      if ((QMetaType::Type)maybeFeatureMap.type() == QMetaType::QVariantMap) {
-        QMap<QString, QVariant> featureMap = maybeFeatureMap.toMap();
-        for (auto &feature : featureMap) {
-          if ((QMetaType::Type)feature.type() == QMetaType::QVariantMap) {
-            QMap<QString, QVariant> featureProperties = feature.toMap();
-            // check for required properties
-            if (featureProperties.contains("BB") &&
-                (QMetaType::Type)featureProperties["BB"].type() ==
-                QMetaType::QVariantList && featureProperties.contains("id")) {
-              QList<QVariant> bb = featureProperties["BB"].toList();
-              if (bb.size() == 6) {
-                GeneratedStructure* structure = new GeneratedStructure();
-                structure->setBounds(
-                    Point(bb[0].toInt(), bb[1].toInt(), bb[2].toInt()),
-                    Point(bb[3].toInt(), bb[4].toInt(), bb[5].toInt()));
-                structure->setType("Structure." +
-                                   featureProperties["id"].toString());
-                structure->setDisplay(featureProperties["id"].toString());
-                structure->setProperties(featureProperties);
+      ret.append( GeneratedStructure::tryParseFeatures(maybeFeatureMap) );
+    }
+  }
+  return ret;
+}
 
-                // base the color on a hash of its type
-                quint32 hue = qHash(featureProperties["id"].toString());
-                QColor color;
-                color.setHsv(hue % 360, 255, 255, 64);
-                structure->setColor(color);
+// parse structures in Chunks
+QList<QSharedPointer<GeneratedStructure>>
+GeneratedStructure::tryParseChunk(const Tag* data) {
+  // we will return a list of all found structures
+  QList<QSharedPointer<GeneratedStructure>> ret;
 
-                // this will have to be maintained if new structures are added
-                if (structure->type() == "Structure.Fortress") {
-                  structure->setDimension("nether");
-                } else if (structure->type() == "Structure.EndCity") {
-                  structure->setDimension("end");
-                } else {
-                  structure->setDimension("overworld");
-                }
-                ret.append(QSharedPointer<GeneratedStructure>(structure));
-              }
+  // parse NBT data for "Starts"
+  if (data && data != &NBT::Null) {
+    auto features = data->at("Starts");
+    if (features && features != &NBT::Null) {
+      // convert the features to a qvariant here
+      QVariant maybeFeatureMap = features->getData();
+      ret.append( GeneratedStructure::tryParseFeatures(maybeFeatureMap) );
+    }
+  }
+  return ret;
+}
+
+QList<QSharedPointer<GeneratedStructure>>
+GeneratedStructure::tryParseFeatures(QVariant &maybeFeatureMap) {
+  // we will return a list of all found structures
+  QList<QSharedPointer<GeneratedStructure>> ret;
+
+  // check if we got a map
+  if ((QMetaType::Type)maybeFeatureMap.type() == QMetaType::QVariantMap) {
+    // convert it to a real map
+    QMap<QString, QVariant> featureMap = maybeFeatureMap.toMap();
+
+    // loop over all elements in feature map
+    for (auto &feature : featureMap) {
+      // check if the element is also a map
+      if ((QMetaType::Type)feature.type() == QMetaType::QVariantMap) {
+        // convert it to a real map
+        QMap<QString, QVariant> featureProperties = feature.toMap();
+        // check for required properties
+        if (featureProperties.contains("id") &&
+            featureProperties.contains("BB") &&
+            (QMetaType::Type)featureProperties["BB"].type() == QMetaType::QVariantList ) {
+          // parse id
+          QString id = featureProperties["id"].toString();
+          // parse Bounding Box
+          QList<QVariant> bb = featureProperties["BB"].toList();
+          if (bb.size() == 6) {
+            GeneratedStructure* structure = new GeneratedStructure();
+            structure->setBounds(
+              Point(bb[0].toInt(), bb[1].toInt(), bb[2].toInt()),
+              Point(bb[3].toInt(), bb[4].toInt(), bb[5].toInt()));
+            structure->setType("Structure." + id);
+            structure->setDisplay(id);
+            structure->setProperties(featureProperties);
+
+            // base the color on a hash of its type
+            int    hue = qHash(id) % 360;
+            QColor color;
+            color.setHsv(hue, 255, 255, 64);
+            structure->setColor(color);
+
+            // this will have to be maintained if new structures are added
+            // that are appearing only a some Dimensions
+            if (structure->type() == "Structure.Fortress") {
+              structure->setDimension("nether");
+            } else if (structure->type() == "Structure.EndCity") {
+              structure->setDimension("end");
+            } else {
+              structure->setDimension("overworld");
             }
+            ret.append( QSharedPointer<GeneratedStructure>(structure) );
           }
         }
       }
@@ -58,8 +99,9 @@ GeneratedStructure::tryParse(const Tag* data) {
 
 bool GeneratedStructure::intersects(const Point& min,
                                     const Point& max) const {
-  return min.x <= p2.x && p1.x <= max.x && min.y <= p2.y &&
-      p1.y <= max.y && min.z <= p2.z && p1.z <= max.z;
+  return min.x <= p2.x && p1.x <= max.x &&
+         min.y <= p2.y && p1.y <= max.y &&
+         min.z <= p2.z && p1.z <= max.z;
 }
 
 void GeneratedStructure::draw(double offsetX, double offsetZ, double scale,

--- a/generatedstructure.h
+++ b/generatedstructure.h
@@ -11,7 +11,9 @@ class QColor;
 
 class GeneratedStructure: public OverlayItem {
  public:
-  static QList<QSharedPointer<GeneratedStructure>> tryParse(const Tag* tag);
+  static QList<QSharedPointer<GeneratedStructure>> tryParseDatFile(const Tag* tag);
+  static QList<QSharedPointer<GeneratedStructure>> tryParseChunk(const Tag* tag);
+  static QList<QSharedPointer<GeneratedStructure>> tryParseFeatures(QVariant &maybeFeatureMap);
 
   virtual bool intersects(const Point& min, const Point& max) const;
   virtual void draw(double offsetX, double offsetZ, double scale,

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -15,7 +15,9 @@ MapView::MapView(QWidget *parent) : QWidget(parent) {
   scale = 1;
   zoom = 1.0;
   connect(&cache, SIGNAL(chunkLoaded(int, int)),
-          this, SLOT(chunkUpdated(int, int)));
+          this,   SLOT  (chunkUpdated(int, int)));
+  connect(&cache, SIGNAL(structureFound(QSharedPointer<GeneratedStructure>)),
+          this,   SLOT  (addStructureFromChunk(QSharedPointer<GeneratedStructure>)));
   setMouseTracking(true);
   setFocusPolicy(Qt::StrongFocus);
 
@@ -313,9 +315,10 @@ void MapView::redraw() {
   // draw the entities
   for (int cz = startz; cz < startz + blockstall; cz++) {
     for (int cx = startx; cx < startx + blockswide; cx++) {
-      for (auto &type : overlayItemTypes) {
-        Chunk *chunk = cache.fetch(cx, cz);
-        if (chunk) {
+      Chunk *chunk = cache.fetch(cx, cz);
+      if (chunk) {
+        // Entities from Chunks
+        for (auto &type : overlayItemTypes) {
           auto range = chunk->entities.equal_range(type);
           for (auto it = range.first; it != range.second; ++it) {
             // don't show entities above our depth
@@ -333,10 +336,10 @@ void MapView::redraw() {
             }
           }
         }
+
       }
     }
   }
-
 
   // draw the generated structures
   for (auto &type : overlayItemTypes) {
@@ -669,11 +672,22 @@ void MapView::getToolTip(int x, int z) {
                         .arg(entityStr));
 }
 
+void MapView::addStructureFromChunk(QSharedPointer<GeneratedStructure> structure) {
+  // update menu (if necessary)
+  emit addOverlayItemType(structure->type(), structure->color());
+  // add to list with overlays
+  addOverlayItem(structure);
+}
+
 void MapView::addOverlayItem(QSharedPointer<OverlayItem> item) {
   overlayItems[item->type()].push_back(item);
 }
 
-void MapView::showOverlayItemTypes(const QSet<QString>& itemTypes) {
+void MapView::clearOverlayItems() {
+  overlayItems.clear();
+}
+
+void MapView::setVisibleOverlayItemTypes(const QSet<QString>& itemTypes) {
   overlayItemTypes = itemTypes;
 }
 

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -643,6 +643,7 @@ void MapView::getToolTip(int x, int z) {
     auto &bi = biomes->getBiome(chunk->biomes[(x & 0xf) + (z & 0xf) * 16]);
     biome = bi.name;
 
+    // count Entity of each display type
     for (auto &item : getItems(x, y, z)) {
       entityIds[item->display()]++;
     }
@@ -651,8 +652,8 @@ void MapView::getToolTip(int x, int z) {
   QString entityStr;
   if (!entityIds.empty()) {
     QStringList entities;
-    QMap<QString, int>::iterator it, itEnd = entityIds.end();
-    for (it = entityIds.begin(); it != itEnd; ++it) {
+    QMap<QString, int>::const_iterator it, itEnd = entityIds.cend();
+    for (it = entityIds.cbegin(); it != itEnd; ++it) {
       if (it.value() > 1) {
         entities << it.key() + ":" + QString::number(it.value());
       } else {
@@ -680,6 +681,14 @@ void MapView::addStructureFromChunk(QSharedPointer<GeneratedStructure> structure
 }
 
 void MapView::addOverlayItem(QSharedPointer<OverlayItem> item) {
+  // test if item is already in list
+  for (auto &it: overlayItems[item->type()]) {
+    OverlayItem::Point p1 = it  ->midpoint();
+    OverlayItem::Point p2 = item->midpoint();
+    if ( (p1.x == p2.x) && (p1.y == p2.y) && (p1.z == p2.z) )
+      return;  // skip if already present
+  }
+  // otherwise add item
   overlayItems[item->type()].push_back(item);
 }
 

--- a/mapview.h
+++ b/mapview.h
@@ -42,7 +42,8 @@ class MapView : public QWidget {
   void setDimension(QString path, int scale);
   void setFlags(int flags);
   void addOverlayItem(QSharedPointer<OverlayItem> item);
-  void showOverlayItemTypes(const QSet<QString>& itemTypes);
+  void clearOverlayItems();
+  void setVisibleOverlayItemTypes(const QSet<QString>& itemTypes);
 
   // public for saving the png
   void renderChunk(Chunk *chunk);
@@ -75,6 +76,9 @@ class MapView : public QWidget {
   void keyPressEvent(QKeyEvent *event);
   void resizeEvent(QResizeEvent *event);
   void paintEvent(QPaintEvent *event);
+
+ private slots:
+  void addStructureFromChunk(QSharedPointer<GeneratedStructure> structure);
 
  private:
   void drawChunk(int x, int z);

--- a/minutor.h
+++ b/minutor.h
@@ -118,12 +118,7 @@ private slots:
   DimensionIdentifier *dimensions;
   QDir currentWorld;
 
-  //           type                 x    z
-  typedef QMap<QString, QHash<QPair<int, int>,
-          QSharedPointer<OverlayItem>>> OverlayMap;
-  OverlayMap overlayItems;
   QSet<QString> overlayItemTypes;
-  int maxentitydistance;
   Properties * propView;
 };
 

--- a/overlayitem.h
+++ b/overlayitem.h
@@ -12,7 +12,7 @@ class OverlayItem {
  public:
   virtual ~OverlayItem() {}
   struct Point {
-    explicit Point(double x = 0, double y = 0, double z = 0):x(x), y(y), z(z) {}
+    explicit Point(double x = 0, double y = 0, double z = 0): x(x), y(y), z(z) {}
     double x, y, z;
   };
 

--- a/village.cpp
+++ b/village.cpp
@@ -2,8 +2,10 @@
 #include "./village.h"
 #include "./nbt.h"
 
+// parse structures in *.dat files
 QList<QSharedPointer<GeneratedStructure>>
-Village::tryParse(const Tag* tag, const QString& dimension) {
+Village::tryParseDatFile(const Tag* tag, const QString& dimension) {
+  // we will return a list of all found structures
   QList<QSharedPointer<GeneratedStructure> > ret;
 
   if (tag && tag != &NBT::Null) {

--- a/village.h
+++ b/village.h
@@ -7,7 +7,7 @@
 class Village : public GeneratedStructure {
  public:
   static QList<QSharedPointer<GeneratedStructure>>
-      tryParse(const Tag* tag, const QString &dimension);
+      tryParseDatFile(const Tag* tag, const QString &dimension);
 
  protected:
   Village() {}


### PR DESCRIPTION
This pull request adds parsing of Structure data inside Chunks.
In my opinion this was the only major missing feature for a 1.13 compatible release.

With Minecraft 1.13 update Structures are no longer stored in extra *.dat files, but as part of Chunks in region files. Storage format is very similar, only the entry NBT key is different. Therefore parsing data can share code between old (tryParseDatFile) and new (tryParseChunk) methods.
Most complicates thing was that Structures now pop up during parsing of Chunks, but are needed in mapview for rendering and minutor for menu creation. This is solved with a very complicated signal slot structure that bubbles up the Structures.
During migration both storage formats will occur in the same world. To prevent duplicate Structures we need a mechanism to prevent multiple entries of the same Structure. Another source for duplicates would be a very large map, where a Chunk was replaced in the Cache and is loaded again.


also fix #136 
also fix #137 
@thewierdnut you are probably the only one to review these changes