### PR TITLE
fix compare of definition file versions

### DIFF
--- a/definitionmanager.cpp
+++ b/definitionmanager.cpp
@@ -273,7 +273,7 @@ void DefinitionManager::installJson(QString path, bool overwrite,
     }
     QString fileversion = def->at("version")->asString();
 
-    if (exeversion.compare(fileversion, Qt::CaseInsensitive) > 0) {
+    if (DefinitionUpdater::versionCompare(exeversion, fileversion) > 0) {
       // force overwriting outdated local copy
       QFile::remove(dest);
       QFile::copy(path, dest);

--- a/definitionupdater.cpp
+++ b/definitionupdater.cpp
@@ -83,6 +83,7 @@ void DefinitionUpdater::finishUpdate() {
   emit updated(this, filename, version);
 }
 
+// static
 int DefinitionUpdater::versionCompare(QString const &version1, QString const &version2)
 {
   // split in major and minor version sections

--- a/definitionupdater.h
+++ b/definitionupdater.h
@@ -15,6 +15,7 @@ class DefinitionUpdater : public QObject {
  public:
   DefinitionUpdater(QString filename, QString url, QString version);
   void update();
+  static int versionCompare( QString const &version1, QString const &version2 );
  signals:
   void updated(DefinitionUpdater *, QString filename, QString version);
  private slots:
@@ -23,7 +24,6 @@ class DefinitionUpdater : public QObject {
   void finishUpdate();
  private:
   QString parseVersion(const QByteArray & data);
-  int versionCompare( QString const &version1, QString const &version2 );
   QString filename;
   QUrl url;
   QString version;


### PR DESCRIPTION
Previously we used QString::compare() but that fails e.g. 1.6.2 looks "newer" than 1.18.0 as this function compares character by character.
Correct solution is to use our own versionCompare() function (and is already available).