### PR TITLE
Added button to export search results to a tab-separated file

### DIFF
--- a/searchresultwidget.h
+++ b/searchresultwidget.h
@@ -53,6 +53,8 @@ private slots:
 
   void on_check_display_all_stateChanged(int arg1);
 
+  void on_saveSearchResults_clicked();
+
 private:
   Ui::SearchResultWidget *ui;
 

--- a/searchresultwidget.ui
+++ b/searchresultwidget.ui
@@ -24,6 +24,19 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="saveSearchResults">
+       <property name="maximumSize">
+        <size>
+         <width>122</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Save to file...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QCheckBox" name="check_display_all">
        <property name="text">
         <string>display all on map</string>


### PR DESCRIPTION
This change adds a button and functionality to write the current search results to a tab-separated file. The change is intended to help with issue #233.

Tested manually under Windows 10 (64 bit), using 32-bit Minutor build and searching for block minecraft:gold_ore in World36 referenced in issue #192. Also searched for entities and exported that data as well.

Caveats:
(1) If a search is in progress, only the current in-progress results will be written.
(2) No attempt is made to extract or impose additional structure on the written data--it's exactly as it appears in the search results, just separated by tabs.