### PR TITLE
fixed a lot of warnings produced by clang on macOS

### DIFF
--- a/generatedstructure.cpp
+++ b/generatedstructure.cpp
@@ -46,20 +46,20 @@ GeneratedStructure::tryParseFeatures(QVariant &maybeFeatureMap) {
   QList<QSharedPointer<GeneratedStructure>> ret;
 
   // check if we got a map
-  if ((QMetaType::Type)maybeFeatureMap.type() == QMetaType::QVariantMap) {
+  if (maybeFeatureMap.type() == QVariant::Map) {
     // convert it to a real map
     QMap<QString, QVariant> featureMap = maybeFeatureMap.toMap();
 
     // loop over all elements in feature map
     for (auto &feature : featureMap) {
       // check if the element is also a map
-      if ((QMetaType::Type)feature.type() == QMetaType::QVariantMap) {
+      if (feature.type() == QVariant::Map) {
         // convert it to a real map
         QMap<QString, QVariant> featureProperties = feature.toMap();
         // check for required properties
         if (featureProperties.contains("id") &&
             featureProperties.contains("BB") &&
-            (QMetaType::Type)featureProperties["BB"].type() == QMetaType::QVariantList ) {
+            featureProperties["BB"].type() == QVariant::List ) {
           // parse id
           QString id = featureProperties["id"].toString();
           // parse Bounding Box

--- a/nbt.h
+++ b/nbt.h
@@ -58,10 +58,10 @@ class NBT {
 class Tag_Byte : public Tag {
  public:
   explicit Tag_Byte(TagDataStream *s);
-  signed   int toInt() const;
+  signed   int toInt() const override;
   unsigned int toUInt() const;
-  virtual const QString toString() const;
-  virtual const QVariant getData() const;
+  const QString toString() const override;
+  const QVariant getData() const override;
  private:
   quint8 data;
 };
@@ -69,10 +69,10 @@ class Tag_Byte : public Tag {
 class Tag_Short : public Tag {
  public:
   explicit Tag_Short(TagDataStream *s);
-  signed   int toInt() const;
+  signed   int toInt() const override;
   unsigned int toUInt() const;
-  virtual const QString toString() const;
-  virtual const QVariant getData() const;
+  const QString toString() const override;
+  const QVariant getData() const override;
  private:
   qint16 data;
 };
@@ -80,10 +80,10 @@ class Tag_Short : public Tag {
 class Tag_Int : public Tag {
  public:
   explicit Tag_Int(TagDataStream *s);
-  qint32 toInt() const;
-  double toDouble() const;
-  virtual const QString toString() const;
-  virtual const QVariant getData() const;
+  qint32 toInt() const override;
+  double toDouble() const override;
+  const QString toString() const override;
+  const QVariant getData() const override;
  private:
   qint32 data;
 };
@@ -91,10 +91,10 @@ class Tag_Int : public Tag {
 class Tag_Long : public Tag {
  public:
   explicit Tag_Long(TagDataStream *s);
-  qint32 toInt() const;
-  double toDouble() const;
-  virtual const QString toString() const;
-  virtual const QVariant getData() const;
+  qint32 toInt() const override;
+  double toDouble() const override;
+  const QString toString() const override;
+  const QVariant getData() const override;
  private:
   qint64 data;
 };
@@ -103,9 +103,9 @@ class Tag_Float : public Tag {
  public:
   explicit Tag_Float(TagDataStream *s);
 
-  virtual double toDouble() const;
-  virtual const QString toString() const;
-  virtual const QVariant getData() const;
+  double toDouble() const override;
+  const QString toString() const override;
+  const QVariant getData() const override;
 
  private:
   float data;
@@ -114,9 +114,9 @@ class Tag_Float : public Tag {
 class Tag_Double : public Tag {
  public:
   explicit Tag_Double(TagDataStream *s);
-  double toDouble() const;
-  virtual const QString toString() const;
-  virtual const QVariant getData() const;
+  double toDouble() const override;
+  const QString toString() const override;
+  const QVariant getData() const override;
  private:
   double data;
 };
@@ -125,10 +125,10 @@ class Tag_Byte_Array : public Tag {
  public:
   explicit Tag_Byte_Array(TagDataStream *s);
   ~Tag_Byte_Array();
-  int length() const;
+  int length() const override;
   const std::vector<quint8>& toByteArray() const override;
-  virtual const QString toString() const;
-  virtual const QVariant getData() const;
+  const QString toString() const override;
+  const QVariant getData() const override;
  private:
   std::vector<quint8> data;
   int len;
@@ -137,8 +137,8 @@ class Tag_Byte_Array : public Tag {
 class Tag_String : public Tag {
  public:
   explicit Tag_String(TagDataStream *s);
-  const QString toString() const;
-  virtual const QVariant getData() const;
+  const QString toString() const override;
+  const QVariant getData() const override;
  private:
   QString data;
 };
@@ -147,10 +147,10 @@ class Tag_List : public Tag {
  public:
   explicit Tag_List(TagDataStream *s);
   ~Tag_List();
-  const Tag *at(int index) const;
-  int length() const;
-  virtual const QString toString() const;
-  virtual const QVariant getData() const;
+  const Tag *at(int index) const override;
+  int length() const override;
+  const QString toString() const override;
+  const QVariant getData() const override;
  private:
   QList<Tag *> data;
 };
@@ -159,10 +159,10 @@ class Tag_Compound : public Tag {
  public:
   explicit Tag_Compound(TagDataStream *s);
   ~Tag_Compound();
-  bool has(const QString key) const;
-  const Tag *at(const QString key) const;
-  virtual const QString toString() const;
-  virtual const QVariant getData() const;
+  bool has(const QString key) const override;
+  const Tag *at(const QString key) const override;
+  const QString toString() const override;
+  const QVariant getData() const override;
  private:
   QHash<QString, Tag *> children;
 };
@@ -171,10 +171,10 @@ class Tag_Int_Array : public Tag {
  public:
   explicit Tag_Int_Array(TagDataStream *s);
   ~Tag_Int_Array();
-  int length() const;
+  int length() const override;
   const std::vector<qint32>& toIntArray() const override;
-  virtual const QString toString() const;
-  virtual const QVariant getData() const;
+  const QString toString() const override;
+  const QVariant getData() const override;
  private:
   int len;
   std::vector<qint32> data;
@@ -184,10 +184,10 @@ class Tag_Long_Array : public Tag {
  public:
   explicit Tag_Long_Array(TagDataStream *s);
   ~Tag_Long_Array();
-  int length() const;
+  int length() const override;
   const std::vector<qint64>& toLongArray() const override;
-  virtual const QString toString() const;
-  virtual const QVariant getData() const;
+  const QString toString() const override;
+  const QVariant getData() const override;
  private:
   int len;
   std::vector<qint64> data;

--- a/properties.cpp
+++ b/properties.cpp
@@ -26,13 +26,13 @@ void Properties::DisplayProperties(QVariant p) {
 
   // only support QVariantMap or QVariantHash at this level
   switch (p.type()) {
-    case QMetaType::QVariantMap:
+    case QVariant::Map:
       treeCreator.ParseIterable(ui->propertyView->invisibleRootItem(), p.toMap());
       break;
-    case QMetaType::QVariantHash:
+    case QVariant::Hash:
       treeCreator.ParseIterable(ui->propertyView->invisibleRootItem(), p.toHash());
       break;
-    case QMetaType::QVariantList:
+    case QVariant::List:
       treeCreator.ParseList(ui->propertyView->invisibleRootItem(), p.toList());
       break;
     default:

--- a/propertietreecreator.cpp
+++ b/propertietreecreator.cpp
@@ -51,13 +51,13 @@ void PropertieTreeCreator::ParseList(QTreeWidgetItem* node, const IterableT& seq
 
 void PropertieTreeCreator::CreateTree(QTreeWidgetItem* node, const QVariant& v) {
   switch (v.type()) {
-    case QMetaType::QVariantMap:
+    case QVariant::Map:
       ParseIterable(node, v.toMap());
       break;
-    case QMetaType::QVariantHash:
+    case QVariant::Hash:
       ParseIterable(node, v.toHash());
       break;
-    case QMetaType::QVariantList:
+    case QVariant::List:
       ParseList(node, v.toList());
       break;
     default:
@@ -70,7 +70,7 @@ void PropertieTreeCreator::CreateTree(QTreeWidgetItem* node, const QVariant& v) 
 QString EvaluateSubExpression(const QString& subexpr, const QVariant& v) {
   if (subexpr.size() == 0) {
     // limit the displayed decimal places
-    if ((QMetaType::Type)v.type() == QMetaType::Double) {
+    if (v.type() == QVariant::Double) {
       return QString::number(v.toDouble(), 'f', 2);
     }
     return v.toString();
@@ -79,7 +79,7 @@ QString EvaluateSubExpression(const QString& subexpr, const QVariant& v) {
     if (rightbracket > 0) {
       bool ok = false;
       int index = subexpr.mid(1, rightbracket-1).toInt(&ok);
-      if (ok && (QMetaType::Type)v.type() == QMetaType::QVariantList) {
+      if (ok && v.type() == QVariant::List) {
         return EvaluateSubExpression(subexpr.mid(rightbracket + 1),
                                      v.toList().at(index));
       }
@@ -87,12 +87,12 @@ QString EvaluateSubExpression(const QString& subexpr, const QVariant& v) {
   } else {
     int dot = subexpr.indexOf('.');
     QString key = subexpr.mid(0, dot);
-    if ((QMetaType::Type)v.type() == QMetaType::QVariantHash) {
+    if (v.type() == QVariant::Hash) {
       QHash<QString, QVariant> h = v.toHash();
       QHash<QString, QVariant>::const_iterator it = h.find(key);
       if (it != h.end())
         return EvaluateSubExpression(subexpr.mid(key.length() + 1), *it);
-    } else if ((QMetaType::Type)v.type() == QMetaType::QVariantMap) {
+    } else if (v.type() == QVariant::Map) {
       QMap<QString, QVariant> h = v.toMap();
       QMap<QString, QVariant>::const_iterator it = h.find(key);
       if (it != h.end())
@@ -122,9 +122,9 @@ QString PropertieTreeCreator::GetSummary(const QString& key, const QVariant& v) 
       }
       ret.replace(pattern, evaluated);
     }
-  } else if ((QMetaType::Type)v.type() == QMetaType::QVariantList) {
+  } else if (v.type() == QVariant::List) {
     ret = QString("(%1 items)").arg(v.toList().size());
-  } else if ((QMetaType::Type)v.type() == QMetaType::QVariantMap) {
+  } else if (v.type() == QVariant::Map) {
     ret = GetSummary("", v);
   }
   return ret;


### PR DESCRIPTION
fixed next warnings:
```
../minutor/properties.cpp:35:10: warning: comparison of two values with different enumeration types in switch statement ('QVariant::Type' and 'QMetaType::Type') [-Wenum-compare-switch]
    case QMetaType::QVariantList:
         ^~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```
```
../minutor/./nbt.h:174:7: warning: 'length' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  int length() const;
      ^
../minutor/./nbt.h:32:15: note: overridden virtual function is here
  virtual int length() const;
              ^
```
there were ~200 warnings caused by missing `override` keyword:
<img width="1280" alt="Screenshot 2020-04-30 09 52 50" src="https://user-images.githubusercontent.com/947647/80684544-7f307680-8ace-11ea-8aae-294ac9e625d2.png">
