### PR TITLE
Add render mode for sea ground skipping all liquid blocks

### DIFF
--- a/chunkrenderer.cpp
+++ b/chunkrenderer.cpp
@@ -63,6 +63,8 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
         BlockInfo &block = BlockIdentifier::Instance().getBlockInfo(section->getPaletteEntry(offset, y).hid);
         if (block.alpha == 0.0) continue;
 
+        if (flags & MapView::flgSeaGround && block.isLiquid()) continue;
+
         // get light value from one block above
         int light = 0;
         ChunkSection *section1 = NULL;
@@ -112,6 +114,7 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
           colg = colg - qMin(shade, colg);
           colb = colb - qMin(shade, colb);
         }
+
         if (flags & MapView::flgMobSpawn) {
           // get block info from 1 and 2 above and 1 below
           uint blid1(0), blid2(0), blidB(0);  // default to legacy air (todo: better handling of block above)
@@ -184,7 +187,9 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
         // finish depth (Y) scanning when color is saturated enough
         if (block.alpha == 1.0 || alpha > 0.9)
           break;
-      }
+
+      } // top -> down
+
       if (flags & MapView::flgCaveMode) {
         float cave_factor = 1.0;
         int cave_test = 0;
@@ -206,6 +211,7 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
         g = (quint8)(cave_factor * g);
         b = (quint8)(cave_factor * b);
       }
+
       *depthbits++ = lasty = highest;
       *bits++ = b;
       *bits++ = g;

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -471,6 +471,8 @@ void MapView::getToolTip(int x, int z) {
       // -> we continue downwards
       auto & block = BlockIdentifier::Instance().getBlockInfo(pdata.hid);
       if (block.alpha == 0.0) continue;
+      if (flags & MapView::flgSeaGround && block.isLiquid()) continue;
+
       // list all Block States
       for (auto key : pdata.properties.keys()) {
         blockstate += key;

--- a/mapview.h
+++ b/mapview.h
@@ -16,13 +16,14 @@ class MapView : public QWidget {
  public:
   /// Values for the individual flags
   enum {
-    flgLighting     = 1,
-    flgMobSpawn     = 2,
-    flgCaveMode     = 4,
-    flgDepthShading = 8,
-    flgShowEntities = 16,
-    flgSingleLayer = 32,
-    flgBiomeColors  = 64
+    flgLighting     = 1 << 0,
+    flgMobSpawn     = 1 << 1,
+    flgCaveMode     = 1 << 2,
+    flgDepthShading = 1 << 3,
+    flgShowEntities = 1 << 4,
+    flgSingleLayer  = 1 << 5,
+    flgBiomeColors  = 1 << 6,
+    flgSeaGround    = 1 << 7
   };
 
   typedef struct {

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -275,6 +275,7 @@ void Minutor::toggleFlags() {
   if (depthShadingAct->isChecked()) flags |= MapView::flgDepthShading;
   if (biomeColorsAct->isChecked())  flags |= MapView::flgBiomeColors;
   if (singleLayerAct->isChecked())  flags |= MapView::flgSingleLayer;
+  if (seaGroundAct->isChecked())    flags |= MapView::flgSeaGround;
   mapview->setFlags(flags);
 
   QSet<QString> overlayTypes;
@@ -403,6 +404,13 @@ void Minutor::createActions() {
   connect(caveModeAct, SIGNAL(triggered()),
           this,        SLOT(toggleFlags()));
 
+  seaGroundAct = new QAction(tr("Sea Gro&und Mode"), this);
+  seaGroundAct->setCheckable(true);
+  seaGroundAct->setShortcut(tr("Ctrl+U"));
+  seaGroundAct->setStatusTip(tr("Toggle sea ground mode on/off"));
+  connect(seaGroundAct, SIGNAL(triggered()),
+          this,           SLOT(toggleFlags()));
+
   jumpToAct = new QAction(tr("&Jump To"), this);
   jumpToAct->setShortcut(tr("Ctrl+G"));
   jumpToAct->setStatusTip(tr("Jump to a location"));
@@ -529,6 +537,7 @@ void Minutor::createMenus() {
   viewMenu->addAction(caveModeAct);
   viewMenu->addAction(depthShadingAct);
   viewMenu->addAction(biomeColorsAct);
+  viewMenu->addAction(seaGroundAct);
   viewMenu->addAction(singleLayerAct);
   // [View->Overlay]
   structureOverlayMenu = viewMenu->addMenu(tr("&Structure Overlay"));

--- a/minutor.h
+++ b/minutor.h
@@ -102,7 +102,7 @@ private slots:
   QAction *openAct, *reloadAct, *saveAct, *exitAct;
   QAction *jumpSpawnAct;
   QList<QAction *>players;
-  QAction *lightingAct, *mobSpawnAct, *caveModeAct, *depthShadingAct, *biomeColorsAct, *singleLayerAct;
+  QAction *lightingAct, *mobSpawnAct, *caveModeAct, *depthShadingAct, *biomeColorsAct, *singleLayerAct, *seaGroundAct;
   QAction *manageDefsAct;
   QAction *refreshAct;
   QAction *aboutAct;


### PR DESCRIPTION
As sea ground in minecraft gets more and more detailed and interesting, I found a visualization of it in minutor would also make sense. For me it helped to find chests in shipwreck or in the ocean ruins.
Example - you can see the shipwreck on the top only with the sea ground mode:
![Minutor Sea Ground - disabled](https://user-images.githubusercontent.com/252806/69464249-1d7d1b00-0d7e-11ea-9e58-4caaa36a73d1.png)
![Minutor Sea Ground - enabled](https://user-images.githubusercontent.com/252806/69464250-1d7d1b00-0d7e-11ea-84b5-d85ebb5908dc.png)
I added new checkable action menu item which enables / disables the sea ground mode.