### PR TITLE
load entities also from extra folder

### DIFF
--- a/chunk.cpp
+++ b/chunk.cpp
@@ -159,6 +159,21 @@ void Chunk::load(const NBT &nbt) {
   loaded = true; // needs to be at the end!
 }
 
+void Chunk::loadEntities(const NBT &nbt) {
+  // parse Entities in extra folder (1.17+)
+  if (version >= 2681) {
+    if (nbt.has("Entities")) {
+      auto entitylist = nbt.at("Entities");
+      int numEntities = entitylist->length();
+      for (int i = 0; i < numEntities; ++i) {
+        auto e = Entity::TryParse(entitylist->at(i));
+        if (e)
+          entities.insertMulti(e->type(), e);
+      }
+    }
+  }
+}
+
 void Chunk::findHighestBlock()
 {
   for (int i = 15; i >= 0; i--) {

--- a/chunk.h
+++ b/chunk.h
@@ -40,6 +40,7 @@ class Chunk : public QObject {
   Chunk();
   ~Chunk();
   void load(const NBT &nbt);
+  void loadEntities(const NBT &nbt);
 
   typedef QMap<QString, QSharedPointer<OverlayItem>> EntityMap;
 

--- a/chunkloader.h
+++ b/chunkloader.h
@@ -13,7 +13,13 @@ class ChunkLoader : public QObject, public QRunnable {
   ChunkLoader(QString path, int cx, int cz);
   ~ChunkLoader();
 
+  enum CHUNKLOAD_TYPE {
+    MAIN_MAP_DATA      = 0,
+    SEPARATED_ENTITIES = 1
+  };
+
   static bool loadNbt(QString path, int cx, int cz, QSharedPointer<Chunk> chunk);
+  static bool loadNbtHelper(QString filename, int cx, int cz, QSharedPointer<Chunk> chunk, int loadtype);
 
  signals:
   void loaded(int cx, int cz);


### PR DESCRIPTION
With upcoming version 1.17 Entities are stored in a separated folder.
This pull request parses this folder for Entities  also.

Should solve part of #242
