### PR TITLE
fix macOS app compiled with Qt 5.9

### DIFF
--- a/minutor.plist
+++ b/minutor.plist
@@ -7,9 +7,9 @@
 	<key>CFBundleDisplayName</key>
 	<string>Minutor</string>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
+	<string>@EXECUTABLE@</string>
 	<key>CFBundleIconFile</key>
-	<string>${ASSETCATALOG_COMPILER_APPICON_NAME}</string>
+	<string>@ICON@</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.seancode.minutor</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -22,8 +22,6 @@
 	<string>2.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>2.3.0</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>${MACOSX_DEPLOYMENT_TARGET}.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2013-2020 Sean Kasun</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
macOS app compiled with Qt 5.9 is unusable due to invalid values
`Info.plist`: placeholders are not replaced at all.

qmake from Qt 5.9 doesn't support environment variables style `${}`
placeholders in `Info.plist`, only its own `@VAR@` style.
moreover, the set of these placeholders is very limited.

replace `${VAR}` style placeholders with `@VAR@` style guarantee good
support for wide range of Qt versions. such style is supported in
newer versions for backward compatibility.

also dropped `LSMinimumSystemVersion` key because its placeholder is
supported only starting from Qt 5.12, and this key is optional.