### PR TITLE
Unknown legacy block IDs show as such and ID+data is shown in tooltip

### DIFF
--- a/blockidentifier.cpp
+++ b/blockidentifier.cpp
@@ -85,6 +85,7 @@ BlockIdentifier::BlockIdentifier() {
   for (int i = 0; i < 16; i++)
     unknownBlock.colors[i] = 0xff00ff;
   unknownBlock.alpha = 1.0;
+  // TODO: Hoist string literal into named constant
   unknownBlock.setName("Unknown Block");
 }
 

--- a/flatteningconverter.cpp
+++ b/flatteningconverter.cpp
@@ -7,9 +7,22 @@
 #include "./flatteningconverter.h"
 #include "./json.h"
 
+const QString PaletteEntry::legacyBlockIdProperty = "lbid";
 
+FlatteningConverter::FlatteningConverter() {
+  // To ensure that unknown legacy (pre-flattening) block IDs
+  // are shown as unknown, and to track their legacy ID to
+  // help definition pack creators, prepopulate the palette array.
 
-FlatteningConverter::FlatteningConverter() {}
+  // TODO: Hoist "Unknown Block" literal into constant
+  QString unknownBlockName = "Unknown Block";
+  uint unknownBlockHID = qHash(unknownBlockName);
+  for (int idx = 0; idx < paletteLength; idx++) {
+    palette[idx].hid = unknownBlockHID;
+    palette[idx].name = unknownBlockName;
+    palette[idx].properties[PaletteEntry::legacyBlockIdProperty] = idx;
+  }
+}
 
 FlatteningConverter::~FlatteningConverter() {}
 

--- a/paletteentry.h
+++ b/paletteentry.h
@@ -11,6 +11,9 @@ class PaletteEntry {
   uint    hid;   // we use hashed name as ID
   QString name;
   QMap<QString, QVariant> properties;
+
+  // Property used to store a legacy block ID
+  static const QString legacyBlockIdProperty;
 };
 
 #endif  // PALETTEENTRY_H_


### PR DESCRIPTION
This change causes unknown legacy block IDs to show as unknown (purple) and displays the legacy ID:data in the tooltip.

Tested manually under Windows using the Exp1 world from https://github.com/mrkite/minutor/pull/236. Without the change, note the air gaps (shown as stone) around lava at Y=5, such as around the lava at -72, 250. With the change, note that the lava is surrounded by purple (unknown) blocks with ID 1930:7 (Chisel's plain basalt2 block). Also observe some modded trees with unknown leaf IDs (such as 1759:4) on the surface, such as -41, 200 at Y=75.

This change does NOT deal with unknown post-flattening IDs. I don't currently have any modded post-1.12.2 worlds with which to experiment.