### PR TITLE
Avoid legacy ID collisions with virtual IDs for <=1.12.2 worlds

### DIFF
--- a/chunk.cpp
+++ b/chunk.cpp
@@ -230,7 +230,8 @@ void Chunk::loadSection1343(ChunkSection *cs, const Tag *section) {
   for (int i = 0; i < 4096; i++) {
     int d = data[i>>1];         // get raw data (two nibbles)
     if (i & 1) d >>= 4;         // get one nibble of data
-    cs->blocks[i] = blocks[i] | ((d & 0x0f) << 8);
+    // Shift enough so virtual IDs never overlap 0-4095 range
+    cs->blocks[i] = blocks[i] | ((d & 0x0f) << 12);
   }
 
   // parse optional "Add" part for higher block IDs in mod packs

--- a/flatteningconverter.h
+++ b/flatteningconverter.h
@@ -18,7 +18,7 @@ public:
   void disableDefinitions(int id);
 //  const BlockData * getPalette();
   PaletteEntry * getPalette();
-  const static int paletteLength = 16*256;  // 4 bit data + 8 bit ID
+  const static int paletteLength = 16*256*16;  // 4096 IDs plus 16 virtual IDs each
 
 private:
   // singleton: prevent access to constructor and copyconstructor

--- a/flatteningconverter.h
+++ b/flatteningconverter.h
@@ -18,7 +18,7 @@ public:
   void disableDefinitions(int id);
 //  const BlockData * getPalette();
   PaletteEntry * getPalette();
-  const static int paletteLength = 16*256*16;  // 4096 IDs plus 16 virtual IDs each
+  const static int paletteLength = 16*4096;  // 4 bit data + 12 bit ID (4096)
 
 private:
   // singleton: prevent access to constructor and copyconstructor


### PR DESCRIPTION
This fixes a bug with the Flattening Converter that could cause ID collisions with IDs from mods. The old "spreading", "shifting", and "virtual ID" algorithms have been changed so they will not generate new internal IDs in the range 0..4095, ensuring that all old-style IDs in that range are usable by both vanilla and modded blocks.

Manually tested on Windows using a 32-bit build, on a 1.12.2 world with a few dozen modded blocks supplied in hand-created JSON files. Prior to the change, some of the modded blocks would show up as obviously wrong (pumpkins instead of ores).