### PR TITLE
Added check to avoid loading data from chunks with empty Biomes data

### DIFF
--- a/chunk.cpp
+++ b/chunk.cpp
@@ -83,7 +83,9 @@ void Chunk::load(const NBT &nbt) {
   chunkZ = level->at("zPos")->toInt();
 
   // load Biome data
-  if (level->has("Biomes")) {
+  // Partially-generated chunks may have an empty Biomes tag. Trying to extract
+  // the Biomes data will cause a crash.
+  if (level->has("Biomes") && level->at("Biomes") && level->at("Biomes")->length()) {
     const Tag_Int_Array * biomes = dynamic_cast<const Tag_Int_Array*>(level->at("Biomes"));
     if (biomes) {  // Biomes is a Tag_Int_Array
       if ((this->version >= 2203)) {


### PR DESCRIPTION
Minutor can crash when attempting to load data from chunks that exist (have an entry in the .mca file) but have not been populated (has a Biomes tag but with no data).

Tested manually on World36 as referenced in issue #192 . Without this change, Minutor crashes when scrolling down on chunk 9, 30 found in file r.0.0.mca. Using NBTExplorer on that file, it shows a chunk with a Biomes tag consisting of 0 integers. I believe this can happen when a chunk is partially created (perhaps due to structures?) but its contents aren't fully generated. With this change the chunk in question loads and is rendered as a black square (distinct from the checkerboard pattern of non-generated chunks), and manually scrolling around the map seemed OK.