### PR TITLE
repair of definition files

### DIFF
--- a/blockidentifier.cpp
+++ b/blockidentifier.cpp
@@ -261,7 +261,7 @@ void BlockIdentifier::parseDefinition(JSONObject *b, BlockInfo *parent,
     // and prevents generating a wrong definition file
     QMessageBox::warning((QWidget*)(NULL),
                          "Error loading Block definition: " + name,
-                         "Failed to add Block from definition file, as it might be a duplicate\nor generates the same hash than an already existing Block." ,
+                         "Failed to add Block from definition file, as it might be a duplicate\nor generates the same hash as an already existing Block." ,
                          QMessageBox::Cancel, QMessageBox::Cancel);
   }
   blocks.insert(hid, block);

--- a/blockidentifier.cpp
+++ b/blockidentifier.cpp
@@ -256,16 +256,14 @@ void BlockIdentifier::parseDefinition(JSONObject *b, BlockInfo *parent,
   uint hid = qHash(name);
   if (!block->blockstate.isEmpty())
     hid = qHash(name + ":" + block->blockstate);
-#ifdef _DEBUG
   if (blocks.contains(hid)) {
     // this will only trigger during development of vanilla_blocks.json
     // and prevents generating a wrong definition file
     QMessageBox::warning((QWidget*)(NULL),
-                         "Error hashing Block",
-                         name,
+                         "Error loading Block definition: " + name,
+                         "Failed to add Block from definition file, as it might be a duplicate\nor generates the same hash than an already existing Block." ,
                          QMessageBox::Cancel, QMessageBox::Cancel);
   }
-#endif
   blocks.insert(hid, block);
   packs[pack].append(block);
 

--- a/blockidentifier.cpp
+++ b/blockidentifier.cpp
@@ -256,6 +256,7 @@ void BlockIdentifier::parseDefinition(JSONObject *b, BlockInfo *parent,
   uint hid = qHash(name);
   if (!block->blockstate.isEmpty())
     hid = qHash(name + ":" + block->blockstate);
+#ifdef _DEBUG
   if (blocks.contains(hid)) {
     // this will only trigger during development of vanilla_blocks.json
     // and prevents generating a wrong definition file
@@ -264,6 +265,7 @@ void BlockIdentifier::parseDefinition(JSONObject *b, BlockInfo *parent,
                          name,
                          QMessageBox::Cancel, QMessageBox::Cancel);
   }
+#endif
   blocks.insert(hid, block);
   packs[pack].append(block);
 

--- a/definitionmanager.h
+++ b/definitionmanager.h
@@ -66,6 +66,7 @@ class DefinitionManager : public QWidget {
   QList<QCheckBox *>checks;
   void installJson(QString path, bool overwrite = true, bool install = true);
   void installZip(QString path, bool overwrite = true, bool install = true);
+  void checkAndRepair();
   void loadDefinition(QString path);
   void loadDefinition(JSONData *, int pack = -1);
   void removeDefinition(QString path);


### PR DESCRIPTION
This also closes #161

Added an new private method to DefinitionManager to hold all maintenance code regarding definition files. This contains for the moment:
* force delete old hashed names (before Qt5.12 compatibility)
* delete orphaned definitions in settings (matching files were deleted)
* refresh old definitions on disk with build-in definitions (from newer releases)