### PR TITLE
Villager poi visualisation

### DIFF
--- a/entity.cpp
+++ b/entity.cpp
@@ -49,29 +49,13 @@ QSharedPointer<OverlayItem> Entity::TryParse(const Tag* tag) {
         if (brain.contains("memories")) {
           QMap<QString, QVariant> memories = brain["memories"].toMap();
           // home is location of bed
-          if (memories.contains("minecraft:home")) {
-            auto home  = memories["minecraft:home"].toMap();
-            auto value = home["value"].toMap();
-            auto pos   = value["pos"].toList();
-            entity->posB = Point(pos[0].toDouble(), pos[1].toDouble(), pos[2].toDouble());
-            entity->hasExtraB = true;
-          }
+          TryParseMemory(memories, "minecraft:home",               entity->posB, entity->hasExtraB);
+
           // location of job site
-          if (memories.contains("minecraft:job_site")) {
-            auto job   = memories["minecraft:job_site"].toMap();
-            auto value = job["value"].toMap();
-            auto pos   = value["pos"].toList();
-            entity->posR = Point(pos[0].toDouble(), pos[1].toDouble(), pos[2].toDouble());
-            entity->hasExtraR = true;
-          }
-          // location of potential job site
-          if (memories.contains("minecraft:potential_job_site")) {
-            auto job   = memories["minecraft:potential_job_site"].toMap();
-            auto value = job["value"].toMap();
-            auto pos   = value["pos"].toList();
-            entity->posR = Point(pos[0].toDouble(), pos[1].toDouble(), pos[2].toDouble());
-            entity->hasExtraR = true;
-          }
+          TryParseMemory(memories, "minecraft:job_site",           entity->posR, entity->hasExtraR);
+          TryParseMemory(memories, "minecraft:potential_job_site", entity->posR, entity->hasExtraR);
+
+          // meeting point is location of bell
         }
       }
 
@@ -79,6 +63,26 @@ QSharedPointer<OverlayItem> Entity::TryParse(const Tag* tag) {
     }
   }
   return ret;
+}
+
+// static
+void Entity::TryParseMemory(const QMap<QString, QVariant> &memories,
+                            const QString memory,
+                            Point &poi, bool &flag) {
+  if (memories.contains(memory)) {
+    QMap<QString, QVariant> location = memories[memory].toMap();
+    QList<QVariant> pos;
+    if (location.contains("value")) {
+      QMap<QString, QVariant> value = location["value"].toMap();
+      pos = value["pos"].toList();
+    } else if (location.contains("pos")) {
+      pos = location["pos"].toList();
+    } else return;
+    poi.x = pos[0].toInt();
+    poi.y = pos[1].toInt();
+    poi.z = pos[2].toInt();
+    flag  = true;
+  }
 }
 
 

--- a/entity.h
+++ b/entity.h
@@ -24,6 +24,10 @@ class Entity: public OverlayItem {
  protected:
   Entity() {}
 
+  static void TryParseMemory(const QMap<QString, QVariant> &memories,
+                             const QString memory,
+                             Point &poi, bool &flag);
+
  private:
   QColor extraColor;
   Point pos;

--- a/entity.h
+++ b/entity.h
@@ -28,6 +28,13 @@ class Entity: public OverlayItem {
   QColor extraColor;
   Point pos;
   QString display;
+
+  // optional job location
+  bool  hasExtraR;
+  Point posR;
+  // optional home location
+  bool  hasExtraB;
+  Point posB;
 };
 
 #endif  // ENTITY_H_

--- a/entity.h
+++ b/entity.h
@@ -24,21 +24,21 @@ class Entity: public OverlayItem {
  protected:
   Entity() {}
 
-  static void TryParseMemory(const QMap<QString, QVariant> &memories,
-                             const QString memory,
-                             Point &poi, bool &flag);
-
  private:
   QColor extraColor;
   Point pos;
   QString display;
 
-  // optional job location
-  bool  hasExtraR;
-  Point posR;
-  // optional home location
-  bool  hasExtraB;
-  Point posB;
+  // optional POI location(s)
+  struct POI {
+    explicit POI(int x = 0, int z = 0): x(x), z(z) {}
+    explicit POI(const QVector3D& pos3D): x(pos3D.x()), z(pos3D.z()) {}
+    double x, z;
+    QColor color;
+  };
+  QList<POI> poiList;
+
+  void tryParseMemory(const QMap<QString, QVariant> &memories, const QString memory, QColor color);
 };
 
 #endif  // ENTITY_H_


### PR DESCRIPTION
Comment before Merge!

Villagers have home and job locations (also called POI system).
Also PiglinBrutes use a home location to patrol around a given location.

These changes will draw small indication lines towards these locations.
I took simple blue for bed and red for work, as they differ well from typical block colors.
But I'm open for better color suggestions.
Also another location is possible to highlight: Meeting Point

Example with 4 farmers working in separate houses:
![grafik](https://user-images.githubusercontent.com/5821779/98104966-824e5a00-1e97-11eb-88a6-a063d02f5dc7.png)

Still open is the dimension. All the locations are stored together with a dimension and should only be drawn when the current rendered dimension is the same.