### PR TITLE
DefinitionManager: Remove dest file before copying new definitions

### DIFF
--- a/definitionmanager.cpp
+++ b/definitionmanager.cpp
@@ -269,8 +269,10 @@ void DefinitionManager::installJson(QString path, bool overwrite,
 
   // import new definition (if file is not present)
   if (!QFile::exists(dest) || overwrite) {
-    if (QFile::exists(dest) && install)
+    if (QFile::exists(dest) && install) {
       removeDefinition(dest);
+      QFile::remove(dest);
+    }
     if (!QFile::copy(path, dest)) {
       QMessageBox::warning(this, tr("Couldn't install %1").arg(path),
                            tr("Copy error"),


### PR DESCRIPTION
This fixes a weird error that the built-in definitions cannot be installed once the user removes them from the list. The default definition files were copied to the writable cache but not installed; user's attempts to install them then failed with "cannot copy file" error because the file already existed.

After: Any definition file that is about to be installed is first removed from the destination (-> overwrite)