### PR TITLE
fix F2 shortcut

### DIFF
--- a/minutor.cpp
+++ b/minutor.cpp
@@ -375,7 +375,7 @@ void Minutor::createActions() {
           jumpSpawnAct, SLOT(setEnabled(bool)));
 
   jumpToAct = new QAction(tr("&Jump To"), this);
-  jumpToAct->setShortcut(tr("F2"));
+  jumpToAct->setShortcut(tr("CTRL+J"));
   jumpToAct->setStatusTip(tr("Jump to a location"));
   connect(jumpToAct, SIGNAL(triggered()),
           jumpTo,    SLOT(show()));


### PR DESCRIPTION
Jump To (Dialog Box) was using the same F2 key. Use CTRL+J instead.

Fixes #227
