### PR TITLE
fix rare rendering bug and improve stability of chunk loading

### DIFF
--- a/chunk.cpp
+++ b/chunk.cpp
@@ -141,8 +141,6 @@ void Chunk::load(const NBT &nbt) {
     }
   }
 
-  loaded = true;
-
   // parse Entities
   if (level->has("Entities")) {
     auto entitylist = level->at("Entities");
@@ -156,6 +154,13 @@ void Chunk::load(const NBT &nbt) {
 
   // check for the highest block in this chunk
   // todo: use highmap from stored NBT data
+  findHighestBlock();
+
+  loaded = true; // needs to be at the end!
+}
+
+void Chunk::findHighestBlock()
+{
   for (int i = 15; i >= 0; i--) {
     if (this->sections[i]) {
       for (int j = 4095; j >= 0; j--) {
@@ -307,7 +312,6 @@ void Chunk::loadSection1519(ChunkSection *cs, const Tag *section) {
     memcpy(cs->blockLight, section->at("BlockLight")->toByteArray(), 2048);
   }
 }
-
 
 const PaletteEntry & ChunkSection::getPaletteEntry(int x, int y, int z) const {
   int xoffset = (x & 0x0f);

--- a/chunk.cpp
+++ b/chunk.cpp
@@ -6,16 +6,16 @@
 #include "./flatteningconverter.h"
 #include "./blockidentifier.h"
 
-template<typename _ValueT>
-inline void* safeMemCpy(void* __dest, const std::vector<_ValueT>& __src, size_t __len)
+template<typename ValueT>
+inline void* safeMemCpy(void* dest, const std::vector<ValueT>& srcVec, size_t length)
 {
-  const size_t src_data_size = (sizeof(_ValueT) * __src.size());
-    if (__len > src_data_size)
+  const size_t src_data_size = (sizeof(ValueT) * srcVec.size());
+    if (length > src_data_size)
     {
-      __len = src_data_size; // this happens sometimes and I guess its then actually a bug in the load() implementation. But this way it at least doesn't crash randomly.
+      length = src_data_size; // this happens sometimes and I guess its then actually a bug in the load() implementation. But this way it at least doesn't crash randomly.
     }
 
-    return memcpy(__dest, &__src[0], __len);
+    return memcpy(dest, &srcVec[0], length);
 }
 
 

--- a/chunk.h
+++ b/chunk.h
@@ -75,6 +75,9 @@ signals:
   friend class ChunkRenderer;
   friend class ChunkCache;
   friend class WorldSave;
+
+private:
+  void findHighestBlock();
 };
 
 #endif  // CHUNK_H_

--- a/nbt.h
+++ b/nbt.h
@@ -16,7 +16,7 @@ class TagDataStream {
   quint16 r16();
   quint32 r32();
   quint64 r64();
-  quint8 *r(int len);
+  void r(int len, std::vector<quint8> &data_out);
   QString utf8(int len);
   void skip(int len);
  private:
@@ -35,9 +35,9 @@ class Tag {
   virtual const QString toString() const;
   virtual qint32 toInt() const;
   virtual double toDouble() const;
-  virtual const quint8 *toByteArray() const;
-  virtual const qint32 *toIntArray() const;
-  virtual const qint64 *toLongArray() const;
+  virtual const std::vector<quint8> &toByteArray() const;
+  virtual const std::vector<qint32> &toIntArray() const;
+  virtual const std::vector<qint64> &toLongArray() const;
   virtual const QVariant getData() const;
 };
 
@@ -126,11 +126,11 @@ class Tag_Byte_Array : public Tag {
   explicit Tag_Byte_Array(TagDataStream *s);
   ~Tag_Byte_Array();
   int length() const;
-  const quint8 *toByteArray() const;
+  const std::vector<quint8>& toByteArray() const override;
   virtual const QString toString() const;
   virtual const QVariant getData() const;
  private:
-  const quint8 *data;
+  std::vector<quint8> data;
   int len;
 };
 
@@ -172,12 +172,12 @@ class Tag_Int_Array : public Tag {
   explicit Tag_Int_Array(TagDataStream *s);
   ~Tag_Int_Array();
   int length() const;
-  const qint32 *toIntArray() const;
+  const std::vector<qint32>& toIntArray() const override;
   virtual const QString toString() const;
   virtual const QVariant getData() const;
  private:
   int len;
-  qint32 *data;
+  std::vector<qint32> data;
 };
 
 class Tag_Long_Array : public Tag {
@@ -185,12 +185,12 @@ class Tag_Long_Array : public Tag {
   explicit Tag_Long_Array(TagDataStream *s);
   ~Tag_Long_Array();
   int length() const;
-  const qint64 *toLongArray() const;
+  const std::vector<qint64>& toLongArray() const override;
   virtual const QString toString() const;
   virtual const QVariant getData() const;
  private:
   int len;
-  qint64 *data;
+  std::vector<qint64> data;
 };
 
 #endif  // NBT_H_


### PR DESCRIPTION
I stumbled across this by chance. I'm pretty sure that the `loaded = true;` needs to be at the very end if this function. 
In addition I extracted the function `Chunk::findHighestBlock` because the code uses a `return` for exiting from multiple nested loops. This would have made it impossible to have the `loaded = true;` at the very end.

I also recognized a random crash in `Chunk::load` caused by `memcpy` of invalid (zero-sized) IntArrayTags. This should at least fix the crash - still there might be an error in the logic of loading