### PR TITLE
fix build with Qt 5.9 and older

### DIFF
--- a/searchchunkswidget.cpp
+++ b/searchchunkswidget.cpp
@@ -108,9 +108,8 @@ void SearchChunksWidget::AsyncSearch::searchLoadedChunk_async(const QSharedPoint
     results = searchExistingChunk_async(chunk);
   }
 
-  QMetaObject::invokeMethod(&parent, [&parent = parent, results](){
-    parent.displayResultsOfSingleChunk(results);
-  });
+  QMetaObject::invokeMethod(&parent, "displayResultsOfSingleChunk", Qt::QueuedConnection,
+                            Q_ARG(QSharedPointer<SearchPluginI::ResultListT>, results));
 }
 
 QSharedPointer<SearchPluginI::ResultListT> SearchChunksWidget::AsyncSearch::searchExistingChunk_async(const QSharedPointer<Chunk>& chunk)


### PR DESCRIPTION
don't use QMetaObject::invokeMethod() signature appeared only in Qt 5.10,
use one of signatures available in any Qt version

it produces the same effect as newer, but it is much more portable

even still actual Ubuntu 18.04 has only Qt 5.9, and it is previous LTS
release, so it should be supported

build fails with that error:
```
searchchunkswidget.cpp: In member function ‘void SearchChunksWidget::AsyncSearch::searchLoadedChunk_async(const QSharedPointer<Chunk>&)’:
searchchunkswidget.cpp:113:4: error: no matching function for call to ‘QMetaObject::invokeMethod(SearchChunksWidget*, SearchChunksWidget::AsyncSearch::searchLoadedChunk_async(const QSharedPointer<Chunk>&)::<lambda()>)’
   });
    ^
```

see [Travis CI output](https://travis-ci.org/github/Kolcha/minutor/jobs/681094442) for details, build is run on Ubuntu 18.04