### PR TITLE
don't include local zlib headers on unix platforms

### DIFF
--- a/minutor.pro
+++ b/minutor.pro
@@ -1,7 +1,5 @@
 TEMPLATE = app
 TARGET = minutor
-DEPENDPATH += .
-INCLUDEPATH += .
 CONFIG += c++14
 QT += widgets network
 QMAKE_INFO_PLIST = minutor.plist

--- a/minutor.pro
+++ b/minutor.pro
@@ -11,15 +11,15 @@ macx:ICON=icon.icns
 
 #for profiling
 #*-g++* {
-#	QMAKE_CXXFLAGS += -pg
-#	QMAKE_LFLAGS += -pg
+#    QMAKE_CXXFLAGS += -pg
+#    QMAKE_LFLAGS += -pg
 #}
 
 # Input
 HEADERS += \
     zlib/zlib.h \
     zlib/zconf.h \
-	  labelledslider.h \
+    labelledslider.h \
     biomeidentifier.h \
     blockidentifier.h \
     chunk.h \
@@ -48,7 +48,7 @@ HEADERS += \
     flatteningconverter.h \
     paletteentry.h
 SOURCES += \
-	  labelledslider.cpp \
+    labelledslider.cpp \
     biomeidentifier.cpp \
     blockidentifier.cpp \
     chunk.cpp \
@@ -77,20 +77,20 @@ SOURCES += \
 RESOURCES = minutor.qrc
 
 win32:SOURCES += zlib/adler32.c \
-		zlib/compress.c \
-		zlib/crc32.c \
-		zlib/deflate.c \
-		zlib/gzclose.c \
-		zlib/gzlib.c \
-		zlib/gzread.c \
-		zlib/gzwrite.c \
-		zlib/infback.c \
-		zlib/inffast.c \
-		zlib/inflate.c \
-		zlib/inftrees.c \
-		zlib/trees.c \
-		zlib/uncompr.c \
-		zlib/zutil.c
+    zlib/compress.c \
+    zlib/crc32.c \
+    zlib/deflate.c \
+    zlib/gzclose.c \
+    zlib/gzlib.c \
+    zlib/gzread.c \
+    zlib/gzwrite.c \
+    zlib/infback.c \
+    zlib/inffast.c \
+    zlib/inflate.c \
+    zlib/inftrees.c \
+    zlib/trees.c \
+    zlib/uncompr.c \
+    zlib/zutil.c
 
 desktopfile.path = /usr/share/applications
 desktopfile.files = minutor.desktop

--- a/minutor.pro
+++ b/minutor.pro
@@ -15,8 +15,6 @@ macx:ICON=icon.icns
 
 # Input
 HEADERS += \
-    zlib/zlib.h \
-    zlib/zconf.h \
     labelledslider.h \
     biomeidentifier.h \
     blockidentifier.h \
@@ -74,7 +72,22 @@ SOURCES += \
     flatteningconverter.cpp
 RESOURCES = minutor.qrc
 
-win32:SOURCES += zlib/adler32.c \
+win32 {
+HEADERS += \
+    zlib/crc32.h \
+    zlib/deflate.h \
+    zlib/gzguts.h \
+    zlib/inffast.h \
+    zlib/inffixed.h \
+    zlib/inflate.h \
+    zlib/inftrees.h \
+    zlib/trees.h \
+    zlib/zconf.h \
+    zlib/zlib.h \
+    zlib/zutil.h
+
+SOURCES += \
+    zlib/adler32.c \
     zlib/compress.c \
     zlib/crc32.c \
     zlib/deflate.c \
@@ -89,6 +102,9 @@ win32:SOURCES += zlib/adler32.c \
     zlib/trees.c \
     zlib/uncompr.c \
     zlib/zutil.c
+
+INCLUDEPATH += zlib
+}
 
 desktopfile.path = /usr/share/applications
 desktopfile.files = minutor.desktop

--- a/nbt.cpp
+++ b/nbt.cpp
@@ -1,11 +1,11 @@
 /** Copyright (c) 2013, Sean Kasun */
+#include <zlib.h>
 #include <QFile>
 #include <QByteArray>
 #include <QDebug>
 #include <QStringList>
 
 #include "./nbt.h"
-#include "zlib/zlib.h"
 
 // this handles decoding the gzipped level.dat
 NBT::NBT(const QString level) {

--- a/worldsave.cpp
+++ b/worldsave.cpp
@@ -7,11 +7,11 @@
  make less-than-optimal PNGs.
  */
 
+#include <zlib.h>
 #include "./worldsave.h"
 #include "./mapview.h"
 #include "./chunkloader.h"
 #include "./chunkrenderer.h"
-#include "zlib/zlib.h"
 
 WorldSave::WorldSave(QString filename, MapView *map,
                      bool regionChecker, bool chunkChecker,

--- a/zipreader.cpp
+++ b/zipreader.cpp
@@ -1,6 +1,6 @@
 /** Copyright (c) 2013, Sean Kasun */
+#include <zlib.h>
 #include "./zipreader.h"
-#include "zlib/zlib.h"
 
 ZipReader::ZipReader(const QString filename) : f(filename) {
 }


### PR DESCRIPTION
it is a bad idea to include local (included in sources) header and link to system library, it may lead to unexpected runtime issues due to slightly different interfaces. (zlib may be not affected by this, it has very stable interface, but all the same it is very bad to do such things)

so use system provided zlib headers and libraries on unix platforms and build zlib sources only on Windows.