### PR TITLE
support Minecraft 1.18 extended build height

### DIFF
--- a/.github/workflows/c++qt-crossplattform.yml
+++ b/.github/workflows/c++qt-crossplattform.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Create BUILD folder
       run: |
         mkdir ../build
-    
+
     - name: Build (Windows)
       if: matrix.os == 'windows-latest'
       working-directory: ../build
@@ -71,7 +71,7 @@ jobs:
         call ${{ matrix.vcvars }}
         qmake ${{ github.workspace }}/minutor.pro
         nmake
-  
+
     - name: Build (others)
       if: matrix.os != 'windows-latest'
       working-directory: ../build

--- a/biomeidentifier.cpp
+++ b/biomeidentifier.cpp
@@ -5,6 +5,7 @@ Copyright (c) 2016, EtlamGit
 
 #include <assert.h>
 #include <cmath>
+#include <QtCore>
 
 #include "./biomeidentifier.h"
 #include "./json.h"
@@ -221,6 +222,9 @@ const BiomeInfo &BiomeIdentifier::getBiome(QString id) const {
   for (const BiomeInfo* biome : this->biomes18) {
     if (biome->nid == id) return *(biome);
   }
+#if defined(DEBUG) || defined(_DEBUG) || defined(QT_DEBUG)
+  qWarning() << "Unknown Biome:" << id;
+#endif
   return unknownBiome;
 }
 

--- a/biomeidentifier.cpp
+++ b/biomeidentifier.cpp
@@ -18,13 +18,13 @@ static BiomeInfo unknownBiome;
 
 BiomeInfo::BiomeInfo()
   : id(-1)
+  , nid("")
   , name("Unknown Biome")
   , enabled(false)
-  , watermodifier(255,255,255)
-  , enabledwatermodifier(false)
-  , alpha(1.0)
   , temperature(0.5)
   , humidity(0.5)
+  , enabledwatermodifier(false)
+  , watermodifier(255,255,255)
 {}
 
 
@@ -185,9 +185,7 @@ QColor BiomeInfo::getBiomeWaterColor( QColor watercolor ) const
 // BiomeIdentifier
 // --------- --------- --------- ---------
 
-BiomeIdentifier::BiomeIdentifier() {
-  unknownBiome.name = "Unknown";
-}
+BiomeIdentifier::BiomeIdentifier() {}
 
 BiomeIdentifier::~BiomeIdentifier() {
   for (int i = 0; i < packs.length(); i++) {
@@ -201,13 +199,29 @@ BiomeIdentifier& BiomeIdentifier::Instance() {
   return singleton;
 }
 
-const BiomeInfo &BiomeIdentifier::getBiome(int biome) const {
-  auto itr = biomes.find(biome);
-  if (itr == biomes.end()) {
+// legacy Biomes
+const BiomeInfo &BiomeIdentifier::getBiome(int id) const {
+  auto itr = this->biomes.find(id);
+  if (itr == this->biomes.end()) {
     return unknownBiome;
   } else {
     return *(*itr);
   }
+}
+
+// new Biomes after Cliffs & Caves update (1.18)
+const BiomeInfo &BiomeIdentifier::getBiome(quint8 id) const {
+  if (id < this->biomes18.length())
+    return *(this->biomes18.at(id));
+  else
+    return unknownBiome;
+}
+
+const BiomeInfo &BiomeIdentifier::getBiome(QString id) const {
+  for (const BiomeInfo* biome : this->biomes18) {
+    if (biome->nid == id) return *(biome);
+  }
+  return unknownBiome;
 }
 
 void BiomeIdentifier::enableDefinitions(int pack) {
@@ -225,90 +239,177 @@ void BiomeIdentifier::disableDefinitions(int pack) {
   updateBiomeDefinition();
 }
 
-int BiomeIdentifier::addDefinitions(JSONArray *defs, int pack) {
+int BiomeIdentifier::addDefinitions(JSONArray *data, JSONArray *data18, int pack) {
   if (pack == -1) {
     pack = packs.length();
-    packs.append(QList<BiomeInfo *>());
+    packs  .append(QList<BiomeInfo *>());
+    packs18.append(QList<BiomeInfo *>());
   }
 
-  int len = defs->length();
-  for (int i = 0; i < len; i++) {
-    JSONObject *b = dynamic_cast<JSONObject *>(defs->at(i));
-    int id = b->at("id")->asNumber();
-
-    BiomeInfo *biome = new BiomeInfo();
-    biome->enabled = true;
-    biome->id = id;
-    if (b->has("name"))
-      biome->name = b->at("name")->asString();
-
-    // check for "alpha" (0: transparent / 1: saturated)
-    // probably never used
-    if (b->has("alpha"))
-      biome->alpha = b->at("alpha")->asNumber();
-
-    // get temperature definition
-    if (b->has("temperature"))
-      biome->temperature = b->at("temperature")->asNumber();
-
-    // get humidity definition
-    if (b->has("humidity"))
-      biome->humidity = b->at("humidity")->asNumber();
-
-    // get watermodifier definition
-    if (b->has("watermodifier")) {
-      biome->watermodifier.setNamedColor(b->at("watermodifier")->asString());
-      biome->enabledwatermodifier = true;
-      assert(biome->watermodifier.isValid());
-    }
-
-    // get color definition
-    QColor biomecolor;
-    if (b->has("color")) {
-      QString colorname = b->at("color")->asString();
-      if (colorname.length() == 6) {
-        // check if this is an old color definition with missing '#'
-        bool ok;
-        colorname.toInt(&ok,16);
-        if (ok)
-          colorname.push_front('#');
-      }
-      biomecolor.setNamedColor(colorname);
-      assert(biomecolor.isValid());
-    } else {
-      // use hashed by name instead
-      quint32 hue = qHash(biome->name);
-      biomecolor.setHsv(hue % 360, 255, 255);
-    }
-
-    // pre-calculate light spectrum
-    for (int i = 0; i < 16; i++) {
-      // calculate light attenuation similar to Minecraft
-      // except base 90% here, were Minecraft is using 80% per level
-      double light_factor = pow(0.90,15-i);
-      biome->colors[i].setRgb(light_factor*biomecolor.red(),
-                              light_factor*biomecolor.green(),
-                              light_factor*biomecolor.blue(),
-                              255*biome->alpha );
-    }
-
-    packs[pack].append(biome);
-  }
+  if (data)   parseBiomeDefinitions0000(data, pack);
+  if (data18) parseBiomeDefinitions2800(data18, pack);
 
   updateBiomeDefinition();
   return pack;
 }
 
+// legacy Biome definitions before Cliffs & Caves (up to 1.17)
+void BiomeIdentifier::parseBiomeDefinitions0000(JSONArray *data, int pack) {
+  int len = data->length();
+  for (int i = 0; i < len; i++) {
+    JSONObject *b = dynamic_cast<JSONObject *>(data->at(i));
+    if (b->has("id")) {
+      int id = b->at("id")->asNumber();
+
+      BiomeInfo *biome = new BiomeInfo();
+      biome->enabled = true;
+      biome->id = id;
+      if (b->has("name"))
+        biome->name = b->at("name")->asString();
+
+      // get temperature definition
+      if (b->has("temperature"))
+        biome->temperature = b->at("temperature")->asNumber();
+
+      // get humidity definition
+      if (b->has("humidity"))
+        biome->humidity = b->at("humidity")->asNumber();
+
+      // get watermodifier definition
+      if (b->has("watermodifier")) {
+        biome->watermodifier.setNamedColor(b->at("watermodifier")->asString());
+        biome->enabledwatermodifier = true;
+        assert(biome->watermodifier.isValid());
+      }
+
+      // get color definition
+      QColor biomecolor;
+      if (b->has("color")) {
+        QString colorname = b->at("color")->asString();
+        if (colorname.length() == 6) {
+          // check if this is an old color definition with missing '#'
+          bool ok;
+          colorname.toInt(&ok,16);
+          if (ok)
+            colorname.push_front('#');
+        }
+        biomecolor.setNamedColor(colorname);
+        assert(biomecolor.isValid());
+      } else {
+        // use hashed by name instead
+        quint32 hue = qHash(biome->name);
+        biomecolor.setHsv(hue % 360, 255, 255);
+      }
+
+      // pre-calculate light spectrum for view mode "Biome Colors"
+      for (int i = 0; i < 16; i++) {
+        // calculate light attenuation similar to Minecraft
+        // except base 90% here, were Minecraft is using 80% per level
+        double light_factor = pow(0.90,15-i);
+        biome->colors[i].setRgb(light_factor*biomecolor.red(),
+                                light_factor*biomecolor.green(),
+                                light_factor*biomecolor.blue());
+      }
+
+      packs[pack].append(biome);
+    }
+  }
+}
+
+// new Biome definitions with Cliffs & Caves (1.18)
+void BiomeIdentifier::parseBiomeDefinitions2800(JSONArray *data18, int pack) {
+  int len = data18->length();
+  for (int i = 0; i < len; i++) {
+    JSONObject *b = dynamic_cast<JSONObject *>(data18->at(i));
+    if (b->has("id")) {
+      BiomeInfo *biome = new BiomeInfo();
+      biome->enabled = true;
+      biome->nid = b->at("id")->asString();
+      biome->id = i;
+
+      if (b->has("name"))
+        biome->name = b->at("name")->asString();
+      else {
+        // construct the name from NID
+        QString nid = QString(biome->nid).replace("minecraft:","").replace("_"," ");
+        QStringList parts = nid.toLower().split(' ', QString::SkipEmptyParts);
+        for (int i = 0; i < parts.size(); i++)
+          parts[i].replace(0, 1, parts[i][0].toUpper());
+        biome->name = parts.join(" ");
+      }
+
+      // get temperature definition
+      if (b->has("temperature"))
+        biome->temperature = b->at("temperature")->asNumber();
+
+      // get humidity definition
+      if (b->has("humidity"))
+        biome->humidity = b->at("humidity")->asNumber();
+
+      // get watermodifier definition
+      biome->enabledwatermodifier = true;
+      if (b->has("watermodifier")) {
+        biome->watermodifier.setNamedColor(b->at("watermodifier")->asString());
+        assert(biome->watermodifier.isValid());
+      } else biome->watermodifier.setNamedColor("#3f76e4");
+
+      // get color definition
+      QColor biomecolor;
+      if (b->has("color")) {
+        QString colorname = b->at("color")->asString();
+        if (colorname.length() == 6) {
+          // check if this is an old color definition with missing '#'
+          bool ok;
+          colorname.toInt(&ok,16);
+          if (ok)
+            colorname.push_front('#');
+        }
+        biomecolor.setNamedColor(colorname);
+        assert(biomecolor.isValid());
+      } else {
+        // use hashed by name instead
+        quint32 hue = qHash(biome->name);
+        biomecolor.setHsv(hue % 360, 255, 255);
+      }
+
+      // pre-calculate light spectrum for view mode "Biome Colors"
+      for (int i = 0; i < 16; i++) {
+        // calculate light attenuation similar to Minecraft
+        // except base 90% here, were Minecraft is using 80% per level
+        double light_factor = pow(0.90,15-i);
+        biome->colors[i].setRgb(light_factor*biomecolor.red(),
+                                light_factor*biomecolor.green(),
+                                light_factor*biomecolor.blue());
+      }
+
+      packs18[pack].append(biome);
+    }
+  }
+}
+
+
 void BiomeIdentifier::updateBiomeDefinition()
 {
   // start from scratch
   biomes.clear();
+  biomes18.clear();
 
-  for (int pack = 0; pack < packs.length(); pack++)
+  for (int pack = 0; pack < packs.length(); pack++) {
+    // legacy Biomes
     for (int i = 0; i < packs[pack].length(); i++) {
       BiomeInfo *bi = packs[pack][i];
       if (bi->enabled) {
         biomes[bi->id] = bi;
       }
     }
+
+    // new Biomes after Cliffs & Caves update (1.18)
+    for (int i = 0; i < packs18[pack].length(); i++) {
+      BiomeInfo *bi = packs18[pack][i];
+      if (bi->enabled) {
+        biomes18.append(bi);
+      }
+    }
+  }
+
 }

--- a/biomeidentifier.h
+++ b/biomeidentifier.h
@@ -69,8 +69,8 @@ private:
   QHash<int, BiomeInfo*>    biomes;   // consolidated Biome mapping
   QList<QList<BiomeInfo*> > packs;    // raw data of all available packs
   // new Biomes after Cliffs & Caves update (1.18)
-  QList<BiomeInfo*>         biomes18;   // consolidated Biome mapping
-  QList<QList<BiomeInfo*> > packs18;    // raw data of all available packs
+  QList<BiomeInfo*>         biomes18; // consolidated Biome mapping
+  QList<QList<BiomeInfo*> > packs18;  // raw data of all available packs
 };
 
 #endif  // BIOMEIDENTIFIER_H_

--- a/biomeidentifier.h
+++ b/biomeidentifier.h
@@ -19,15 +19,15 @@ class BiomeInfo {
 
   // public members
  public:
-  int id;
+  int     id;   // numerical ID
+  QString nid;  // namespace ID
   QString name;
-  bool enabled;
-  QColor colors[16];
-  QColor watermodifier;
-  bool   enabledwatermodifier;
-  double alpha;
-  double temperature;
-  double humidity;
+  bool    enabled;
+  double  temperature;
+  double  humidity;
+  bool    enabledwatermodifier;
+  QColor  watermodifier;
+  QColor  colors[16];
 
   // private methods and members
  private:
@@ -47,11 +47,13 @@ class BiomeIdentifier {
   // singleton: access to global usable instance
   static BiomeIdentifier &Instance();
 
-  int addDefinitions(JSONArray *, int pack = -1);
+  int  addDefinitions(JSONArray * data, JSONArray *data18, int pack = -1);
   void enableDefinitions(int id);
   void disableDefinitions(int id);
   void updateBiomeDefinition();
   const BiomeInfo &getBiome(int id) const;
+  const BiomeInfo &getBiome(quint8 id) const;
+  const BiomeInfo &getBiome(QString id) const;
 
 private:
   // singleton: prevent access to constructor and copyconstructor
@@ -60,8 +62,15 @@ private:
   BiomeIdentifier(const BiomeIdentifier &);
   BiomeIdentifier &operator=(const BiomeIdentifier &);
 
+  void parseBiomeDefinitions0000(JSONArray *data, int pack);
+  void parseBiomeDefinitions2800(JSONArray *data18, int pack);
+
+  // legacy Biomes
   QHash<int, BiomeInfo*>    biomes;   // consolidated Biome mapping
   QList<QList<BiomeInfo*> > packs;    // raw data of all available packs
+  // new Biomes after Cliffs & Caves update (1.18)
+  QList<BiomeInfo*>         biomes18;   // consolidated Biome mapping
+  QList<QList<BiomeInfo*> > packs18;    // raw data of all available packs
 };
 
 #endif  // BIOMEIDENTIFIER_H_

--- a/chunk.cpp
+++ b/chunk.cpp
@@ -23,35 +23,41 @@ inline void* safeMemCpy(void* dest, const std::vector<ValueT>& srcVec, size_t le
 
 Chunk::Chunk()
   : version(0)
-  , highest(0)
+  , highest(INT_MIN)
+  , lowest(INT_MAX)
   , loaded(false)
   , rendering(false)
 {}
 
 Chunk::~Chunk() {
   if (loaded) {
-    for (int i = 0; i < 16; i++)
-      if (sections[i]) {
-        if (!(sections[i]->blockPaletteIsShared) && (sections[i]->blockPaletteLength > 0)) {
-          delete[] sections[i]->blockPalette;
-        }
-        sections[i]->blockPaletteLength = 0;
-        sections[i]->blockPalette = NULL;
-
-        delete sections[i];
-        sections[i] = NULL;
-      }
     loaded = false;
+    for (auto sec : this->sections)
+      if (sec) {
+        if (!(sec->blockPaletteIsShared) && (sec->blockPaletteLength > 0)) {
+          delete[] sec->blockPalette;
+        }
+        sec->blockPaletteLength = 0;
+        sec->blockPalette = NULL;
+
+        delete sec;
+      }
+    this->sections.clear();
   }
 }
 
 void Chunk::findHighestBlock()
 {
-  for (int i = 15; i >= 0; i--) {
-    if (this->sections[i]) {
+  // loop over all Sections in reverse order
+  QMapIterator<qint8, ChunkSection*> it(this->sections);
+  it.toBack();
+  while (it.hasPrevious()) {
+    it.previous();
+    if (it.value()) {
       for (int j = 4095; j >= 0; j--) {
-        if (this->sections[i]->blocks[j]) {
-          highest = i * 16 + (j >> 8);
+        if (it.value()->blocks[j]) {
+          // found first non-air Block
+          highest = it.key() * 16 + (j >> 8);
           return;
         }
       }
@@ -63,12 +69,18 @@ const Chunk::EntityMap &Chunk::getEntityMap() const {
   return entities;
 }
 
+//inline
 const ChunkSection *Chunk::getSectionByY(int y) const {
-  size_t section_idx = static_cast<size_t>(y) >> 4;
-  if (section_idx >= sections.size())
-    return nullptr;
+  qint8 section_idx = (y >> 4);
+  return getSectionByIdx(section_idx);
+}
 
-  return sections[section_idx];
+//inline
+const ChunkSection *Chunk::getSectionByIdx(qint8 y) const {
+  if (sections.contains(y))
+    return sections[y];
+
+  return nullptr;
 }
 
 uint Chunk::getBlockHID(int x, int y, int z) const {
@@ -87,15 +99,19 @@ int Chunk::getBiomeID(int x, int y, int z) const {
 
   if (this->version >= 2800) {
     // Minecraft 1.18 has Y dependand Biome stored per Section
-    int x_idx = x         >> 2;
-    int y_idx = (y & 0xf) >> 2;
-    int z_idx = z         >> 2;
+    int x_idx = x          >> 2;
+    int y_idx = (y & 0x0f) >> 2;
+    int z_idx = z          >> 2;
     offset = x_idx + 4*z_idx + 16*y_idx;
-    int y_section = y >> 4;
-    if ((y_section>=0) && (y_section<16) && this->sections[y_section])
-      return this->sections[y_section]->biomes[offset];
-    else
+    int s_idx = (y >> 4);
+    if (this->sections.contains(s_idx) && this->sections[s_idx])
+      return this->sections[s_idx]->getBiome(offset);
+    else {
+      #if defined(DEBUG) || defined(_DEBUG) || defined(QT_DEBUG)
+      qWarning() << "Section not found for Biome lookup!";
+      #endif
       return -1;
+    }
   } else if (this->version >= 2203) {
     // Minecraft 1.15 has Y dependand Biome
     int x_idx = x >> 2;
@@ -121,10 +137,9 @@ int Chunk::getBiomeID(int x, int y, int z) const {
 // this is where we load NBT data and parse it
 
 void Chunk::load(const NBT &nbt) {
-  renderedAt = -1;  // impossible.
+  renderedAt = INT_MIN;  // impossible.
   renderedFlags = 0;  // no flags
-  for (int i = 0; i < 16; i++)
-    this->sections[i] = NULL;
+  this->sections.clear();
 
   if (nbt.has("DataVersion"))
     this->version = nbt.at("DataVersion")->toInt();
@@ -169,21 +184,25 @@ void Chunk::load(const NBT &nbt) {
     for (int s = 0; s < numSections; s++) {
       const Tag * section = sections->at(s);
       int idx = section->at("Y")->toInt();
-      // only sections 0..15 contain block data
-      if ((idx >=0) && (idx <16)) {
-        ChunkSection *cs = new ChunkSection();
-        if (this->version >= 2836) {
-          // after "Cliffs & Caves" update (1.18)
-          loadSection2800(cs, section);
-        } else if (this->version >= 1519) {
-          // after "The Flattening" update (1.13)
-          loadSection1519(cs, section);
-        } else {
-          loadSection1343(cs, section);
-        }
 
-        this->sections[idx] = cs;
+      const Tag_Compound * tc = static_cast<const Tag_Compound *>(section);
+      if (tc->length() <= 1)
+        continue; // skip sections without data
+
+      ChunkSection *cs = new ChunkSection();
+      if (this->version >= 2836) {
+        // after "Cliffs & Caves" update (1.18)
+        loadSection2800(cs, section);
+      } else if (this->version >= 1519) {
+        // after "The Flattening" update (1.13)
+        loadSection1519(cs, section);
+      } else {
+        loadSection1343(cs, section);
       }
+
+      // todo: only if section contains usefull data, otherwise: delete cs
+      this->sections[idx] = cs;
+      this->lowest = std::min(this->lowest, idx*16);
     }
   }
 
@@ -497,7 +516,7 @@ ChunkSection::ChunkSection()
 const PaletteEntry & ChunkSection::getPaletteEntry(int x, int y, int z) const {
   int xoffset = (x & 0x0f);
   int yoffset = (y & 0x0f) << 8;
-  int zoffset = z << 4;
+  int zoffset = (z & 0x0f) << 4;
   return getPaletteEntry(xoffset + yoffset + zoffset);
 }
 
@@ -519,17 +538,17 @@ quint8 ChunkSection::getBiome(int x, int y, int z) const {
   int xoffset = x;
   int yoffset = (y & 0x0f) << 8;
   int zoffset = z << 4;
-  return getBlockLight(xoffset + yoffset + zoffset);
+  return getBiome(xoffset + yoffset + zoffset);
 }
 
 quint8 ChunkSection::getBiome(int offset, int y) const {
   int yoffset = (y & 0x0f) << 8;
-  return getBlockLight(offset + yoffset);
+  return getBiome(offset + yoffset);
 }
 
 inline
 quint8 ChunkSection::getBiome(int offset) const {
-  return blockLight[offset];
+  return biomes[offset];
 }
 
 //quint8 ChunkSection::getSkyLight(int x, int y, int z) {

--- a/chunk.cpp
+++ b/chunk.cpp
@@ -10,12 +10,14 @@ template<typename ValueT>
 inline void* safeMemCpy(void* dest, const std::vector<ValueT>& srcVec, size_t length)
 {
   const size_t src_data_size = (sizeof(ValueT) * srcVec.size());
-    if (length > src_data_size)
-    {
-      length = src_data_size; // this happens sometimes and I guess its then actually a bug in the load() implementation. But this way it at least doesn't crash randomly.
-    }
+  if (length > src_data_size) {
+    #if defined(DEBUG) || defined(_DEBUG) || defined(QT_DEBUG)
+      qWarning() << "Copy too much data!";
+    #endif
+    length = src_data_size; // this happens sometimes and I guess its then actually a bug in the load() implementation. But this way it at least doesn't crash randomly.
+  }
 
-    return memcpy(dest, &srcVec[0], length);
+  return memcpy(dest, &srcVec[0], length);
 }
 
 Chunk::Chunk()
@@ -29,11 +31,11 @@ Chunk::~Chunk() {
   if (loaded) {
     for (int i = 0; i < 16; i++)
       if (sections[i]) {
-        if (!(sections[i]->paletteIsShared) && (sections[i]->paletteLength > 0)) {
-          delete[] sections[i]->palette;
+        if (!(sections[i]->blockPaletteIsShared) && (sections[i]->blockPaletteLength > 0)) {
+          delete[] sections[i]->blockPalette;
         }
-        sections[i]->paletteLength = 0;
-        sections[i]->palette = NULL;
+        sections[i]->blockPaletteLength = 0;
+        sections[i]->blockPalette = NULL;
 
         delete sections[i];
         sections[i] = NULL;
@@ -42,12 +44,44 @@ Chunk::~Chunk() {
   }
 }
 
-
-int Chunk::get_biome(int x, int z) {
-  return get_biome(x, 64, z);
+void Chunk::findHighestBlock()
+{
+  for (int i = 15; i >= 0; i--) {
+    if (this->sections[i]) {
+      for (int j = 4095; j >= 0; j--) {
+        if (this->sections[i]->blocks[j]) {
+          highest = i * 16 + (j >> 8);
+          return;
+        }
+      }
+    }
+  }
 }
 
-int Chunk::get_biome(int x, int y, int z) {
+const Chunk::EntityMap &Chunk::getEntityMap() const {
+  return entities;
+}
+
+const ChunkSection *Chunk::getSectionByY(int y) const {
+  size_t section_idx = static_cast<size_t>(y) >> 4;
+  if (section_idx >= sections.size())
+    return nullptr;
+
+  return sections[section_idx];
+}
+
+uint Chunk::getBlockHID(int x, int y, int z) const {
+  const ChunkSection * const section = getSectionByY(y);
+  if (!section) {
+    return 0;
+  }
+
+  const PaletteEntry& pdata = section->getPaletteEntry(x, y, z);
+
+  return pdata.hid;
+}
+
+int Chunk::getBiomeID(int x, int y, int z) const {
   int offset;
 
   if (this->version >= 2203) {
@@ -61,20 +95,18 @@ int Chunk::get_biome(int x, int y, int z) {
     offset = x + 16*z;
   }
 
-  return get_biome(offset);
-}
-
-int Chunk::get_biome(int offset) {
-#if defined(DEBUG) || defined(_DEBUG) || defined(QT_DEBUG)
-  if ((offset < 0) || ((unsigned long long)(offset) > sizeof(this->biomes) / sizeof(int))) {
+  #if defined(DEBUG) || defined(_DEBUG) || defined(QT_DEBUG)
+  if ((offset < 0) || ((unsigned long long)(offset) > sizeof(this->biomes)/sizeof(this->biomes[0]))) {
     qWarning() << "Biome index out of range!";
     return 0;
   }
-#endif
+  #endif
   return this->biomes[offset];
 }
 
 
+//-------------------------------------------------------------------------------------------------
+// this is where we load NBT data and parse it
 
 void Chunk::load(const NBT &nbt) {
   renderedAt = -1;  // impossible.
@@ -89,24 +121,31 @@ void Chunk::load(const NBT &nbt) {
   chunkZ = level->at("zPos")->toInt();
 
   // load Biome data
-  // Partially-generated chunks may have an empty Biomes tag. Trying to extract
-  // the Biomes data will cause a crash.
+  // Partially-generated chunks may have an empty Biomes tag.
+  // Trying to extract the Biomes data in that case will cause a crash.
   if (level->has("Biomes") && level->at("Biomes") && level->at("Biomes")->length()) {
-    const Tag_Int_Array * biomes = dynamic_cast<const Tag_Int_Array*>(level->at("Biomes"));
-    if (biomes) {  // Biomes is a Tag_Int_Array
+    const Tag * biomesTag = level->at("Biomes");
+    if (typeid(*biomesTag) == typeid(Tag_Int_Array)) {
+      // Biomes is Tag_Int_Array
+      // -> format after "The Flattening"
       // raw copy Biome data
-      std::size_t len = std::min(sizeof(this->biomes), (sizeof(int)*biomes->length()));
-      safeMemCpy(this->biomes, biomes->toIntArray(), len);
-    } else {  // Biomes is not a Tag_Int_Array
-      const Tag_Byte_Array * biomes = dynamic_cast<const Tag_Byte_Array*>(level->at("Biomes"));
+      const Tag_Int_Array * biomeData = dynamic_cast<const Tag_Int_Array*>(level->at("Biomes"));
+      std::size_t len = std::min(sizeof(this->biomes), (sizeof(int)*biomeData->length()));
+      safeMemCpy(this->biomes, biomeData->toIntArray(), len);
+    } else if (typeid(*biomesTag) == typeid(Tag_Byte_Array)) {
+      // Biomes is Tag_Byte_Array
+      // -> old Biome format before "The Flattening"
+      const Tag_Byte_Array * biomeData = dynamic_cast<const Tag_Byte_Array*>(level->at("Biomes"));
       // convert quint8 to quint32
-      auto rawBiomes = biomes->toByteArray();
-      for (int i=0; i<256; i++) {
+      auto rawBiomes = biomeData->toByteArray();
+      int len = std::min(256, biomeData->length());
+      for (int i=0; i<len; i++) {
         this->biomes[i] = rawBiomes[i];
       }
     }
   } else {  // no Biome data present
-    for (int i=0; i<16*16*4; i++)
+    int len = sizeof(this->biomes) / sizeof(this->biomes[0]);
+    for (int i=0; i<len; i++)
       this->biomes[i] = -1;
   }
 
@@ -121,7 +160,11 @@ void Chunk::load(const NBT &nbt) {
       // only sections 0..15 contain block data
       if ((idx >=0) && (idx <16)) {
         ChunkSection *cs = new ChunkSection();
-        if (this->version >= 1519) {
+        if (this->version >= 2836) {
+          // after "Cliff & Caves" update (1.18)
+          loadSection2800(cs, section);
+        } else if (this->version >= 1519) {
+          // after "The Flattening" update (1.13)
           loadSection1519(cs, section);
         } else {
           loadSection1343(cs, section);
@@ -161,6 +204,7 @@ void Chunk::load(const NBT &nbt) {
   loaded = true; // needs to be at the end!
 }
 
+
 void Chunk::loadEntities(const NBT &nbt) {
   // parse Entities in extra folder (1.17+)
   if (version >= 2681) {
@@ -176,42 +220,6 @@ void Chunk::loadEntities(const NBT &nbt) {
   }
 }
 
-void Chunk::findHighestBlock()
-{
-  for (int i = 15; i >= 0; i--) {
-    if (this->sections[i]) {
-      for (int j = 4095; j >= 0; j--) {
-        if (this->sections[i]->blocks[j]) {
-          highest = i * 16 + (j >> 8);
-          return;
-        }
-      }
-    }
-  }
-}
-
-const Chunk::EntityMap &Chunk::getEntityMap() const {
-  return entities;
-}
-
-const ChunkSection *Chunk::getSectionByY(int y) const {
-  size_t section_idx = static_cast<size_t>(y) >> 4;
-  if (section_idx >= sections.size())
-    return nullptr;
-
-  return sections[section_idx];
-}
-
-uint Chunk::getBlockHid(int x, int y, int z) const {
-  const ChunkSection * const section = getSectionByY(y);
-  if (!section) {
-    return 0;
-  }
-
-  const PaletteEntry& pdata = section->getPaletteEntry(x, y, z);
-
-  return pdata.hid;
-}
 
 // supported DataVersions:
 //    0 = 1.8 and below
@@ -263,101 +271,29 @@ void Chunk::loadSection1343(ChunkSection *cs, const Tag *section) {
   }
 
   // link to Converter palette
-  cs->paletteLength = FlatteningConverter::Instance().paletteLength;
-  cs->palette = FlatteningConverter::Instance().getPalette();
-  cs->paletteIsShared = true;
+  cs->blockPaletteLength = FlatteningConverter::Instance().paletteLength;
+  cs->blockPalette = FlatteningConverter::Instance().getPalette();
+  cs->blockPaletteIsShared = true;
 }
+
 
 // Chunk format after "The Flattening" version 1519
 void Chunk::loadSection1519(ChunkSection *cs, const Tag *section) {
-  BlockIdentifier &bi = BlockIdentifier::Instance();
+
   // decode Palette to be able to map BlockStates
   if (section->has("Palette")) {
-    auto rawPalette = section->at("Palette");
-    cs->paletteLength = rawPalette->length();
-    cs->paletteIsShared = false;
-    cs->palette = new PaletteEntry[cs->paletteLength];
-    for (int j = 0; j < rawPalette->length(); j++) {
-      // get name and hash it to hid
-      cs->palette[j].name = rawPalette->at(j)->at("Name")->toString();
-      uint hid  = qHash(cs->palette[j].name);
-      // copy all other properties
-      if (rawPalette->at(j)->has("Properties"))
-      cs->palette[j].properties = rawPalette->at(j)->at("Properties")->getData().toMap();
-
-      // check vor variants
-      BlockInfo const & block = bi.getBlockInfo(hid);
-      if (block.hasVariants()) {
-      // test all available properties
-      for (auto key : cs->palette[j].properties.keys()) {
-        QString vname = cs->palette[j].name + ":" + key + ":" + cs->palette[j].properties[key].toString();
-        uint vhid = qHash(vname);
-        if (bi.hasBlockInfo(vhid))
-          hid = vhid; // use this vaiant instead
-        }
-      }
-      // store hash of found variant
-      cs->palette[j].hid  = hid;
-    }
-  } else {
-    // create a dummy palette
-    cs->palette = new PaletteEntry[1];
-    cs->palette[0].name = "minecraft:air";
-    cs->palette[0].hid  = 0;
-  }
+    loadSection_decodeBlockPalette(cs, section->at("Palette"));
+  } else loadSection_createDummyPalette(cs);  // create a dummy palette
 
   // map BlockStates to BlockData
   if (section->has("BlockStates")) {
-    auto blockStates = section->at("BlockStates")->toLongArray();
-    int blockStatesLength = section->at("BlockStates")->length();
-    int bsCnt  = 0;  // counter for 64bit words
-    int bitCnt = 0;  // counter for bits
-
-    if (this->version < 2529) {
-      // compact BlockStates
-      for (int i = 0; i < 4096; i++) {
-        int bitSize = (blockStatesLength)*64/4096;
-        int bitMask = (1 << bitSize)-1;
-        if (bitCnt+bitSize <= 64) {
-          // bits fit into current word
-          uint64_t blockState = blockStates[bsCnt];
-          cs->blocks[i] = (blockState >> bitCnt) & bitMask;
-          bitCnt += bitSize;
-          if (bitCnt == 64) {
-            bitCnt = 0;
-            bsCnt++;
-          }
-        } else {
-          // bits are spread accross two words
-          uint64_t blockState1 = blockStates[bsCnt++];
-          uint64_t blockState2 = blockStates[bsCnt];
-          uint32_t block = (blockState1 >> bitCnt) & bitMask;
-          bitCnt += bitSize;
-          bitCnt -= 64;
-          block += (blockState2 << (bitSize - bitCnt)) & bitMask;
-          cs->blocks[i] = block;
-        }
-      }
-    } else {
-      // "optimized for loading" BlockStates since 1.16.20w17a
-      int bitSize = std::max(4, int(ceil(log2(cs->paletteLength))));
-      int bitMask = (1 << bitSize)-1;
-      for (int i = 0; i < 4096; i++) {
-        uint64_t blockState = blockStates[bsCnt];
-        cs->blocks[i] = (blockState >> bitCnt) & bitMask;
-        bitCnt += bitSize;
-        if (bitCnt+bitSize > 64) {
-          bsCnt++;
-          bitCnt = 0;
-        }
-      }
-    }
+    loadSection_loadBlockStates(cs, section->at("BlockStates"));
   } else {
     // set everything to 0 (minecraft:air)
     memset(cs->blocks, 0, sizeof(cs->blocks));
   }
 
-    // copy Light data
+  // copy Light data
 //  if (section->has("SkyLight")) {
 //    safeMemCpy(cs->skyLight, section->at("SkyLight")->toByteArray(), 2048);
 //  }
@@ -369,31 +305,167 @@ void Chunk::loadSection1519(ChunkSection *cs, const Tag *section) {
 }
 
 
+// Chunk format after "Clifs & Cave version 2800
+void Chunk::loadSection2800(ChunkSection * cs, const Tag * section) {
+
+  // decode Palette to be able to map BlockStates
+  if (section->has("block_states") && section->at("block_states")->has("palette")) {
+    loadSection_decodeBlockPalette(cs, section->at("block_states")->at("palette"));
+  } else loadSection_createDummyPalette(cs);
+
+  // map BlockStates to BlockData
+  if (section->has("block_states") && section->at("block_states")->has("data")) {
+    loadSection_loadBlockStates(cs, section->at("block_states")->at("data"));
+  } else {
+    // set everything to 0 (minecraft:air)
+    memset(cs->blocks, 0, sizeof(cs->blocks));
+  }
+
+  // copy Light data
+//  if (section->has("SkyLight")) {
+//    safeMemCpy(cs->skyLight, section->at("SkyLight")->toByteArray(), 2048);
+//  }
+  if (section->has("BlockLight")) {
+    safeMemCpy(cs->blockLight, section->at("BlockLight")->toByteArray(), 2048);
+  } else {
+    memset(cs->blockLight, 0, sizeof(cs->blockLight));
+  }
+}
+
+
+void Chunk::loadSection_decodeBlockPalette(ChunkSection * cs, const Tag * paletteTag) {
+  BlockIdentifier &bi = BlockIdentifier::Instance();
+
+  cs->blockPaletteLength = paletteTag->length();
+  cs->blockPaletteIsShared = false;
+  cs->blockPalette = new PaletteEntry[cs->blockPaletteLength];
+  for (int j = 0; j < paletteTag->length(); j++) {
+    // get name and hash it to hid
+    cs->blockPalette[j].name = paletteTag->at(j)->at("Name")->toString();
+    uint hid  = qHash(cs->blockPalette[j].name);
+    // copy all other properties
+    if (paletteTag->at(j)->has("Properties"))
+    cs->blockPalette[j].properties = paletteTag->at(j)->at("Properties")->getData().toMap();
+
+    // check vor variants
+    BlockInfo const & block = bi.getBlockInfo(hid);
+    if (block.hasVariants()) {
+    // test all available properties
+    for (auto key : cs->blockPalette[j].properties.keys()) {
+      QString vname = cs->blockPalette[j].name + ":" + key + ":" + cs->blockPalette[j].properties[key].toString();
+      uint vhid = qHash(vname);
+      if (bi.hasBlockInfo(vhid))
+        hid = vhid; // use this vaiant instead
+      }
+    }
+    // store hash of found variant
+    cs->blockPalette[j].hid  = hid;
+  }
+}
+
+
+void Chunk::loadSection_createDummyPalette(ChunkSection *cs) {
+  // create a dummy palette
+  cs->blockPalette = new PaletteEntry[1];
+  cs->blockPalette[0].name = "minecraft:air";
+  cs->blockPalette[0].hid  = 0;
+}
+
+
+void Chunk::loadSection_loadBlockStates(ChunkSection *cs, const Tag * blockStateTag) {
+
+  auto blockStates = blockStateTag->toLongArray();
+  int bsCnt  = 0;  // counter for 64bit words
+  int bitCnt = 0;  // counter for bits
+
+  if (this->version < 2529) {
+    // "compact BlockStates" just the first time after "The Flattening"
+    for (int i = 0; i < 4096; i++) {
+      int bitSize = (blockStateTag->length())*64/4096;
+      int bitMask = (1 << bitSize)-1;
+      if (bitCnt+bitSize <= 64) {
+        // bits fit into current word
+        uint64_t blockState = blockStates[bsCnt];
+        cs->blocks[i] = (blockState >> bitCnt) & bitMask;
+        bitCnt += bitSize;
+        if (bitCnt == 64) {
+          bitCnt = 0;
+          bsCnt++;
+        }
+      } else {
+        // bits are spread accross two words
+        uint64_t blockState1 = blockStates[bsCnt++];
+        uint64_t blockState2 = blockStates[bsCnt];
+        uint32_t block = (blockState1 >> bitCnt) & bitMask;
+        bitCnt += bitSize;
+        bitCnt -= 64;
+        block += (blockState2 << (bitSize - bitCnt)) & bitMask;
+        cs->blocks[i] = block;
+      }
+    }
+  } else {
+    // "optimized for loading" BlockStates since 1.16.20w17a
+    int bitSize = std::max(4, int(ceil(log2(cs->blockPaletteLength))));
+    int bitMask = (1 << bitSize)-1;
+    for (int i = 0; i < 4096; i++) {
+      uint64_t blockState = blockStates[bsCnt];
+      cs->blocks[i] = (blockState >> bitCnt) & bitMask;
+      bitCnt += bitSize;
+      if (bitCnt+bitSize > 64) {
+        bsCnt++;
+        bitCnt = 0;
+      }
+    }
+  }
+
+}
+
+
+//-------------------------------------------------------------------------------------------------
 // ChunkSection
+
 ChunkSection::ChunkSection()
-  : palette(NULL)
-  , paletteLength(0)
-  , paletteIsShared(false)  // only the "old" converted format is using one shared palette
+  : blockPalette(NULL)
+  , blockPaletteLength(0)
+  , blockPaletteIsShared(false)  // only the "old" converted format is using one shared palette
 {}
 
 const PaletteEntry & ChunkSection::getPaletteEntry(int x, int y, int z) const {
   int xoffset = (x & 0x0f);
   int yoffset = (y & 0x0f) << 8;
   int zoffset = z << 4;
-  quint16 blockid = blocks[xoffset + yoffset + zoffset];
-  if (blockid < paletteLength)
-    return palette[blockid];
-  else
-    return palette[0];
+  return getPaletteEntry(xoffset + yoffset + zoffset);
 }
 
 const PaletteEntry & ChunkSection::getPaletteEntry(int offset, int y) const {
   int yoffset = (y & 0x0f) << 8;
-  quint16 blockid = blocks[offset + yoffset];
-  if (blockid < paletteLength)
-    return palette[blockid];
+  return getPaletteEntry(offset + yoffset);
+}
+
+inline
+const PaletteEntry & ChunkSection::getPaletteEntry(int offset) const {
+  quint16 blockid = blocks[offset];
+  if (blockid < blockPaletteLength)
+    return blockPalette[blockid];
   else
-    return palette[0];
+    return blockPalette[0];
+}
+
+quint8 ChunkSection::getBiome(int x, int y, int z) const {
+  int xoffset = x;
+  int yoffset = (y & 0x0f) << 8;
+  int zoffset = z << 4;
+  return getBlockLight(xoffset + yoffset + zoffset);
+}
+
+quint8 ChunkSection::getBiome(int offset, int y) const {
+  int yoffset = (y & 0x0f) << 8;
+  return getBlockLight(offset + yoffset);
+}
+
+inline
+quint8 ChunkSection::getBiome(int offset) const {
+  return blockLight[offset];
 }
 
 //quint8 ChunkSection::getSkyLight(int x, int y, int z) {
@@ -416,14 +488,17 @@ quint8 ChunkSection::getBlockLight(int x, int y, int z) const {
   int xoffset = x;
   int yoffset = (y & 0x0f) << 8;
   int zoffset = z << 4;
-  int value = blockLight[(xoffset + yoffset + zoffset) / 2];
-  if (x & 1) value >>= 4;
-  return value & 0x0f;
+  return getBlockLight(xoffset + yoffset + zoffset);
 }
 
 quint8 ChunkSection::getBlockLight(int offset, int y) const {
   int yoffset = (y & 0x0f) << 8;
-  int value = blockLight[(offset + yoffset) / 2];
+  return getBlockLight(offset + yoffset);
+}
+
+inline
+quint8 ChunkSection::getBlockLight(int offset) const {
+  int value = blockLight[offset / 2];
   if (offset & 1) value >>= 4;
   return value & 0x0f;
 }

--- a/chunk.cpp
+++ b/chunk.cpp
@@ -442,7 +442,9 @@ bool Chunk::loadSection2844(ChunkSection * cs, const Tag * section) {
   // decode Biomes-Palette to be able to map Biome
   if (section->has("biomes") && section->at("biomes")->has("palette")) {
     loadSection_decodeBiomePalette(cs, section->at("biomes"));
-  } else {;/*todo*/}
+  } else {
+    sectionContainsData = false;  // never observed in real live
+  }
 
   // copy Light data
 //  if (section->has("SkyLight")) {

--- a/chunk.h
+++ b/chunk.h
@@ -49,10 +49,13 @@ class Chunk : public QObject {
   void load(const NBT &nbt);
   void loadEntities(const NBT &nbt);
 
+  // public getters to read-only access internal data
   int getChunkX() const { return chunkX; }
   int getChunkZ() const { return chunkZ; }
+  const uchar * getImage() const { return image; }
 
   const ChunkSection* getSectionByY(int y) const;
+  const ChunkSection* getSectionByIdx(qint8 y) const;
 
   uint   getBlockHID(int x, int y, int z) const;
   qint32 getBiomeID(int x, int y, int z) const;
@@ -72,20 +75,20 @@ signals:
   int  chunkZ;
   int  version;
   int  highest;
+  int  lowest;
   int  renderedAt;
   int  renderedFlags;
   bool loaded;
   bool rendering;
 
-  std::array<ChunkSection*, 16> sections;
+  QMap<qint8, ChunkSection*> sections;
   qint32 biomes[16 * 16 * 4];
   uchar  image[16 * 16 * 4];  // cached render: RGBA for 16*16 Blocks
-  uchar  depth[16 * 16];
+  short  depth[16 * 16];      // cached depth map to create shadow
   EntityMap entities;
   friend class MapView;
   friend class ChunkRenderer;
   friend class ChunkCache;
-  friend class WorldSave;
 
 private:
   void findHighestBlock();

--- a/chunk.h
+++ b/chunk.h
@@ -34,7 +34,7 @@ class ChunkSection {
   bool       blockPaletteIsShared;
 
   quint16 blocks[16*16*16];       // index into blockPalette for each Block
-  quint8  biomes[16*16*4];        // key into BiomeIdentifer for each 4x4x4 volume of Blocks defining the Biome
+  quint8  biomes[4*4*4];          // key into BiomeIdentifer for each 4x4x4 volume of Blocks defining the Biome
 //quint8  skyLight[16*16*16/2];   // not needed in Minutor
   quint8  blockLight[16*16*16/2]; // light value for each Block
 };
@@ -92,7 +92,7 @@ private:
   void loadSection_decodeBlockPalette(ChunkSection * cs, const Tag * paletteTag);
   void loadSection_createDummyPalette(ChunkSection * cs);
   void loadSection_loadBlockStates(ChunkSection *cs, const Tag * blockStateTag);
-
+  bool loadSection_decodeBiomePalette(ChunkSection * cs, const Tag * biomesTag);
 };
 
 #endif  // CHUNK_H_

--- a/chunk.h
+++ b/chunk.h
@@ -67,9 +67,9 @@ signals:
   void structureFound(QSharedPointer<GeneratedStructure> structure);
 
  protected:
-  void loadSection1343(ChunkSection * cs, const Tag * section);
-  void loadSection1519(ChunkSection * cs, const Tag * section);
-  void loadSection2800(ChunkSection * cs, const Tag * section);
+  bool loadSection1343(ChunkSection * cs, const Tag * section);
+  bool loadSection1519(ChunkSection * cs, const Tag * section);
+  bool loadSection2844(ChunkSection * cs, const Tag * section);
 
   int  chunkX;
   int  chunkZ;
@@ -92,6 +92,8 @@ signals:
 
 private:
   void findHighestBlock();
+  void loadLevelTag(const Tag * levelTag);  // nested structure with Level tag (up to 1.17)
+  void loadCliffsCaves(const NBT &nbt);     // flat structure without Level tag (1.18+)
   void loadSection_decodeBlockPalette(ChunkSection * cs, const Tag * paletteTag);
   void loadSection_createDummyPalette(ChunkSection * cs);
   void loadSection_loadBlockStates(ChunkSection *cs, const Tag * blockStateTag);

--- a/chunkrenderer.cpp
+++ b/chunkrenderer.cpp
@@ -83,7 +83,7 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
 //        if (light > 15) light = 15;
 
         // get Biome
-        auto &biome = BiomeIdentifier::Instance().getBiome(chunk->get_biome(x,y,z));
+        auto &biome = BiomeIdentifier::Instance().getBiome(chunk->getBiomeID(x,y,z));
         // get current block color
         QColor blockcolor = block.colors[15];  // get the color from Block definition
         if (block.biomeWater()) {

--- a/chunkrenderer.cpp
+++ b/chunkrenderer.cpp
@@ -28,9 +28,14 @@ void ChunkRenderer::run() {
 }
 
 void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
+  // threshold for mob spawn detection
+  const int lightSpawnSave = (chunk->version >= 2800)? 1 : 8;
+
   int offset = 0;
   uchar *bits = chunk->image;
   short *depthbits = chunk->depth;
+
+  // render loop
   for (int z = 0; z < 16; z++) {  // n->s
     int lasty = -1;
     for (int x = 0; x < 16; x++, offset++) {  // e->w
@@ -137,7 +142,7 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
 
            // spawn check #1: on top of solid block
            if (block0.doesBlockHaveSolidTopSurface() &&
-               !block0.isBedrock() && light1 < 8 &&
+               !block0.isBedrock() && light1 < lightSpawnSave &&
                !block1.isBlockNormalCube() && block1.spawninside &&
                !block1.isLiquid() &&
                !block2.isBlockNormalCube() && block2.spawninside) {
@@ -148,7 +153,7 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
            // spawn check #2: current block is transparent,
            // but mob can spawn through (e.g. snow)
            if (blockB.doesBlockHaveSolidTopSurface() &&
-               !blockB.isBedrock() && light0 < 8 &&
+               !blockB.isBedrock() && light0 < lightSpawnSave &&
                !block0.isBlockNormalCube() && block0.spawninside &&
                !block0.isLiquid() &&
                !block1.isBlockNormalCube() && block1.spawninside) {

--- a/chunkrenderer.cpp
+++ b/chunkrenderer.cpp
@@ -83,7 +83,9 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
 //        if (light > 15) light = 15;
 
         // get Biome
-        auto &biome = BiomeIdentifier::Instance().getBiome(chunk->getBiomeID(x,y,z));
+        const BiomeInfo &biome = (chunk->version >=2800) ?
+            BiomeIdentifier::Instance().getBiome((quint8)chunk->getBiomeID(x,y,z)) :
+            BiomeIdentifier::Instance().getBiome((qint32)chunk->getBiomeID(x,y,z));
         // get current block color
         QColor blockcolor = block.colors[15];  // get the color from Block definition
         if (block.biomeWater()) {
@@ -165,7 +167,6 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
           colr = biome.colors[light].red();
           colg = biome.colors[light].green();
           colb = biome.colors[light].blue();
-          alpha = 0;
         }
 
         // combine current block to final color

--- a/definitionmanager.cpp
+++ b/definitionmanager.cpp
@@ -434,7 +434,8 @@ void DefinitionManager::loadDefinition(QString path) {
       d.type = Definition::Block;
     } else if (type == "biome") {
       d.id = biomeManager.addDefinitions(
-          dynamic_cast<JSONArray*>(def->at("data")));
+            dynamic_cast<JSONArray*>(def->at("data")),
+            dynamic_cast<JSONArray*>(def->at("data18")));
       d.type = Definition::Biome;
     } else if (type == "dimension") {
       d.id = dimensionManager.addDefinitions(
@@ -488,7 +489,8 @@ void DefinitionManager::loadDefinition(QString path) {
               dynamic_cast<JSONArray*>(def->at("data")), d.blockid);
       } else if (type == "biome") {
         d.biomeid = biomeManager.addDefinitions(
-            dynamic_cast<JSONArray*>(def->at("data")), d.biomeid);
+              dynamic_cast<JSONArray*>(def->at("data")),
+              dynamic_cast<JSONArray*>(def->at("data18")), d.biomeid);
       } else if (type == "dimension") {
         d.dimensionid = dimensionManager.addDefinitions(
             dynamic_cast<JSONArray*>(def->at("data")), d.dimensionid);

--- a/definitions/vanilla_biomes.json
+++ b/definitions/vanilla_biomes.json
@@ -258,7 +258,7 @@
       "humidity": 0.6
     },
     {
-      "id": "minecraft:old growth_spruce_taiga",
+      "id": "minecraft:old_growth_spruce_taiga",
       "color": "#818e79",
       "temperature": 0.25,
       "humidity": 0.8
@@ -306,13 +306,22 @@
       "humidity": 0.0
     },
     {
+      "id": "minecraft:meadow"
+    },
+    {
       "id": "minecraft:mountain_meadow"
+    },
+    {
+      "id": "minecraft:grove"
     },
     {
       "id": "minecraft:mountain_grove"
     },
     {
       "id": "minecraft:snowy_slopes"
+    },
+    {
+      "id": "minecraft:frozen_peaks"
     },
     {
       "id": "minecraft:lofty_peaks"
@@ -322,6 +331,9 @@
     },
     {
       "id": "minecraft:stony_peaks"
+    },
+    {
+      "id": "minecraft:jagged_peaks"
     },
     {
       "id": "minecraft:lush_caves"

--- a/definitions/vanilla_biomes.json
+++ b/definitions/vanilla_biomes.json
@@ -1,7 +1,335 @@
 {
   "name": "Vanilla",
   "type": "biome",
-  "version": "1.17",
+  "version": "1.18.21w40a",
+  "data18": [
+    {
+      "id": "minecraft:ocean",
+      "color": "#000070"
+    },
+    {
+      "id": "minecraft:plains",
+      "color": "#8db360",
+      "temperature": 0.8,
+      "humidity": 0.4
+    },
+    {
+      "id": "minecraft:desert",
+      "color": "#fa9418",
+      "temperature": 2.0,
+      "humidity": 0.0
+    },
+    {
+      "id": "minecraft:windswept_hills",
+      "color": "#606060",
+      "temperature": 0.2,
+      "humidity": 0.3
+    },
+    {
+      "id": "minecraft:forest",
+      "color": "#056621",
+      "temperature": 0.7,
+      "humidity": 0.8
+    },
+    {
+      "id": "minecraft:taiga",
+      "color": "#0b6659",
+      "temperature": 0.25,
+      "humidity": 0.8
+    },
+    {
+      "id": "minecraft:swamp",
+      "color": "#07f9b2",
+      "watermodifier": "#617b64",
+      "temperature": 0.8,
+      "humidity": 0.9
+    },
+    {
+      "id": "minecraft:river",
+      "color": "#0000ff"
+    },
+    {
+      "id": "minecraft:nether_wastes",
+      "color": "#ff0000",
+      "temperature": 2.0,
+      "humidity": 0.0
+    },
+    {
+      "id": "minecraft:the_end",
+      "color": "#8080ff"
+    },
+    {
+      "id": "minecraft:frozen_ocean",
+      "color": "#9090a0",
+      "watermodifier": "#3938c9",
+      "temperature": 0.0,
+      "humidity": 0.5
+    },
+    {
+      "id": "minecraft:frozen_river",
+      "color": "#a0a0ff",
+      "watermodifier": "#3938c9",
+      "temperature": 0.0,
+      "humidity": 0.5
+    },
+    {
+      "id": "minecraft:snowy_plains",
+      "color": "#ffffff",
+      "temperature": 0.0,
+      "humidity": 0.5
+    },
+    {
+      "id": "minecraft:mushroom_fields",
+      "color": "#ff00ff",
+      "temperature": 0.9,
+      "humidity": 1.0
+    },
+    {
+      "id": "minecraft:beach",
+      "color": "#fade55",
+      "temperature": 0.8,
+      "humidity": 0.4
+    },
+    {
+      "id": "minecraft:jungle",
+      "color": "#537b09",
+      "temperature": 0.95,
+      "humidity": 0.9
+    },
+    {
+      "id": "minecraft:sparse_jungle",
+      "color": "#628b17",
+      "temperature": 0.95,
+      "humidity": 0.8
+    },
+    {
+      "id": "minecraft:deep_ocean",
+      "color": "#000030"
+    },
+    {
+      "id": "minecraft:stony_shore",
+      "color": "#a2a284",
+      "temperature": 0.2,
+      "humidity": 0.3
+    },
+    {
+      "id": "minecraft:snowy_beach",
+      "color": "#faf0c0",
+      "temperature": 0.05,
+      "humidity": 0.3
+    },
+    {
+      "id": "minecraft:birch_forest",
+      "color": "#307444",
+      "temperature": 0.6,
+      "humidity": 0.6
+    },
+    {
+      "id": "minecraft:dark_forest",
+      "color": "#40511a",
+      "temperature": 0.7,
+      "humidity": 0.8
+    },
+    {
+      "id": "minecraft:snowy_taiga",
+      "color": "#31554a",
+      "temperature": -0.5,
+      "humidity": 0.4
+    },
+    {
+      "id": "minecraft:old_growth_pine_taiga",
+      "color": "#596651",
+      "temperature": 0.3,
+      "humidity": 0.8
+    },
+    {
+      "id": "minecraft:windswept_forest",
+      "color": "#507050",
+      "temperature": 0.2,
+      "humidity": 0.3
+    },
+    {
+      "id": "minecraft:savanna",
+      "color": "#bdb25f",
+      "temperature": 1.2,
+      "humidity": 0.0
+    },
+    {
+      "id": "minecraft:savanna_plateau",
+      "color": "#a79d64",
+      "temperature": 1.0,
+      "humidity": 0.0
+    },
+    {
+      "id": "minecraft:badlands",
+      "color": "#d94515",
+      "temperature": 2.0,
+      "humidity": 0.0
+    },
+    {
+      "id": "minecraft:wooded_badlands",
+      "color": "#b09765",
+      "temperature": 2.0,
+      "humidity": 0.0
+    },
+    {
+      "id": "minecraft:small_end_islands",
+      "color": "#8080ff"
+    },
+    {
+      "id": "minecraft:end_midlands",
+      "color": "#8080ff"
+    },
+    {
+      "id": "minecraft:end_highlands",
+      "color": "#8080ff"
+    },
+    {
+      "id": "minecraft:end_barrens",
+      "color": "#8080ff"
+    },
+    {
+      "id": "minecraft:warm_ocean",
+      "color": "#0000ac",
+      "watermodifier": "#43d5ee"
+    },
+    {
+      "id": "minecraft:lukewarm_ocean",
+      "color": "#000090",
+      "watermodifier": "#45adf2"
+    },
+    {
+      "id": "minecraft:cold_ocean",
+      "color": "#202070",
+      "watermodifier": "#3d57d6"
+    },
+    {
+      "id": "minecraft:deep_warm_ocean",
+      "color": "#000050",
+      "watermodifier": "#43d5ee"
+    },
+    {
+      "id": "minecraft:deep_lukewarm_ocean",
+      "color": "#000040",
+      "watermodifier": "#45adf2"
+    },
+    {
+      "id": "minecraft:deep_cold_ocean",
+      "color": "#202038",
+      "watermodifier": "#3d57d6"
+    },
+    {
+      "id": "minecraft:deep_frozen_ocean",
+      "color": "#404090",
+      "watermodifier": "#3938c9"
+    },
+    {
+      "id": "minecraft:the_void",
+      "color": "#282898"
+    },
+    {
+      "id": "minecraft:sunflower_plains",
+      "color": "#b5db88",
+      "temperature": 0.8,
+      "humidity": 0.4
+    },
+    {
+      "id": "minecraft:windswept_gravelly_hills",
+      "color": "#888888",
+      "temperature": 0.2,
+      "humidity": 0.3
+    },
+    {
+      "id": "minecraft:flower_forest",
+      "color": "#2d8e49",
+      "temperature": 0.7,
+      "humidity": 0.8
+    },
+    {
+      "id": "minecraft:ice_spikes",
+      "color": "#b4dcdc",
+      "temperature": 0.0,
+      "humidity": 0.5
+    },
+    {
+      "id": "minecraft:old_growth_birch_forest",
+      "color": "#589c6c",
+      "temperature": 0.6,
+      "humidity": 0.6
+    },
+    {
+      "id": "minecraft:old growth_spruce_taiga",
+      "color": "#818e79",
+      "temperature": 0.25,
+      "humidity": 0.8
+    },
+    {
+      "id": "minecraft:windswept_savanna",
+      "color": "#e5da87",
+      "temperature": 1.1,
+      "humidity": 0.0
+    },
+    {
+      "id": "minecraft:eroded_badlands",
+      "color": "#ff6d3d",
+      "temperature": 2.0,
+      "humidity": 0.0
+    },
+    {
+      "id": "minecraft:bamboo_jungle",
+      "color": "#768e14",
+      "temperature": 0.95,
+      "humidity": 0.9
+    },
+    {
+      "id": "minecraft:soul_sand_valley",
+      "color": "#522921",
+      "temperature": 2.0,
+      "humidity": 0.0
+    },
+    {
+      "id": "minecraft:crimson_forest",
+      "color": "#dd0808",
+      "temperature": 2.0,
+      "humidity": 0.0
+    },
+    {
+      "id": "minecraft:warped_forest",
+      "color": "#49907b",
+      "temperature": 2.0,
+      "humidity": 0.0
+    },
+    {
+      "id": "minecraft:basalt_deltas",
+      "color": "#403636",
+      "temperature": 2.0,
+      "humidity": 0.0
+    },
+    {
+      "id": "minecraft:mountain_meadow"
+    },
+    {
+      "id": "minecraft:mountain_grove"
+    },
+    {
+      "id": "minecraft:snowy_slopes"
+    },
+    {
+      "id": "minecraft:lofty_peaks"
+    },
+    {
+      "id": "minecraft:snow_capped_peaks"
+    },
+    {
+      "id": "minecraft:stony_peaks"
+    },
+    {
+      "id": "minecraft:lush_caves"
+    },
+    {
+      "id": "minecraft:dripstone_caves"
+    }
+  ],
   "data": [
     {
       "id": 0,

--- a/definitions/vanilla_dims.json
+++ b/definitions/vanilla_dims.json
@@ -9,7 +9,7 @@
       "path": ".",
       "minY": -64,
       "maxY": 319,
-      "defaultY": 192,
+      "defaultY": 191,
       "scale": 1
     },
     {
@@ -18,7 +18,7 @@
       "path": "DIM-1",
       "minY": -64,
       "maxY": 319,
-      "defaultY": 100,
+      "defaultY": 95,
       "scale": 8
     },
     {

--- a/definitions/vanilla_dims.json
+++ b/definitions/vanilla_dims.json
@@ -1,21 +1,33 @@
 {
   "name": "Vanilla",
   "type": "dimension",
-  "version": "1.6.2",
+  "version": "1.18.0",
   "data": [
     {
       "name": "Overworld",
+      "id": "minecraft:overworld",
       "path": ".",
+      "minY": -64,
+      "maxY": 319,
+      "defaultY": 192,
       "scale": 1
     },
     {
-      "name": "Nether",
+      "name": "The Nether",
+      "id": "minecraft:the_nether",
       "path": "DIM-1",
+      "minY": -64,
+      "maxY": 319,
+      "defaultY": 100,
       "scale": 8
     },
     {
-      "name": "End",
+      "name": "The End",
+      "id": "minecraft:the_end",
       "path": "DIM1",
+      "minY": -64,
+      "maxY": 319,
+      "defaultY": 255,
       "scale": 0
     }
   ],

--- a/dimensionidentifier.h
+++ b/dimensionidentifier.h
@@ -14,14 +14,19 @@ class JSONArray;
 
 class DimensionInfo {
  public:
-  DimensionInfo(QString path, int scale, QString name) : path(path),
-    scale(scale), name(name) {}
-  QString path;
-  int scale;
+  DimensionInfo();
+
+  QString id;
   QString name;
+  QString path;
+  bool pathIsRegEx;
+  bool enabled;
+  int  scale;
+  int  minY;
+  int  maxY;
+  int  defaultY;
 };
 
-class DimensionDef;
 
 class DimensionIdentifier : public QObject {
   Q_OBJECT
@@ -30,17 +35,19 @@ class DimensionIdentifier : public QObject {
   // singleton: access to global usable instance
   static DimensionIdentifier &Instance();
 
-  int addDefinitions(JSONArray *, int pack = -1);
+  // definition parsing
+  int  addDefinitions(JSONArray *, int pack = -1);
   void enableDefinitions(int id);
   void disableDefinitions(int id);
-  void getDimensions(QDir path, QMenu *menu, QObject *parent);
-  void removeDimensions(QMenu *menu);
+  // Dimesnion view menu
+  void clearDimensionsMenu(QMenu *menu);
+  void getDimensionsInWorld(QDir path, QMenu *menu, QObject *parent);
 
  signals:
-  void dimensionChanged(const DimensionInfo &dim);
+  void dimensionChanged(const DimensionInfo &dim);    // dimension changed in menu
 
  private slots:
-  void viewDimension();
+  void changeViewToDimension();                       // dimension changed in menu
 
  private:
   // singleton: prevent access to constructor and copyconstructor
@@ -49,15 +56,15 @@ class DimensionIdentifier : public QObject {
   DimensionIdentifier(const DimensionIdentifier &);
   DimensionIdentifier &operator=(const DimensionIdentifier &);
 
-  void addDimension(QDir path, QString dir, QString name, int scale,
-                    QObject *parent);
-  QList<QAction *> items;
-  QList<DimensionInfo> dimensions;
-  QList<DimensionDef*> definitions;
-  QList<QList<DimensionDef*> > packs;
-  QActionGroup *group;
+  void addDimensionMenu(QDir path, QString dir, QString name, QObject *parent);
 
-  QHash<QString, bool> foundDimensions;
+  // GUI menu
+  QList<QAction *> currentMenuActions;
+  QActionGroup *   menuActionGroup;
+  QList<QString>   foundDimensionDirs;  // all directories where we already found a Dimension
+  // dimension storage
+  QList<DimensionInfo*>         definitions;  // definition of possible Dimensions
+  QList<QList<DimensionInfo*> > packs;
 };
 
 #endif  // DIMENSIONIDENTIFIER_H_

--- a/generatedstructure.cpp
+++ b/generatedstructure.cpp
@@ -22,15 +22,18 @@ GeneratedStructure::tryParseDatFile(const Tag* data) {
   return ret;
 }
 
-// parse structures in Chunks
+// parse structures stored in Chunks
 QList<QSharedPointer<GeneratedStructure>>
-GeneratedStructure::tryParseChunk(const Tag* data) {
+GeneratedStructure::tryParseChunk(const Tag* structuresTag) {
   // we will return a list of all found structures
   QList<QSharedPointer<GeneratedStructure>> ret;
 
-  // parse NBT data for "Starts"
-  if (data && data != &NBT::Null) {
-    auto features = data->at("Starts");
+  // parse NBT data for "Starts" & "starts"
+  if (structuresTag && structuresTag != &NBT::Null) {
+    QString starts("Starts");
+    if (!structuresTag->has(starts))
+      starts = "starts";
+    auto features = structuresTag->at(starts);
     if (features && features != &NBT::Null) {
       // convert the features to a qvariant here
       QVariant maybeFeatureMap = features->getData();

--- a/labelledslider.cpp
+++ b/labelledslider.cpp
@@ -6,6 +6,8 @@ LabelledSlider::LabelledSlider(Qt::Orientation orientation, QWidget *parent) :
   QWidget(parent) {
   slider = new MSlider(orientation);
   slider->setRange(0, 255);
+  slider->setTickInterval(64);
+  slider->setTickPosition(QSlider::TicksBelow);
 
   label = new QLabel();
   label->setAlignment(Qt::AlignCenter | Qt::AlignVCenter);
@@ -41,6 +43,12 @@ void LabelledSlider::setValue(int v) {
 // public slot
 void LabelledSlider::changeValue(int v) {
   slider->setValue(slider->value() + v);
+}
+
+// public slot
+void LabelledSlider::setRange(int minVal, int maxVal)
+{
+  slider->setRange(minVal, maxVal);
 }
 
 // private slot

--- a/labelledslider.h
+++ b/labelledslider.h
@@ -30,8 +30,9 @@ class LabelledSlider : public QWidget {
   void valueChanged(int val);
 
  public slots:
-  void setValue(int val);  // set absolute
-  void changeValue(int val);  // change relative
+  void setValue(int val);                 // set absolute value
+  void changeValue(int val);              // change value relative to current
+  void setRange(int minVal, int maxVal);  // set slider range
 
  private slots:
   void intValueChange(int val);

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -495,7 +495,7 @@ void MapView::getToolTip(int x, int z) {
   QString blockstate;
   QMap<QString, int> entityIds;
 
-  if (chunk) {
+  if ((chunk) && (chunk->highest >= chunk->lowest)) {
     int top = std::min(depth, chunk->highest);
     for (y = top; y >= chunk->lowest; y--) {
       const ChunkSection *section = chunk->getSectionByY(y);

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -539,8 +539,8 @@ void MapView::getToolTip(int x, int z) {
       blockstate.chop(1);
       break;
     }
-    int biome_code = chunk->get_biome((x & 0xf), y, (z & 0xf));
-    auto &bi = BiomeIdentifier::Instance().getBiome(biome_code);
+    int biomeID = chunk->getBiomeID((x & 0xf), y, (z & 0xf));
+    auto &bi = BiomeIdentifier::Instance().getBiome(biomeID);
     biome = bi.name;
 
     // count Entity of each display type

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -330,9 +330,9 @@ void Minutor::viewDimension(const DimensionInfo &dim) {
     // legacy versions before Cliffs & Caves (up to 1.17)
     depth->setRange(0, 255);
     if (dim.id == "minecraft:overworld") {
-      depth->setValue(128);   // cloud level
+      depth->setValue(127);   // cloud level
     } else if (dim.id == "minecraft:the_nether") {
-      depth->setValue(96);    // somewhere below Nether ceiling
+      depth->setValue(95);    // somewhere below Nether ceiling
     } else {
       depth->setValue(255);   // top
     }

--- a/minutor.h
+++ b/minutor.h
@@ -138,6 +138,7 @@ signals:
   Settings *settings;
   JumpTo *jumpTo;
   QDir currentWorld;
+  int  currentWorldVersion;
   QNetworkAccessManager qnam;
 
   QSet<QString> overlayItemTypes;

--- a/searchblockpluginwidget.cpp
+++ b/searchblockpluginwidget.cpp
@@ -90,7 +90,7 @@ SearchPluginI::ResultListT SearchBlockPluginWidget::searchChunk(Chunk &chunk)
     {
       for (int x = 0; x < 16; x++)
       {
-        const uint blockHid = chunk.getBlockHid(x,y,z);
+        const uint blockHid = chunk.getBlockHID(x,y,z);
         const auto it = m_searchForIds.find(blockHid);
         if (it != m_searchForIds.end())
         {

--- a/worldsave.cpp
+++ b/worldsave.cpp
@@ -268,14 +268,14 @@ void WorldSave::blankChunk(uchar *scanlines, int stride, int x) {
 void WorldSave::drawChunk(uchar *scanlines, int stride, int x, QSharedPointer<Chunk> chunk) {
   // calculate attenuation
   float attenuation = 1.0f;
-  if (this->regionChecker && static_cast<int>(floor(chunk->chunkX / 32.0f) +
-                                              floor(chunk->chunkZ / 32.0f)) % 2 != 0)
+  if (this->regionChecker && static_cast<int>(floor(chunk->getChunkX() / 32.0f) +
+                                              floor(chunk->getChunkZ() / 32.0f)) % 2 != 0)
     attenuation *= 0.9f;
-  if (this->chunkChecker && ((chunk->chunkX + chunk->chunkZ) % 2) != 0)
+  if (this->chunkChecker && ((chunk->getChunkX() + chunk->getChunkZ()) % 2) != 0)
     attenuation *= 0.9f;
 
   // render chunk with current settings
-  ChunkRenderer renderer(chunk->chunkX, chunk->chunkZ, map->getDepth(), map->getFlags());
+  ChunkRenderer renderer(chunk->getChunkX(), chunk->getChunkZ(), map->getDepth(), map->getFlags());
   renderer.renderChunk(chunk);
   // we can't memcpy each scanline because it's in BGRA format.
   int offset = x * 16 * 4 + 1;
@@ -283,10 +283,10 @@ void WorldSave::drawChunk(uchar *scanlines, int stride, int x, QSharedPointer<Ch
   for (int y = 0; y < 16; y++, offset += stride) {
     int xofs = offset;
     for (int x = 0; x < 16; x++, xofs += 4) {
-      scanlines[xofs+2] = attenuation * chunk->image[ioffset++];
-      scanlines[xofs+1] = attenuation * chunk->image[ioffset++];
-      scanlines[xofs+0] = attenuation * chunk->image[ioffset++];
-      scanlines[xofs+3] = attenuation * chunk->image[ioffset++];
+      scanlines[xofs+2] = attenuation * chunk->getImage()[ioffset++];
+      scanlines[xofs+1] = attenuation * chunk->getImage()[ioffset++];
+      scanlines[xofs+0] = attenuation * chunk->getImage()[ioffset++];
+      scanlines[xofs+3] = attenuation * chunk->getImage()[ioffset++];
     }
   }
 }


### PR DESCRIPTION
This is the new code to load and parse the Cliffs & Caves NBT data structures and solves most of the #255 topics.

+ Chunk data is parsed also in new locations (no Level Tag anymore, renamed tags)
+ Biomes are also parsed when stored as palette
+ Sections can be in (Block) range -4096 .. +4095 (like for custom dimensions)
+ depth slider is set automatically based on Dimension and version of world
+ depth slider default value can be set via definition files per Dimension (e.g. in The Nether below the ceiling)

+ bug fix: save to PNG crashed at empty region files (1.17 problem)