### PR TITLE
fix rendering of old format worlds

### DIFF
--- a/chunk.cpp
+++ b/chunk.cpp
@@ -29,7 +29,7 @@ Chunk::~Chunk() {
   if (loaded) {
     for (int i = 0; i < 16; i++)
       if (sections[i]) {
-        if (sections[i]->paletteLength > 0) {
+        if ((!sections[i]->paletteIsShared) && (sections[i]->paletteLength > 0)) {
           delete[] sections[i]->palette;
         }
         sections[i]->paletteLength = 0;
@@ -243,8 +243,9 @@ void Chunk::loadSection1343(ChunkSection *cs, const Tag *section) {
   }
 
   // link to Converter palette
-  cs->paletteLength = 0;
+  cs->paletteLength = FlatteningConverter::Instance().paletteLength;
   cs->palette = FlatteningConverter::Instance().getPalette();
+  cs->paletteIsShared = true;
 }
 
 // Chunk format after "The Flattening" version 1519
@@ -343,6 +344,12 @@ void Chunk::loadSection1519(ChunkSection *cs, const Tag *section) {
     safeMemCpy(cs->blockLight, section->at("BlockLight")->toByteArray(), 2048);
   }
 }
+
+
+ChunkSection::ChunkSection()
+  : paletteLength(0)
+  , paletteIsShared(false)  // only the "old" converted format is using one shared palette
+{}
 
 const PaletteEntry & ChunkSection::getPaletteEntry(int x, int y, int z) const {
   int xoffset = (x & 0x0f);

--- a/chunk.h
+++ b/chunk.h
@@ -14,6 +14,8 @@
 
 class ChunkSection {
  public:
+  ChunkSection();
+
   const PaletteEntry & getPaletteEntry(int x, int y, int z) const;
   const PaletteEntry & getPaletteEntry(int offset, int y) const;
   quint8 getSkyLight(int x, int y, int z);
@@ -23,6 +25,7 @@ class ChunkSection {
 
   PaletteEntry *palette;
   int        paletteLength;
+  bool       paletteIsShared;
 
   quint16 blocks[16*16*16];
 //quint8  skyLight[16*16*16/2];   // not needed in Minutor

--- a/flatteningconverter.h
+++ b/flatteningconverter.h
@@ -18,6 +18,7 @@ public:
   void disableDefinitions(int id);
 //  const BlockData * getPalette();
   PaletteEntry * getPalette();
+  const static int paletteLength = 16*256;  // 4 bit data + 8 bit ID
 
 private:
   // singleton: prevent access to constructor and copyconstructor
@@ -27,7 +28,7 @@ private:
   FlatteningConverter &operator=(const FlatteningConverter &);
 
   void parseDefinition(JSONObject *block, int *parentID, int pack);
-  PaletteEntry palette[16*256];  // 4 bit data + 8 bit ID
+  PaletteEntry palette[paletteLength];
 //  QList<QList<BlockInfo*> > packs;
 };
 

--- a/paletteentry.h
+++ b/paletteentry.h
@@ -3,6 +3,7 @@
 #define PALETTEENTRY_H_
 
 #include <QString>
+#include <QVariant>
 #include <QMap>
 
 class PaletteEntry {


### PR DESCRIPTION
The extra check for valid Palette entries breaks rendering of old worlds.
(And we both changed the line with boost at the same time...)