### PR TITLE
upgrade Qt version for Ubuntu 16.04

### DIFF
--- a/.github/workflows/c++qt-crossplattform.yml
+++ b/.github/workflows/c++qt-crossplattform.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           - name: ubuntu-16.04
             os: ubuntu-16.04
-            qt: '5.5'
+            qt: '5.9.5'
             artifact: minutor
           - name: ubuntu-18.04
             os: ubuntu-18.04


### PR DESCRIPTION
download link for old QT version was removed at qt.io

We could upgrade Qt to 5.9.5 (same as with Ubuntu 18.04) and our CI would work again.

I would prefer to remove Ubuntu 16.04 completely.
Just give your comments!