### PR TITLE
fixed Linux build - don't use DWORDLONG on unix systems

### DIFF
--- a/chunkcache.cpp
+++ b/chunkcache.cpp
@@ -32,7 +32,7 @@ ChunkCache::ChunkCache() {
 #ifdef _SC_AVPHYS_PAGES
   auto pages = sysconf(_SC_AVPHYS_PAGES);
   auto page_size = sysconf(_SC_PAGE_SIZE);
-  DWORDLONG available = (pages*page_size);
+  quint64 available = (pages*page_size);
   chunks   = available / sizeChunkMax;
   maxcache = available / sizeChunkTypical;  // most chunks are less filled with sections
 #endif


### PR DESCRIPTION
DWORDLONG is Windows only type, and it is not defined on Linux.
According to MS documentation, it is unsigned 64 bit integer, so
use Qt' quint64 type instead of this one on any Unix system.