### PR TITLE
updated macOS Info.plist

### DIFF
--- a/minutor.plist
+++ b/minutor.plist
@@ -2,28 +2,30 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildMachineOSBuild</key>
-	<string>11E53</string>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Minutor</string>
 	<key>CFBundleExecutable</key>
-	<string>minutor</string>
+	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>
-	<string>icon.icns</string>
+	<string>${ASSETCATALOG_COMPILER_APPICON_NAME}</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.seancode.minutor</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>minutor</string>
+	<string>Minutor</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
+	<string>2.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.0</string>
+	<string>2.3.0</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>${MACOSX_DEPLOYMENT_TARGET}.0</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>© 2013-2020 Sean Kasun</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>


### PR DESCRIPTION
- drop useless key BuildMachineOSBuild
- drop obsolete key CFBundleSignature
- fixed values of [CFBundleDevelopmentRegion](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundledevelopmentregion?language=objc) and [CFBundleName](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-109585)
- updated app version to 2.3.0 (as in sources)
- used [qmake placeholders](https://doc.qt.io/qt-5/qmake-variable-reference.html#qmake-info-plist) for CFBundleExecutable and CFBundleIconFile values
- added missed [recommended keys](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/AboutInformationPropertyListFiles.html): [CFBundleDisplayName](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-110725), [NSHumanReadableCopyright](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-112854-TPXREF117)
- added [LSMinimumSystemVersion](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/20001431-113253) key and set its value using [qmake placeholder](https://doc.qt.io/qt-5/qmake-variable-reference.html#qmake-info-plist)