### PR TITLE
fix Overlays when changing depth

### DIFF
--- a/chunkcache.cpp
+++ b/chunkcache.cpp
@@ -69,6 +69,14 @@ QString ChunkCache::getPath() const {
   return path;
 }
 
+int ChunkCache::getCost() const {
+  return cache.totalCost();
+}
+
+int ChunkCache::getMaxCost() const {
+  return cache.maxCost();
+}
+
 QSharedPointer<Chunk> ChunkCache::fetchCached(int cx, int cz) {
   // try to get Chunk from Cache
   ChunkID id(cx, cz);

--- a/chunkcache.h
+++ b/chunkcache.h
@@ -37,6 +37,8 @@ class ChunkCache : public QObject {
   QString getPath() const;
   QSharedPointer<Chunk> fetch(int cx, int cz);         // fetch Chunk and load when not found
   QSharedPointer<Chunk> fetchCached(int cx, int cz);   // fetch Chunk only if cached
+  int getCost() const;
+  int getMaxCost() const;
 
  signals:
   void chunkLoaded(int cx, int cz);

--- a/mapview.h
+++ b/mapview.h
@@ -96,7 +96,8 @@ class MapView : public QWidget {
   double zoom;
   int flags;
   ChunkCache &cache;
-  QImage image;
+  QImage imageChunks;
+  QImage imageOverlays;
   DefinitionManager *dm;
   uchar placeholder[16 * 16 * 4];  // no chunk found placeholder
   QSet<QString> overlayItemTypes;


### PR DESCRIPTION
When changing depth or other reasons that update the Chunk in
background, the Overlay is overwritten.
By using separated images for the Chunk data and "the rest" (Overlays)
these two categories to not interfere anymore.

Also put Cache usage statistics in status bar when on DEBUG build.