### PR TITLE
Sugestion on future release numbers

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -15,7 +15,7 @@ int main(int argc, char *argv[]) {
   app.installTranslator(&translator);
 
   app.setApplicationName("Minutor");
-  app.setApplicationVersion("2.3.0");
+  app.setApplicationVersion("2.17.0");
   app.setOrganizationName("seancode");
 
   Minutor minutor;

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -325,7 +325,7 @@ void Minutor::about() {
                         "&copy; Copyright %3, %4")
                      .arg(qApp->applicationName())
                      .arg(qApp->applicationVersion())
-                     .arg(2019)
+                     .arg("2010 - 2021")
                      .arg(qApp->organizationName()));
 }
 


### PR DESCRIPTION
I think we have done far too less releases during the past years.
Especially when users complain about stuff not working, it would be much easier if we have a meaningful release version number.

My suggestion is now to:
* use Minecraft minor part of version number also as minor part of our version number
* only upgrade that number if something in normal code has changed for that version, so definition updates are out of scope
* if we provide official release downloads for each of that versions is something different, but at least the nightly builds will have new numbers

With that, users will directly see they are using Minecraft 1.18 but Minutor is still at 2.17, so their new build height will not be rendered correctly. I think it is fine that we have a different major number than Minecraft (2 versus 1), as Mojang probably will never change the major number.


This PullRequest will bump the version number to **2.17.0** as the last major code change was for **1.17** update.