### PR TITLE
Asynchronous chunk loading & rendering (using Thread Pool)

### DIFF
--- a/chunk.h
+++ b/chunk.h
@@ -59,6 +59,7 @@ class Chunk : public QObject {
   int chunkX;
   int chunkZ;
   friend class MapView;
+  friend class ChunkRenderer;
   friend class ChunkCache;
   friend class WorldSave;
 };

--- a/chunkcache.cpp
+++ b/chunkcache.cpp
@@ -59,9 +59,9 @@ QString ChunkCache::getPath() {
 
 Chunk *ChunkCache::fetch(int x, int z) {
   ChunkID id(x, z);
-  //mutex.lock();
+  mutex.lock();
   Chunk *chunk = cache[id];   // const operation
-  //mutex.unlock();
+  mutex.unlock();
   if (chunk != NULL) {
     if (chunk->loaded)
       return chunk;

--- a/chunkcache.cpp
+++ b/chunkcache.cpp
@@ -59,9 +59,9 @@ QString ChunkCache::getPath() {
 
 Chunk *ChunkCache::fetch(int x, int z) {
   ChunkID id(x, z);
-  mutex.lock();
-  Chunk *chunk = cache[id];
-  mutex.unlock();
+  //mutex.lock();
+  Chunk *chunk = cache[id];   // const operation
+  //mutex.unlock();
   if (chunk != NULL) {
     if (chunk->loaded)
       return chunk;
@@ -72,7 +72,7 @@ Chunk *ChunkCache::fetch(int x, int z) {
   connect(chunk, SIGNAL(structureFound(QSharedPointer<GeneratedStructure>)),
           this,  SLOT  (routeStructure(QSharedPointer<GeneratedStructure>)));
   mutex.lock();
-  cache.insert(id, chunk);
+  cache.insert(id, chunk);    // non-const operation !
   mutex.unlock();
   ChunkLoader *loader = new ChunkLoader(path, x, z, cache, &mutex);
   connect(loader, SIGNAL(loaded(int, int)),

--- a/chunkcache.h
+++ b/chunkcache.h
@@ -51,6 +51,7 @@ class ChunkCache : public QObject {
   QCache<ChunkID, Chunk> cache;   // real Cache
   QMutex mutex;                   // Mutex for accessing the Cache
   int maxcache;                   // number of Chunks that fit into Cache
+  QThreadPool loaderThreadPool;   // extra thread pool for loading
 };
 
 #endif  // CHUNKCACHE_H_

--- a/chunkcache.h
+++ b/chunkcache.h
@@ -8,40 +8,49 @@
 
 class ChunkID {
  public:
-  ChunkID(int x, int z);
+  ChunkID(int cx, int cz);
   bool operator==(const ChunkID &) const;
   friend uint qHash(const ChunkID &);
  protected:
-  int x, z;
+  int cx, cz;
 };
 
 class ChunkCache : public QObject {
   Q_OBJECT
 
  public:
+  // singleton: access to global usable instance
+  static ChunkCache &Instance();
+ private:
+  // singleton: prevent access to constructor and copyconstructor
   ChunkCache();
   ~ChunkCache();
+  ChunkCache(const ChunkCache &);
+  ChunkCache &operator=(const ChunkCache &);
+
+ public:
   void clear();
   void setPath(QString path);
-  QString getPath();
-  Chunk *fetch(int x, int z);
+  QString getPath() const;
+  Chunk *fetch(int cx, int cz);         // fetch Chunk and load when not found
+  Chunk *fetchCached(int cx, int cz);   // fetch Chunk only if cached
 
  signals:
-  void chunkLoaded(int x, int z);
+  void chunkLoaded(int cx, int cz);
   void structureFound(QSharedPointer<GeneratedStructure> structure);
 
  public slots:
-  void adaptCacheToWindow(int x, int y);
+  void adaptCacheToWindow(int wx, int wy);
 
  private slots:
-  void gotChunk(int x, int z);
+  void gotChunk(int cx, int cz);
   void routeStructure(QSharedPointer<GeneratedStructure> structure);
 
  private:
-  QString path;
-  QCache<ChunkID, Chunk> cache;
-  QMutex mutex;
-  int maxcache;
+  QString path;                   // path to folder with region files
+  QCache<ChunkID, Chunk> cache;   // real Cache
+  QMutex mutex;                   // Mutex for accessing the Cache
+  int maxcache;                   // number of Chunks that fit into Cache
 };
 
 #endif  // CHUNKCACHE_H_

--- a/chunkloader.cpp
+++ b/chunkloader.cpp
@@ -45,9 +45,9 @@ void ChunkLoader::run() {
   }
   // get existing Chunk entry from Cache
   ChunkID id(x, z);
-  //mutex->lock();
+  mutex->lock();
   Chunk *chunk = cache[id];   // const operation
-  //mutex->unlock();
+  mutex->unlock();
   // parse Chunk data
   // Chunk will be flagged "loaded" in a thread save way
   if (chunk) {

--- a/chunkloader.cpp
+++ b/chunkloader.cpp
@@ -13,6 +13,7 @@ ChunkLoader::~ChunkLoader() {
 }
 
 void ChunkLoader::run() {
+  // get coordinates of Region file
   int rx = x >> 5;
   int rz = z >> 5;
 
@@ -42,13 +43,17 @@ void ChunkLoader::run() {
     emit loaded(x, z);
     return;
   }
-  NBT nbt(raw);
+  // get existing Chunk entry from Cache
   ChunkID id(x, z);
-  mutex->lock();
-  Chunk *chunk = cache[id];
-  if (chunk)
+  //mutex->lock();
+  Chunk *chunk = cache[id];   // const operation
+  //mutex->unlock();
+  // parse Chunk data
+  // Chunk will be flagged "loaded" in a thread save way
+  if (chunk) {
+    NBT nbt(raw);
     chunk->load(nbt);
-  mutex->unlock();
+  }
   f.unmap(raw);
   f.close();
 

--- a/chunkloader.h
+++ b/chunkloader.h
@@ -4,26 +4,25 @@
 
 #include <QObject>
 #include <QRunnable>
-class Chunk;
-class ChunkID;
-class QMutex;
+#include "chunkcache.h"
 
 class ChunkLoader : public QObject, public QRunnable {
   Q_OBJECT
 
  public:
-  ChunkLoader(QString path, int x, int z, const QCache<ChunkID, Chunk> &cache,
-              QMutex *mutex);
+  ChunkLoader(QString path, int cx, int cz);
   ~ChunkLoader();
+
  signals:
-  void loaded(int x, int z);
+  void loaded(int cx, int cz);
+
  protected:
   void run();
+
  private:
   QString path;
-  int x, z;
-  const QCache<ChunkID, Chunk> &cache;
-  QMutex *mutex;
+  int     cx, cz;
+  ChunkCache &cache;
 };
 
 #endif  // CHUNKLOADER_H_

--- a/chunkrenderer.cpp
+++ b/chunkrenderer.cpp
@@ -1,0 +1,234 @@
+/** Copyright (c) 2019, Mc_Etlam */
+
+#include "./chunk.h"
+#include "./chunkrenderer.h"
+#include "./chunkcache.h"
+#include "./mapview.h"
+#include "./blockidentifier.h"
+#include "./biomeidentifier.h"
+#include "./clamp.h"
+
+ChunkRenderer::ChunkRenderer(int cx, int cz, int y, int flags)
+  : cx(cx)
+  , cz(cz)
+  , depth(y)
+  , flags(flags)
+  , cache(ChunkCache::Instance())
+{}
+
+
+void ChunkRenderer::run() {
+  // get existing Chunk entry from Cache
+  Chunk *chunk = cache.fetchCached(cx, cz);
+  // render Chunk data
+  if (chunk) {
+    renderChunk(chunk);
+  }
+  emit rendered(cx, cz);
+}
+
+void ChunkRenderer::renderChunk(Chunk *chunk) {
+  int offset = 0;
+  uchar *bits = chunk->image;
+  uchar *depthbits = chunk->depth;
+  for (int z = 0; z < 16; z++) {  // n->s
+    int lasty = -1;
+    for (int x = 0; x < 16; x++, offset++) {  // e->w
+      // initialize color
+      uchar r = 0, g = 0, b = 0;
+      double alpha = 0.0;
+      // get Biome
+      auto &biome = BiomeIdentifier::Instance().getBiome(chunk->biomes[offset]);
+      int top = depth;
+      if (top > chunk->highest)
+        top = chunk->highest;
+      int highest = 0;
+      for (int y = top; y >= 0; y--) {  // top->down
+        int sec = y >> 4;
+        ChunkSection *section = chunk->sections[sec];
+        if (!section) {
+          y = (sec << 4) - 1;  // skip whole section
+          continue;
+        }
+
+        // get data value
+        //int data = section->getData(offset, y);
+
+        // get BlockInfo from block value
+        BlockInfo &block = BlockIdentifier::Instance().getBlockInfo(section->getPaletteEntry(offset, y).hid);
+        if (block.alpha == 0.0) continue;
+
+        // get light value from one block above
+        int light = 0;
+        ChunkSection *section1 = NULL;
+        if (y < 255)
+          section1 = chunk->sections[(y+1) >> 4];
+        if (section1)
+          light = section1->getBlockLight(offset, y+1);
+        int light1 = light;
+        if (!(flags & MapView::flgLighting))
+          light = 13;
+        if (alpha == 0.0 && lasty != -1) {
+          if (lasty < y)
+            light += 2;
+          else if (lasty > y)
+            light -= 2;
+        }
+//        if (light < 0) light = 0;
+//        if (light > 15) light = 15;
+
+        // get current block color
+        QColor blockcolor = block.colors[15];  // get the color from Block definition
+        if (block.biomeWater()) {
+          blockcolor = biome.getBiomeWaterColor(blockcolor);
+        }
+        else if (block.biomeGrass()) {
+          blockcolor = biome.getBiomeGrassColor(blockcolor, y-64);
+        }
+        else if (block.biomeFoliage()) {
+          blockcolor = biome.getBiomeFoliageColor(blockcolor, y-64);
+        }
+
+        // shade color based on light value
+        double light_factor = pow(0.90,15-light);
+        quint32 colr = std::clamp( int(light_factor*blockcolor.red()),   0, 255 );
+        quint32 colg = std::clamp( int(light_factor*blockcolor.green()), 0, 255 );
+        quint32 colb = std::clamp( int(light_factor*blockcolor.blue()),  0, 255 );
+
+        // process flags
+        if (flags & MapView::flgDepthShading) {
+          // Use a table to define depth-relative shade:
+          static const quint32 shadeTable[] = {
+            0, 12, 18, 22, 24, 26, 28, 29, 30, 31, 32};
+          size_t idx = qMin(static_cast<size_t>(depth - y),
+                            sizeof(shadeTable) / sizeof(*shadeTable) - 1);
+          quint32 shade = shadeTable[idx];
+          colr = colr - qMin(shade, colr);
+          colg = colg - qMin(shade, colg);
+          colb = colb - qMin(shade, colb);
+        }
+        if (flags & MapView::flgMobSpawn) {
+          // get block info from 1 and 2 above and 1 below
+          uint blid1(0), blid2(0), blidB(0);  // default to legacy air (todo: better handling of block above)
+          ChunkSection *section2 = NULL;
+          ChunkSection *sectionB = NULL;
+          if (y < 254)
+            section2 = chunk->sections[(y+2) >> 4];
+          if (y > 0)
+            sectionB = chunk->sections[(y-1) >> 4];
+          if (section1) {
+            blid1 = section1->getPaletteEntry(offset, y+1).hid;
+          }
+          if (section2) {
+            blid2 = section2->getPaletteEntry(offset, y+2).hid;
+          }
+          if (sectionB) {
+            blidB = sectionB->getPaletteEntry(offset, y-1).hid;
+          }
+          BlockInfo &block2 = BlockIdentifier::Instance().getBlockInfo(blid2);
+          BlockInfo &block1 = BlockIdentifier::Instance().getBlockInfo(blid1);
+          BlockInfo &block0 = block;
+          BlockInfo &blockB = BlockIdentifier::Instance().getBlockInfo(blidB);
+          int light0 = section->getBlockLight(offset, y);
+
+           // spawn check #1: on top of solid block
+           if (block0.doesBlockHaveSolidTopSurface() &&
+               !block0.isBedrock() && light1 < 8 &&
+               !block1.isBlockNormalCube() && block1.spawninside &&
+               !block1.isLiquid() &&
+               !block2.isBlockNormalCube() && block2.spawninside) {
+             colr = (colr + 256) / 2;
+             colg = (colg + 0) / 2;
+             colb = (colb + 192) / 2;
+           }
+           // spawn check #2: current block is transparent,
+           // but mob can spawn through (e.g. snow)
+           if (blockB.doesBlockHaveSolidTopSurface() &&
+               !blockB.isBedrock() && light0 < 8 &&
+               !block0.isBlockNormalCube() && block0.spawninside &&
+               !block0.isLiquid() &&
+               !block1.isBlockNormalCube() && block1.spawninside) {
+             colr = (colr + 192) / 2;
+             colg = (colg + 0) / 2;
+             colb = (colb + 256) / 2;
+           }
+        }
+        if (flags & MapView::flgBiomeColors) {
+          colr = biome.colors[light].red();
+          colg = biome.colors[light].green();
+          colb = biome.colors[light].blue();
+          alpha = 0;
+        }
+
+        // combine current block to final color
+        if (alpha == 0.0) {
+          // first color sample
+          alpha = block.alpha;
+          r = colr;
+          g = colg;
+          b = colb;
+          highest = y;
+        } else {
+          // combine further color samples with blending
+          r = (quint8)(alpha * r + (1.0 - alpha) * colr);
+          g = (quint8)(alpha * g + (1.0 - alpha) * colg);
+          b = (quint8)(alpha * b + (1.0 - alpha) * colb);
+          alpha += block.alpha * (1.0 - alpha);
+        }
+
+        // finish depth (Y) scanning when color is saturated enough
+        if (block.alpha == 1.0 || alpha > 0.9)
+          break;
+      }
+      if (flags & MapView::flgCaveMode) {
+        float cave_factor = 1.0;
+        int cave_test = 0;
+        for (int y=highest-1; (y >= 0) && (cave_test < CaveShade::CAVE_DEPTH); y--, cave_test++) {  // top->down
+          // get section
+          ChunkSection *section = chunk->sections[y >> 4];
+          if (!section) continue;
+          // get data value
+          // int data = section->getData(offset, y);
+          // get BlockInfo from block value
+          BlockInfo &block = BlockIdentifier::Instance().getBlockInfo(section->getPaletteEntry(offset, y).hid);
+          if (block.transparent) {
+            cave_factor -= CaveShade::getShade(cave_test);
+          }
+        }
+        cave_factor = std::max(cave_factor,0.25f);
+        // darken color by blending with cave shade factor
+        r = (quint8)(cave_factor * r);
+        g = (quint8)(cave_factor * g);
+        b = (quint8)(cave_factor * b);
+      }
+      *depthbits++ = lasty = highest;
+      *bits++ = b;
+      *bits++ = g;
+      *bits++ = r;
+      *bits++ = 0xff;
+    }
+  }
+  chunk->renderedAt = depth;
+  chunk->renderedFlags = flags;
+}
+
+
+// define a shading curve for Cave Mode:
+
+CaveShade::CaveShade()
+{
+  // calculate exponential function for cave shade
+  float cavesum = 0.0;
+  for (int i=0; i<CAVE_DEPTH; i++) {
+   caveshade[i] = 1/exp(i/(CAVE_DEPTH/2.0));
+    cavesum += caveshade[i];
+  }
+  for (int i=0; i<CAVE_DEPTH; i++) {
+    caveshade[i] = 1.5 * caveshade[i] / cavesum;
+  }
+}
+
+float CaveShade::getShade(int index) {
+  static CaveShade singleton;
+  return singleton.caveshade[index];
+}

--- a/chunkrenderer.h
+++ b/chunkrenderer.h
@@ -1,0 +1,48 @@
+/** Copyright (c) 2019, Mc_Etlam */
+#ifndef CHUNKRENDERER_H
+#define CHUNKRENDERER_H
+
+#include <QObject>
+#include <QRunnable>
+#include "chunkcache.h"
+
+class ChunkRenderer : public QObject, public QRunnable {
+  Q_OBJECT
+
+ public:
+  ChunkRenderer(int cx, int cz, int y, int flags);
+  ~ChunkRenderer() {}
+
+ protected:
+  void run();
+
+ public:  // public to allow usage from WorldSave
+  void ChunkRenderer::renderChunk(Chunk *chunk);
+
+ signals:
+  void rendered(int cx, int cz);
+
+ private:
+  int cx, cz;
+  int depth;
+  int flags;
+  ChunkCache &cache;
+};
+
+class CaveShade {
+ public:
+  // singleton: access to global usable instance
+  static float getShade(int index);
+ private:
+  // singleton: prevent access to constructor and copyconstructor
+  CaveShade();
+  ~CaveShade() {}
+  CaveShade(const CaveShade &);
+  CaveShade &operator=(const CaveShade &);
+
+ public:
+  static const int CAVE_DEPTH = 16;  // maximum depth caves are searched in cave mode
+  float caveshade[CAVE_DEPTH];
+};
+
+#endif // CHUNKRENDERER_H

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -5,12 +5,16 @@
 #include <assert.h>
 
 #include "./mapview.h"
+#include "./chunkcache.h"
 #include "./definitionmanager.h"
 #include "./blockidentifier.h"
 #include "./biomeidentifier.h"
 #include "./clamp.h"
 
-MapView::MapView(QWidget *parent) : QWidget(parent) {
+MapView::MapView(QWidget *parent)
+  : QWidget(parent)
+  , cache(ChunkCache::Instance())
+{
   depth = 255;
   scale = 1;
   zoom = 1.0;
@@ -361,6 +365,7 @@ void MapView::drawChunk(int x, int z) {
   uchar *src = placeholder;
   // fetch the chunk
   Chunk *chunk = cache.fetch(x, z);
+  if (chunk && !chunk->loaded) return;
 
   if (chunk && (chunk->renderedAt != depth ||
                 chunk->renderedFlags != flags)) {

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -6,6 +6,7 @@
 
 #include "./mapview.h"
 #include "./chunkcache.h"
+#include "./chunkrenderer.h"
 #include "./definitionmanager.h"
 #include "./blockidentifier.h"
 #include "./biomeidentifier.h"
@@ -106,6 +107,14 @@ void MapView::setDepth(int depth) {
 
 void MapView::setFlags(int flags) {
   this->flags = flags;
+}
+
+int MapView::getFlags() const {
+  return flags;
+}
+
+int MapView::getDepth() const {
+  return depth;
 }
 
 void MapView::chunkUpdated(int x, int z) {
@@ -369,7 +378,12 @@ void MapView::drawChunk(int x, int z) {
 
   if (chunk && (chunk->renderedAt != depth ||
                 chunk->renderedFlags != flags)) {
-    renderChunk(chunk);
+    //renderChunk(chunk);
+    ChunkRenderer *renderer = new ChunkRenderer(x, z, depth, flags);
+    connect(renderer, SIGNAL(rendered(int, int)),
+            this,     SLOT(chunkUpdated(int, int)));
+    QThreadPool::globalInstance()->start(renderer);
+    return;
   }
 
   // this figures out where on the screen this chunk should be drawn
@@ -426,191 +440,6 @@ void MapView::drawChunk(int x, int z) {
                static_cast<int>(floor(x / zoom) * 4), 4);
     }
   }
-}
-
-void MapView::renderChunk(Chunk *chunk) {
-  int offset = 0;
-  uchar *bits = chunk->image;
-  uchar *depthbits = chunk->depth;
-  for (int z = 0; z < 16; z++) {  // n->s
-    int lasty = -1;
-    for (int x = 0; x < 16; x++, offset++) {  // e->w
-      // initialize color
-      uchar r = 0, g = 0, b = 0;
-      double alpha = 0.0;
-      // get Biome
-      auto &biome = BiomeIdentifier::Instance().getBiome(chunk->biomes[offset]);
-      int top = depth;
-      if (top > chunk->highest)
-        top = chunk->highest;
-      int highest = 0;
-      for (int y = top; y >= 0; y--) {  // top->down
-        int sec = y >> 4;
-        ChunkSection *section = chunk->sections[sec];
-        if (!section) {
-          y = (sec << 4) - 1;  // skip whole section
-          continue;
-        }
-
-        // get data value
-        //int data = section->getData(offset, y);
-
-        // get BlockInfo from block value
-        BlockInfo &block = BlockIdentifier::Instance().getBlockInfo(section->getPaletteEntry(offset, y).hid);
-        if (block.alpha == 0.0) continue;
-
-        // get light value from one block above
-        int light = 0;
-        ChunkSection *section1 = NULL;
-        if (y < 255)
-          section1 = chunk->sections[(y+1) >> 4];
-        if (section1)
-          light = section1->getBlockLight(offset, y+1);
-        int light1 = light;
-        if (!(flags & flgLighting))
-          light = 13;
-        if (alpha == 0.0 && lasty != -1) {
-          if (lasty < y)
-            light += 2;
-          else if (lasty > y)
-            light -= 2;
-        }
-//        if (light < 0) light = 0;
-//        if (light > 15) light = 15;
-
-        // get current block color
-        QColor blockcolor = block.colors[15];  // get the color from Block definition
-        if (block.biomeWater()) {
-          blockcolor = biome.getBiomeWaterColor(blockcolor);
-        }
-        else if (block.biomeGrass()) {
-          blockcolor = biome.getBiomeGrassColor(blockcolor, y-64);
-        }
-        else if (block.biomeFoliage()) {
-          blockcolor = biome.getBiomeFoliageColor(blockcolor, y-64);
-        }
-
-        // shade color based on light value
-        double light_factor = pow(0.90,15-light);
-        quint32 colr = std::clamp( int(light_factor*blockcolor.red()),   0, 255 );
-        quint32 colg = std::clamp( int(light_factor*blockcolor.green()), 0, 255 );
-        quint32 colb = std::clamp( int(light_factor*blockcolor.blue()),  0, 255 );
-
-        // process flags
-        if (flags & flgDepthShading) {
-          // Use a table to define depth-relative shade:
-          static const quint32 shadeTable[] = {
-            0, 12, 18, 22, 24, 26, 28, 29, 30, 31, 32};
-          size_t idx = qMin(static_cast<size_t>(depth - y),
-                            sizeof(shadeTable) / sizeof(*shadeTable) - 1);
-          quint32 shade = shadeTable[idx];
-          colr = colr - qMin(shade, colr);
-          colg = colg - qMin(shade, colg);
-          colb = colb - qMin(shade, colb);
-        }
-        if (flags & flgMobSpawn) {
-          // get block info from 1 and 2 above and 1 below
-          uint blid1(0), blid2(0), blidB(0);  // default to legacy air (todo: better handling of block above)
-          ChunkSection *section2 = NULL;
-          ChunkSection *sectionB = NULL;
-          if (y < 254)
-            section2 = chunk->sections[(y+2) >> 4];
-          if (y > 0)
-            sectionB = chunk->sections[(y-1) >> 4];
-          if (section1) {
-            blid1 = section1->getPaletteEntry(offset, y+1).hid;
-          }
-          if (section2) {
-            blid2 = section2->getPaletteEntry(offset, y+2).hid;
-          }
-          if (sectionB) {
-            blidB = sectionB->getPaletteEntry(offset, y-1).hid;
-          }
-          BlockInfo &block2 = BlockIdentifier::Instance().getBlockInfo(blid2);
-          BlockInfo &block1 = BlockIdentifier::Instance().getBlockInfo(blid1);
-          BlockInfo &block0 = block;
-          BlockInfo &blockB = BlockIdentifier::Instance().getBlockInfo(blidB);
-          int light0 = section->getBlockLight(offset, y);
-
-           // spawn check #1: on top of solid block
-           if (block0.doesBlockHaveSolidTopSurface() &&
-               !block0.isBedrock() && light1 < 8 &&
-               !block1.isBlockNormalCube() && block1.spawninside &&
-               !block1.isLiquid() &&
-               !block2.isBlockNormalCube() && block2.spawninside) {
-             colr = (colr + 256) / 2;
-             colg = (colg + 0) / 2;
-             colb = (colb + 192) / 2;
-           }
-           // spawn check #2: current block is transparent,
-           // but mob can spawn through (e.g. snow)
-           if (blockB.doesBlockHaveSolidTopSurface() &&
-               !blockB.isBedrock() && light0 < 8 &&
-               !block0.isBlockNormalCube() && block0.spawninside &&
-               !block0.isLiquid() &&
-               !block1.isBlockNormalCube() && block1.spawninside) {
-             colr = (colr + 192) / 2;
-             colg = (colg + 0) / 2;
-             colb = (colb + 256) / 2;
-           }
-        }
-        if (flags & flgBiomeColors) {
-          colr = biome.colors[light].red();
-          colg = biome.colors[light].green();
-          colb = biome.colors[light].blue();
-          alpha = 0;
-        }
-
-        // combine current block to final color
-        if (alpha == 0.0) {
-          // first color sample
-          alpha = block.alpha;
-          r = colr;
-          g = colg;
-          b = colb;
-          highest = y;
-        } else {
-          // combine further color samples with blending
-          r = (quint8)(alpha * r + (1.0 - alpha) * colr);
-          g = (quint8)(alpha * g + (1.0 - alpha) * colg);
-          b = (quint8)(alpha * b + (1.0 - alpha) * colb);
-          alpha += block.alpha * (1.0 - alpha);
-        }
-
-        // finish depth (Y) scanning when color is saturated enough
-        if (block.alpha == 1.0 || alpha > 0.9)
-          break;
-      }
-      if (flags & flgCaveMode) {
-        float cave_factor = 1.0;
-        int cave_test = 0;
-        for (int y=highest-1; (y >= 0) && (cave_test < CAVE_DEPTH); y--, cave_test++) {  // top->down
-          // get section
-          ChunkSection *section = chunk->sections[y >> 4];
-          if (!section) continue;
-          // get data value
-          // int data = section->getData(offset, y);
-          // get BlockInfo from block value
-          BlockInfo &block = BlockIdentifier::Instance().getBlockInfo(section->getPaletteEntry(offset, y).hid);
-          if (block.transparent) {
-            cave_factor -= caveshade[cave_test];
-          }
-        }
-        cave_factor = std::max(cave_factor,0.25f);
-        // darken color by blending with cave shade factor
-        r = (quint8)(cave_factor * r);
-        g = (quint8)(cave_factor * g);
-        b = (quint8)(cave_factor * b);
-      }
-      *depthbits++ = lasty = highest;
-      *bits++ = b;
-      *bits++ = g;
-      *bits++ = r;
-      *bits++ = 0xff;
-    }
-  }
-  chunk->renderedAt = depth;
-  chunk->renderedFlags = flags;
 }
 
 void MapView::getToolTip(int x, int z) {

--- a/mapview.h
+++ b/mapview.h
@@ -94,7 +94,7 @@ class MapView : public QWidget {
   int scale;
   double zoom;
   int flags;
-  ChunkCache cache;
+  ChunkCache &cache;
   QImage image;
   DefinitionManager *dm;
   uchar placeholder[16 * 16 * 4];  // no chunk found placeholder

--- a/mapview.h
+++ b/mapview.h
@@ -41,12 +41,13 @@ class MapView : public QWidget {
   BlockLocation *getLocation();
   void setDimension(QString path, int scale);
   void setFlags(int flags);
+  int  getFlags() const;
+  int  getDepth() const;
   void addOverlayItem(QSharedPointer<OverlayItem> item);
   void clearOverlayItems();
   void setVisibleOverlayItemTypes(const QSet<QString>& itemTypes);
 
   // public for saving the png
-  void renderChunk(Chunk *chunk);
   QString getWorldPath();
 
 

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -100,6 +100,12 @@ Minutor::Minutor() {
   emit worldLoaded(false);
 }
 
+Minutor::~Minutor() {
+  // wait for sheduled tasks
+  QThreadPool::globalInstance()->waitForDone();
+}
+
+
 void Minutor::openWorld() {
   QAction *action = qobject_cast<QAction*>(sender());
   if (action)

--- a/minutor.h
+++ b/minutor.h
@@ -34,6 +34,7 @@ class Minutor : public QMainWindow {
 
  public:
   Minutor();
+  ~Minutor();
 
   void loadWorld(QDir path);
 

--- a/minutor.pro
+++ b/minutor.pro
@@ -25,6 +25,7 @@ HEADERS += \
     chunk.h \
     chunkcache.h \
     chunkloader.h \
+    chunkrenderer.h \
     definitionmanager.h \
     definitionupdater.h \
     dimensionidentifier.h \
@@ -53,6 +54,7 @@ SOURCES += \
     chunk.cpp \
     chunkcache.cpp \
     chunkloader.cpp \
+    chunkrenderer.cpp \
     definitionmanager.cpp \
     definitionupdater.cpp \
     dimensionidentifier.cpp \

--- a/worldsave.cpp
+++ b/worldsave.cpp
@@ -9,6 +9,7 @@
 
 #include "./worldsave.h"
 #include "./mapview.h"
+#include "./chunkrenderer.h"
 #include "zlib/zlib.h"
 
 WorldSave::WorldSave(QString filename, MapView *map,
@@ -292,13 +293,14 @@ void WorldSave::drawChunk(uchar *scanlines, int stride, int x, Chunk *chunk) {
   // calculate attenuation
   float attenuation = 1.0f;
   if (this->regionChecker && static_cast<int>(floor(chunk->chunkX / 32.0f) +
-                                  floor(chunk->chunkZ / 32.0f)) % 2 != 0)
+                                              floor(chunk->chunkZ / 32.0f)) % 2 != 0)
     attenuation *= 0.9f;
   if (this->chunkChecker && ((chunk->chunkX + chunk->chunkZ) % 2) != 0)
     attenuation *= 0.9f;
 
   // render chunk with current settings
-  map->renderChunk(chunk);
+  ChunkRenderer renderer(chunk->chunkX, chunk->chunkZ, map->getDepth(), map->getFlags());
+  renderer.renderChunk(chunk);
   // we can't memcpy each scanline because it's in BGRA format.
   int offset = x * 16 * 4 + 1;
   int ioffset = 0;


### PR DESCRIPTION
- Fix current implementation for asynchronous Chunk loading. Due to a misplaced mutex unlock we only used one loading thread at the time.
- Move Chunk rendering into own (runnable) class and let it render in global thread pool.
- Use separated thread pools for loading and rendering, as Qt queues tasks in order they arrive. This would result in all loading tasks to be executed before anything gets rendered. By using optimal/2 for loading and optimal thread number for rendering we get 1.5x the number of threads than we have CPU cores. In my opinion this is fine, as loading implies disk activity which stalls the task.