### PR TITLE
Restrict zoom based on available memory

### DIFF
--- a/chunkcache.cpp
+++ b/chunkcache.cpp
@@ -3,6 +3,7 @@
 #include "./chunkcache.h"
 #include "./chunkloader.h"
 
+
 #if defined(__unix__) || defined(__unix) || defined(unix)
 #include <unistd.h>
 #elif defined(_WIN32) || defined(WIN32)
@@ -19,22 +20,32 @@ uint qHash(const ChunkID &c) {
 }
 
 ChunkCache::ChunkCache() {
-  int chunks = 10000;  // 10% more than 1920x1200 blocks
+  const int sizeChunkMax     = sizeof(Chunk) + 16 * sizeof(ChunkSection);  // all sections contain Blocks
+  const int sizeChunkTypical = sizeof(Chunk) + 6 * sizeof(ChunkSection);   // world generation is average Y=64..128
+
+  // default: 10% more than 1920x1200 blocks
+  int chunks = 10000;
+  maxcache = chunks;
+
+  // try to determine available pysical memory based on operation system we are running on
 #if defined(__unix__) || defined(__unix) || defined(unix)
 #ifdef _SC_AVPHYS_PAGES
   auto pages = sysconf(_SC_AVPHYS_PAGES);
   auto page_size = sysconf(_SC_PAGE_SIZE);
-  chunks = (pages*page_size) / (sizeof(Chunk) + 16*sizeof(ChunkSection));
+  DWORDLONG available = (pages*page_size);
+  chunks   = available / sizeChunkMax;
+  maxcache = available / sizeChunkTypical;  // most chunks are less filled with sections
 #endif
 #elif defined(_WIN32) || defined(WIN32)
   MEMORYSTATUSEX status;
   status.dwLength = sizeof(status);
   GlobalMemoryStatusEx(&status);
   DWORDLONG available = qMin(status.ullAvailPhys, status.ullAvailVirtual);
-  chunks = available / (sizeof(Chunk) + 16 * sizeof(ChunkSection));
+  chunks   = available / sizeChunkMax;
+  maxcache = available / sizeChunkTypical;  // most chunks are less filled with sections
 #endif
+  // we start the Cache based on worst case calculation
   cache.setMaxCost(chunks);
-  maxcache = 2 * chunks;  // most chunks are less than half filled with sections
 
   // determain optimal thread pool size for "loading"
   // as this contains disk access, use less than number of cores
@@ -69,12 +80,16 @@ QString ChunkCache::getPath() const {
   return path;
 }
 
-int ChunkCache::getCost() const {
+int ChunkCache::getCacheUsage() const {
   return cache.totalCost();
 }
 
-int ChunkCache::getMaxCost() const {
+int ChunkCache::getCacheMax() const {
   return cache.maxCost();
+}
+
+int ChunkCache::getMemoryMax() const {
+  return maxcache;
 }
 
 QSharedPointer<Chunk> ChunkCache::fetchCached(int cx, int cz) {
@@ -128,10 +143,8 @@ void ChunkCache::routeStructure(QSharedPointer<GeneratedStructure> structure) {
   emit structureFound(structure);
 }
 
-void ChunkCache::adaptCacheToWindow(int wx, int wy) {
-  int chunks = ((wx + 15) >> 4) * ((wy + 15) >> 4);  // number of chunks visible
-  chunks *= 1.10;  // add 10%
-
+void ChunkCache::setCacheMaxSize(int chunks) {
   QMutexLocker guard(&mutex);
-  cache.setMaxCost(qMin(chunks, maxcache));
+  // we never decrease Cache size, and never exceed physical memory
+  cache.setMaxCost(std::max<int>(cache.maxCost(), std::min<int>(chunks, maxcache)));
 }

--- a/chunkcache.h
+++ b/chunkcache.h
@@ -37,15 +37,16 @@ class ChunkCache : public QObject {
   QString getPath() const;
   QSharedPointer<Chunk> fetch(int cx, int cz);         // fetch Chunk and load when not found
   QSharedPointer<Chunk> fetchCached(int cx, int cz);   // fetch Chunk only if cached
-  int getCost() const;
-  int getMaxCost() const;
+  int getCacheUsage() const;
+  int getCacheMax() const;
+  int getMemoryMax() const;
 
  signals:
   void chunkLoaded(int cx, int cz);
   void structureFound(QSharedPointer<GeneratedStructure> structure);
 
  public slots:
-  void adaptCacheToWindow(int wx, int wy);
+  void setCacheMaxSize(int chunks);
 
  private slots:
   void gotChunk(int cx, int cz);
@@ -55,7 +56,7 @@ class ChunkCache : public QObject {
   QString path;                                   // path to folder with region files
   QCache<ChunkID, QSharedPointer<Chunk>> cache;   // real Cache
   QMutex mutex;                                   // Mutex for accessing the Cache
-  int maxcache;                                   // number of Chunks that fit into Cache
+  int maxcache;                                   // number of Chunks that fit into memory
   QThreadPool loaderThreadPool;                   // extra thread pool for loading
 };
 

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -160,14 +160,15 @@ void MapView::adjustZoom(double steps, bool allowZoomOut)
     int ppc = ceil(16*zoom);
     int cx = (imageChunks.width() +ppc-1) / ppc;
     int cz = (imageChunks.height()+ppc-1) / ppc;
-    chunks = 1.2 * (cx * cz);
-    if (chunks <= maxchunks)
-      restrictZoom = false; // everything matches
+    chunks = cx * cz;
+    if ((1.2 * chunks) <= maxchunks)
+      restrictZoom = false; // everything matches with a low margin of 20%
     else
       zoomIndex++;          // restrict zoom
   } while (restrictZoom);
 
-  cache.setCacheMaxSize(chunks);
+  // we try to set higher margin than above (100%)!
+  cache.setCacheMaxSize(2.0 * chunks);
 }
 
 static int lastMouseX = -1, lastMouseY = -1;
@@ -234,10 +235,13 @@ void MapView::mouseDoubleClickEvent(QMouseEvent *event) {
 }
 
 void MapView::wheelEvent(QWheelEvent *event) {
-  if   ((event->modifiers() & Qt::ShiftModifier) == Qt::ShiftModifier) {
+  Qt::KeyboardModifier modifier4DepthSlider = Qt::KeyboardModifier(QSettings().value("modifier4DepthSlider", Qt::ShiftModifier).toUInt());
+  Qt::KeyboardModifier modifier4ZoomOut     = Qt::KeyboardModifier(QSettings().value("modifier4ZoomOut",     Qt::ControlModifier).toUInt());
+
+  if ((event->modifiers() & modifier4DepthSlider) == modifier4DepthSlider) {
     // change depth
     emit demandDepthChange(event->delta() / 120);
-  } if ((event->modifiers() & Qt::ControlModifier) == Qt::ControlModifier) {
+  } else if ((event->modifiers() & modifier4ZoomOut) == modifier4ZoomOut) {
     // allow change zoom also to zoom OUT
     adjustZoom( event->delta() / 120.0, true );
     redraw();

--- a/mapview.h
+++ b/mapview.h
@@ -87,7 +87,7 @@ class MapView : public QWidget {
   void getToolTip(int x, int z);
   int getY(int x, int z);
   QList<QSharedPointer<OverlayItem>> getItems(int x, int y, int z);
-  void adjustZoom(double steps);
+  void adjustZoom(double steps, bool allowZoomOut);
 
   static const int CAVE_DEPTH = 16;  // maximum depth caves are searched in cave mode
   float caveshade[CAVE_DEPTH];
@@ -95,6 +95,7 @@ class MapView : public QWidget {
   int depth;
   double x, z;
   int scale;
+  int zoomIndex;
   double zoom;
   int flags;
   ChunkCache &cache;

--- a/settings.cpp
+++ b/settings.cpp
@@ -41,8 +41,6 @@ Settings::Settings(QWidget *parent) : QDialog(parent) {
   }
   autoUpdate = info.value("autoupdate", true).toBool();
   verticalDepth = info.value("verticaldepth", true).toBool();
-  fineZoom = info.value("finezoom", false).toBool();
-  zoomOut = info.value("zoomout", false).toBool();
 
   // Set the UI to the current settings' values:
   m_ui.checkBox_AutoUpdate->setChecked(autoUpdate);
@@ -50,8 +48,6 @@ Settings::Settings(QWidget *parent) : QDialog(parent) {
   m_ui.lineEdit_Location->setDisabled(useDefault);
   m_ui.checkBox_DefaultLocation->setChecked(useDefault);
   m_ui.checkBox_VerticalDepth->setChecked(verticalDepth);
-  m_ui.checkBox_fine_zoom->setChecked(fineZoom);
-  m_ui.checkBox_zoom_out->setChecked(zoomOut);
 }
 
 QString Settings::getDefaultLocation()
@@ -106,21 +102,5 @@ void Settings::toggleVerticalDepth(bool value) {
   verticalDepth = value;
   QSettings info;
   info.setValue("verticaldepth", value);
-  emit settingsUpdated();
-}
-
-void Settings::on_checkBox_zoom_out_toggled(bool checked)
-{
-  zoomOut = checked;
-  QSettings info;
-  info.setValue("zoomout", checked);
-  emit settingsUpdated();
-}
-
-void Settings::on_checkBox_fine_zoom_toggled(bool checked)
-{
-  fineZoom = checked;
-  QSettings info;
-  info.setValue("finezoom", checked);
   emit settingsUpdated();
 }

--- a/settings.cpp
+++ b/settings.cpp
@@ -30,6 +30,20 @@ Settings::Settings(QWidget *parent) : QDialog(parent) {
   connect(m_ui.checkBox_AutoUpdate, SIGNAL(toggled(bool)),
           this, SLOT(toggleAutoUpdate(bool)));
 
+  connect(m_ui.radioButton_depth_shift, &QRadioButton::toggled,
+          this,                         &Settings::toggleModifier4DepthSlider);
+  connect(m_ui.radioButton_depth_ctrl,  &QRadioButton::toggled,
+          this,                         &Settings::toggleModifier4DepthSlider);
+  connect(m_ui.radioButton_depth_alt,   &QRadioButton::toggled,
+          this,                         &Settings::toggleModifier4DepthSlider);
+
+  connect(m_ui.radioButton_zoom_shift, &QRadioButton::toggled,
+          this,                        &Settings::toggleModifier4ZoomOut);
+  connect(m_ui.radioButton_zoom_ctrl,  &QRadioButton::toggled,
+          this,                        &Settings::toggleModifier4ZoomOut);
+  connect(m_ui.radioButton_zoom_alt,   &QRadioButton::toggled,
+          this,                        &Settings::toggleModifier4ZoomOut);
+
   // Load the settings:
   QSettings info;
   auto useDefault = info.value("usedefault", true).toBool();
@@ -39,15 +53,41 @@ Settings::Settings(QWidget *parent) : QDialog(parent) {
   else {
     mcpath = info.value("mcdir", "").toString();
   }
-  autoUpdate = info.value("autoupdate", true).toBool();
+  autoUpdate    = info.value("autoupdate", true).toBool();
   verticalDepth = info.value("verticaldepth", true).toBool();
+  modifier4DepthSlider = Qt::KeyboardModifier(info.value("modifier4DepthSlider", 0x02000000).toUInt());
+  modifier4ZoomOut     = Qt::KeyboardModifier(info.value("modifier4ZoomOut",     0x04000000).toUInt());
 
   // Set the UI to the current settings' values:
-  m_ui.checkBox_AutoUpdate->setChecked(autoUpdate);
   m_ui.lineEdit_Location->setText(mcpath);
   m_ui.lineEdit_Location->setDisabled(useDefault);
   m_ui.checkBox_DefaultLocation->setChecked(useDefault);
   m_ui.checkBox_VerticalDepth->setChecked(verticalDepth);
+  m_ui.checkBox_AutoUpdate->setChecked(autoUpdate);
+  switch (modifier4DepthSlider) {
+  case Qt::ControlModifier:
+    m_ui.radioButton_depth_ctrl->setChecked(true);
+    break;
+  case Qt::AltModifier:
+    m_ui.radioButton_depth_alt->setChecked(true);
+    break;
+  default:
+    m_ui.radioButton_depth_shift->setChecked(true);
+    break;
+  }
+  switch (modifier4ZoomOut) {
+  case Qt::ControlModifier:
+    m_ui.radioButton_zoom_ctrl->setChecked(true);
+    break;
+  case Qt::AltModifier:
+    m_ui.radioButton_zoom_alt->setChecked(true);
+    break;
+  default:
+    m_ui.radioButton_zoom_shift->setChecked(true);
+    break;
+  }
+  this->toggleModifier4DepthSlider();
+  this->toggleModifier4ZoomOut();
 }
 
 QString Settings::getDefaultLocation()
@@ -103,4 +143,50 @@ void Settings::toggleVerticalDepth(bool value) {
   QSettings info;
   info.setValue("verticaldepth", value);
   emit settingsUpdated();
+}
+
+void Settings::toggleModifier4DepthSlider() {
+  if (m_ui.radioButton_depth_shift->isChecked()) {
+    modifier4DepthSlider = Qt::ShiftModifier;
+    m_ui.radioButton_zoom_shift->setEnabled(false);
+    m_ui.radioButton_zoom_ctrl ->setEnabled(true);
+    m_ui.radioButton_zoom_alt  ->setEnabled(true);
+  }
+  if (m_ui.radioButton_depth_ctrl->isChecked()) {
+    modifier4DepthSlider = Qt::ControlModifier;
+    m_ui.radioButton_zoom_shift->setEnabled(true);
+    m_ui.radioButton_zoom_ctrl ->setEnabled(false);
+    m_ui.radioButton_zoom_alt  ->setEnabled(true);
+  }
+  if (m_ui.radioButton_depth_alt->isChecked()) {
+    modifier4DepthSlider = Qt::AltModifier;
+    m_ui.radioButton_zoom_shift->setEnabled(true);
+    m_ui.radioButton_zoom_ctrl ->setEnabled(true);
+    m_ui.radioButton_zoom_alt  ->setEnabled(false);
+  }
+  QSettings info;
+  info.setValue("modifier4DepthSlider", modifier4DepthSlider);
+}
+
+void Settings::toggleModifier4ZoomOut() {
+  if (m_ui.radioButton_zoom_shift->isChecked()) {
+    modifier4ZoomOut = Qt::ShiftModifier;
+    m_ui.radioButton_depth_shift->setEnabled(false);
+    m_ui.radioButton_depth_ctrl ->setEnabled(true);
+    m_ui.radioButton_depth_alt  ->setEnabled(true);
+  }
+  if (m_ui.radioButton_zoom_ctrl->isChecked()) {
+    modifier4ZoomOut = Qt::ControlModifier;
+    m_ui.radioButton_depth_shift->setEnabled(true);
+    m_ui.radioButton_depth_ctrl ->setEnabled(false);
+    m_ui.radioButton_depth_alt  ->setEnabled(true);
+  }
+  if (m_ui.radioButton_zoom_alt->isChecked()) {
+    modifier4ZoomOut = Qt::AltModifier;
+    m_ui.radioButton_depth_shift->setEnabled(true);
+    m_ui.radioButton_depth_ctrl ->setEnabled(true);
+    m_ui.radioButton_depth_alt  ->setEnabled(false);
+  }
+  QSettings info;
+  info.setValue("modifier4ZoomOut", modifier4ZoomOut);
 }

--- a/settings.h
+++ b/settings.h
@@ -11,9 +11,11 @@ class Settings : public QDialog {
  public:
   explicit Settings(QWidget *parent = 0);
 
-  bool autoUpdate;
-  bool verticalDepth;
   QString mcpath;
+  bool verticalDepth;
+  bool autoUpdate;
+  Qt::KeyboardModifier modifier4DepthSlider;
+  Qt::KeyboardModifier modifier4ZoomOut;
 
   /** Returns the default path to be used for Minecraft location. */
   static QString getDefaultLocation();
@@ -28,6 +30,8 @@ class Settings : public QDialog {
   void toggleDefaultLocation(bool on);
   void pathChanged(const QString &path);
   void toggleVerticalDepth(bool on);
+  void toggleModifier4DepthSlider();
+  void toggleModifier4ZoomOut();
 
  private:
   Ui::Settings m_ui;

--- a/settings.h
+++ b/settings.h
@@ -14,9 +14,6 @@ class Settings : public QDialog {
   bool autoUpdate;
   bool verticalDepth;
   QString mcpath;
-  bool fineZoom;
-  bool zoomOut;
-
 
   /** Returns the default path to be used for Minecraft location. */
   static QString getDefaultLocation();
@@ -32,11 +29,7 @@ class Settings : public QDialog {
   void pathChanged(const QString &path);
   void toggleVerticalDepth(bool on);
 
-  void on_checkBox_zoom_out_toggled(bool checked);
-
-  void on_checkBox_fine_zoom_toggled(bool checked);
-
-private:
+ private:
   Ui::Settings m_ui;
 };
 

--- a/settings.ui
+++ b/settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>290</height>
+    <height>451</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -79,6 +79,94 @@
          <widget class="QCheckBox" name="checkBox_AutoUpdate">
           <property name="text">
            <string>Auto-check for updates (every 7 days)</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Mouse Wheel</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QGroupBox" name="groupBox_2">
+          <property name="title">
+           <string>Depth Slider</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <item>
+            <widget class="QRadioButton" name="radioButton_depth_shift">
+             <property name="text">
+              <string>Shift</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="radioButton_depth_ctrl">
+             <property name="text">
+              <string>Ctrl</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="radioButton_depth_alt">
+             <property name="text">
+              <string>Alt</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox_3">
+          <property name="title">
+           <string>Zoom Out</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_6">
+           <item>
+            <widget class="QRadioButton" name="radioButton_zoom_shift">
+             <property name="text">
+              <string>Shift</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="radioButton_zoom_ctrl">
+             <property name="text">
+              <string>Ctrl</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="radioButton_zoom_alt">
+             <property name="text">
+              <string>Alt</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Without any modifier key, turning the mouse wheel controls zoom IN.</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
           </property>
          </widget>
         </item>

--- a/settings.ui
+++ b/settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>370</height>
+    <height>290</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -79,29 +79,6 @@
          <widget class="QCheckBox" name="checkBox_AutoUpdate">
           <property name="text">
            <string>Auto-check for updates (every 7 days)</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_experimental">
-       <property name="title">
-        <string>Experimental or unstable features</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_5">
-        <item>
-         <widget class="QCheckBox" name="checkBox_fine_zoom">
-          <property name="text">
-           <string>Fine zoom steps (recommended for zoom-out)</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="checkBox_zoom_out">
-          <property name="text">
-           <string>Zoom-out functionality (needs much RAM)</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
These changes restrict ZOOM based on available physical RAM and current window size. It should fix all out of memory issues we have at the moment.
Basically possible ChunkCache size is estimated at startup. Only a conservative amount of Chunks is reserved at that moment. Each time the user changes the window size or zooms, the ChunkCache is increased until we reach the initially estimated maximum. In case we hit that boundary, ZOOM is decreased automatically until the amount of visible Chunks matches the Cache again.

To achieve this, the ZOOM behavior was changed to:
* a linear INDEX that is changed by the Mouse Wheel in increments of 1 for each typical scroll event
* a zoom curve TABLE to map a desired zoom factor from the given index
  * Positive indices result in the well known zoom IN but with something like the new proposed exponential behavior. As it is implemented via a table-look-up any desired behavior is possible. I took Fibonacci numbers to achieve only integer multiples of Blocks. 
  * Negative indices result in the new zoom OUT feature. Values are mapped like before:
    -1 -> 2^1 -> 2:1
    -2 -> 2^2 -> 4:1
    -3 -> 2^3 -> 8:1
    -4 -> 2^4 -> 16:1 one Chunk per pixel (maximum possible) demanding about 32..64G free RAM

The settings for experimental zoom out are removed, as it is working like desired.
Instead I added new settings to change the modifier keys which are used to determine what to do when the Mouse Wheel is scrolled. Default behavior is:
* NO modifier key: normal zoom without the possibility the accidentally zoom out
* CTRL modifier: zoom and also allow zoom out
* SHIFT modifier: change the Depth Slider

Via keyboard, zoom out is always possible.

Please carefully review the changed zoom behavior.
Restricted zoom is something we can not circumvent anyway.