### PR TITLE
add missing include, fix build on Linux

### DIFF
--- a/searchresultwidget.cpp
+++ b/searchresultwidget.cpp
@@ -1,6 +1,8 @@
 #include "searchresultwidget.h"
 #include "ui_searchresultwidget.h"
 
+#include <cmath>
+
 #include "properties.h"
 
 Q_DECLARE_METATYPE(SearchResultItem);


### PR DESCRIPTION
fixes build error with any GCC compiler:
```
searchresultwidget.cpp: In member function 'void SearchResultWidget::addResult(const SearchResultItem&)':
searchresultwidget.cpp:62:43: error: 'roundf' is not a member of 'std'
   item->setText(c++, QString::number(std::roundf(slopeDistance)));
                                           ^~~~~~
```
see for details:
- [my OBS project](https://build.opensuse.org/package/show/home:nikoneko:minutor/minutor) (packaging for various Linux systems)
- [Travis CI output](https://travis-ci.org/github/Kolcha/minutor/builds/680991744) (from my fork)
- [AppVeyor output](https://ci.appveyor.com/project/Kolcha/minutor/builds/32529010) for MinGW build (also from my fork)

please setup Travis CI and AppVeyor builds for your repo to prevent such incidents in future, you already have everything required, just login to build servers using GitHub account and enable build. nothing more is required.
then you will have build status icon for latest pushed commit for each branch and even merge request. see [my fork](https://github.com/Kolcha/minutor) for example, red cross icon can be found here, pressing it some details and links to build servers are provided.