### PR TITLE
Show spawners as overlay

### DIFF
--- a/chunk.cpp
+++ b/chunk.cpp
@@ -226,6 +226,15 @@ void Chunk::loadLevelTag(const Tag * level) {
     }
   }
 
+  // parse Spawners in this Chunk
+  if (level->has("TileEntities")) {
+    auto nbtListBE = level->at("TileEntities");
+    auto spawnerlist = GeneratedStructure::tryParseBlockEntites(nbtListBE);
+    for (auto it = spawnerlist.begin(); it != spawnerlist.end(); ++it) {
+      emit structureFound(*it);
+    }
+  }
+
   // parse Structures that start in this Chunk
   if (version >= 1519) {
     if (level->has("Structures")) {
@@ -290,6 +299,15 @@ void Chunk::loadCliffsCaves(const NBT &nbt) {
       } else {  // otherwise: delete cs
         delete cs;
       }
+    }
+  }
+
+  // parse Spawners in this Chunk
+  if (nbt.has("block_entities")) {
+    auto nbtListBE = nbt.at("block_entities");
+    auto spawnerlist = GeneratedStructure::tryParseBlockEntites(nbtListBE);
+    for (auto it = spawnerlist.begin(); it != spawnerlist.end(); ++it) {
+      emit structureFound(*it);
     }
   }
 

--- a/chunk.cpp
+++ b/chunk.cpp
@@ -226,11 +226,11 @@ void Chunk::loadLevelTag(const Tag * level) {
     }
   }
 
-  // parse Spawners in this Chunk
+  // parse Tile Entities in this Chunk
   if (level->has("TileEntities")) {
     auto nbtListBE = level->at("TileEntities");
-    auto spawnerlist = GeneratedStructure::tryParseBlockEntites(nbtListBE);
-    for (auto it = spawnerlist.begin(); it != spawnerlist.end(); ++it) {
+    auto belist    = GeneratedStructure::tryParseBlockEntites(nbtListBE);
+    for (auto it = belist.begin(); it != belist.end(); ++it) {
       emit structureFound(*it);
     }
   }
@@ -302,11 +302,11 @@ void Chunk::loadCliffsCaves(const NBT &nbt) {
     }
   }
 
-  // parse Spawners in this Chunk
+  // parse Block Entities in this Chunk
   if (nbt.has("block_entities")) {
     auto nbtListBE = nbt.at("block_entities");
-    auto spawnerlist = GeneratedStructure::tryParseBlockEntites(nbtListBE);
-    for (auto it = spawnerlist.begin(); it != spawnerlist.end(); ++it) {
+    auto belist    = GeneratedStructure::tryParseBlockEntites(nbtListBE);
+    for (auto it = belist.begin(); it != belist.end(); ++it) {
       emit structureFound(*it);
     }
   }

--- a/generatedstructure.cpp
+++ b/generatedstructure.cpp
@@ -63,13 +63,15 @@ GeneratedStructure::tryParseBlockEntites(const Tag* tagBlockEntites) {
         ret.append( GeneratedStructure::tryParseSpawner(be) );
       }
 
-      if (be->has("id") &&
-          ( (be->at("id")->toString() == "minecraft:chest") ||
+/*    if (be->has("id") &&
+          ( (be->at("id")->toString() == "minecraft:shulker_box") ||
+            (be->at("id")->toString() == "minecraft:chest") ||
             (be->at("id")->toString() == "Chest") ) ) {
-        // mob spawner found
+        // chest found
         // -> parse the chest data to a GeneratedStructure pointer
-        //ret.append( GeneratedStructure::tryParseChest(be) );
+        ret.append( GeneratedStructure::tryParseChest(be) );
       }
+*/
     }
   }
 
@@ -116,7 +118,6 @@ GeneratedStructure::tryParseSpawner(const Tag* tagSpawner) {
 
   // base the color on a hash of its type
   int    hue = qHash(QString("minecraft:spawner"), 0) % 360;
-  qInfo("Hue: %d", hue);
   QColor color;
   color.setHsv(hue, 255, 255, 64);
   spawner->setColor(color);

--- a/generatedstructure.cpp
+++ b/generatedstructure.cpp
@@ -43,6 +43,102 @@ GeneratedStructure::tryParseChunk(const Tag* structuresTag) {
   return ret;
 }
 
+// static
+QList<QSharedPointer<GeneratedStructure>>
+GeneratedStructure::tryParseBlockEntites(const Tag* tagBlockEntites) {
+  // we will return a list of all found block entities
+  QList<QSharedPointer<GeneratedStructure>> ret;
+
+  if (tagBlockEntites && tagBlockEntites != &NBT::Null) {
+
+    // loop over all block entities in Chunk (typically chests and spawners)
+    for (int idx = 0; idx < tagBlockEntites->length(); idx++) {
+      const Tag * be = tagBlockEntites->at(idx);
+
+      if (be->has("id") &&
+          ( (be->at("id")->toString() == "minecraft:mob_spawner") ||
+            (be->at("id")->toString() == "MobSpawner") ) ) {
+        // mob spawner found
+        // -> parse the spawner data to a GeneratedStructure pointer
+        ret.append( GeneratedStructure::tryParseSpawner(be) );
+      }
+
+      if (be->has("id") &&
+          ( (be->at("id")->toString() == "minecraft:chest") ||
+            (be->at("id")->toString() == "Chest") ) ) {
+        // mob spawner found
+        // -> parse the chest data to a GeneratedStructure pointer
+        //ret.append( GeneratedStructure::tryParseChest(be) );
+      }
+    }
+  }
+
+  return ret;
+}
+
+
+
+// static
+QSharedPointer<GeneratedStructure>
+GeneratedStructure::tryParseChest(const Tag* tagChest) {
+  return QSharedPointer<GeneratedStructure>();
+}
+
+// static
+QSharedPointer<GeneratedStructure>
+GeneratedStructure::tryParseSpawner(const Tag* tagSpawner) {
+  // we will return a list of all found structures
+  QSharedPointer<GeneratedStructure> spawner = QSharedPointer<GeneratedStructure>(new GeneratedStructure());
+
+  QString mobType = "minecraft:unknown_mob";
+  // before "The Flattening"
+  if (tagSpawner->has("EntityId")) {
+    mobType = tagSpawner->at("EntityId")->toString();
+    // reformat CamelCase text to flattening
+    // split at uppercase characters
+    QStringList tokens = mobType.split(QRegExp("(?<=[a-z])(?=[A-Z])"), QString::SkipEmptyParts);
+    mobType = tokens.join("_").toLower();
+  }
+  // after "The Flattening"
+  if (tagSpawner->has("SpawnData") && tagSpawner->at("SpawnData")->has("id")) {
+    mobType = tagSpawner->at("SpawnData")->at("id")->toString();
+  }
+  // after "Caves & Cliffs"
+  if (tagSpawner->has("SpawnData") && tagSpawner->at("SpawnData")->has("entity") &&
+      tagSpawner->at("SpawnData")->at("entity")->has("id")) {
+    mobType = tagSpawner->at("SpawnData")->at("entity")->at("id")->toString();
+  }
+  mobType.replace("minecraft:", "");
+
+  spawner->setType("Structure.minecraft:spawner");
+  spawner->setDisplay("minecraft:spawner:"+mobType);
+  spawner->setDimension("overworld");
+
+  // base the color on a hash of its type
+  int    hue = qHash(QString("minecraft:spawner"), 0) % 360;
+  qInfo("Hue: %d", hue);
+  QColor color;
+  color.setHsv(hue, 255, 255, 64);
+  spawner->setColor(color);
+
+  // fill properties
+  const Tag_Compound * tc = static_cast<const Tag_Compound *>(tagSpawner);
+  QMap<QString, QVariant> spawnerProperties = tc->getData().toMap();
+  spawner->setProperties(spawnerProperties);
+
+  // get covered area
+  int x = tagSpawner->at("x")->toInt();
+  int y = tagSpawner->at("y")->toInt();
+  int z = tagSpawner->at("z")->toInt();
+  int r = 4;
+  if (tagSpawner->has("SpawnRange"))
+    r = tagSpawner->at("SpawnRange")->toInt();
+  spawner->setBounds( Point(x-r, y, z-r), Point(x+r, y, z+r));
+
+  return spawner;
+}
+
+// static
 QList<QSharedPointer<GeneratedStructure>>
 GeneratedStructure::tryParseFeatures(QVariant &maybeFeatureMap) {
   // we will return a list of all found structures
@@ -71,13 +167,13 @@ GeneratedStructure::tryParseFeatures(QVariant &maybeFeatureMap) {
           structure->setProperties(featureProperties);
 
           // base the color on a hash of its type
-          int    hue = qHash(id) % 360;
+          int    hue = qHash(id, 0) % 360;
           QColor color;
           color.setHsv(hue, 255, 255, 64);
           structure->setColor(color);
 
           // this will have to be maintained if new structures are added
-          // that are appearing only a some Dimensions
+          // that are appearing only in some Dimensions
           if (structure->type() == "Structure.Fortress") {
             structure->setDimension("nether");
           } else if (structure->type() == "Structure.EndCity") {
@@ -140,6 +236,7 @@ GeneratedStructure::tryParseFeatures(QVariant &maybeFeatureMap) {
   }
   return ret;
 }
+
 
 bool GeneratedStructure::intersects(const OverlayItem::Cuboid& cuboid) const {
   return cuboid.min.x <= p2.x && p1.x <= cuboid.max.x &&

--- a/generatedstructure.h
+++ b/generatedstructure.h
@@ -13,7 +13,7 @@ class GeneratedStructure: public OverlayItem {
  public:
   static QList<QSharedPointer<GeneratedStructure>> tryParseDatFile(const Tag* tag);
   static QList<QSharedPointer<GeneratedStructure>> tryParseChunk(const Tag* tag);
-  static QList<QSharedPointer<GeneratedStructure>> tryParseFeatures(QVariant &maybeFeatureMap);
+  static QList<QSharedPointer<GeneratedStructure>> tryParseBlockEntites(const Tag* tagBlockEntities);
 
   virtual bool intersects(const Cuboid &cuboid) const;
   virtual void draw(double offsetX, double offsetZ, double scale,
@@ -23,10 +23,13 @@ class GeneratedStructure: public OverlayItem {
  protected:
   GeneratedStructure() {}
 
+  static QSharedPointer<GeneratedStructure> tryParseChest(const Tag* tagChest);
+  static QSharedPointer<GeneratedStructure> tryParseSpawner(const Tag* tagSpawner);
+  static QList<QSharedPointer<GeneratedStructure>> tryParseFeatures(QVariant &maybeFeatureMap);
+
   // these are used to draw a rounded rect. If you want to draw something
   // else, override draw()
   void setBounds(const Point& min, const Point& max) {p1 = min; p2 = max;}
-
   static const int RADIUS = 10;
 
  private:

--- a/properties.cpp
+++ b/properties.cpp
@@ -28,15 +28,31 @@ void Properties::DisplayProperties(QVariant p) {
 
   // only support QVariantMap or QVariantHash at this level
   switch ((QMetaType::Type)p.type()) {
-    case QMetaType::QVariantMap:
-      treeCreator.ParseIterable(ui->propertyView->invisibleRootItem(), p.toMap());
+    case QMetaType::QVariantMap: {
+      // we got a QMap with all properties stored as [key]->value
+      auto data = p.toMap();
+      treeCreator.ParseIterable(ui->propertyView->invisibleRootItem(), data);
+      this->setWindowTitle(data.value("id", "Properties").toString());
       break;
-    case QMetaType::QVariantHash:
-      treeCreator.ParseIterable(ui->propertyView->invisibleRootItem(), p.toHash());
+    }
+    case QMetaType::QVariantHash: {
+      // we got a QHashMap with all properties stored as [key]->value
+      auto data = p.toHash();
+      treeCreator.ParseIterable(ui->propertyView->invisibleRootItem(), data);
+      this->setWindowTitle(data.value("id", "Properties").toString());
       break;
-    case QMetaType::QVariantList:
-      treeCreator.ParseList(ui->propertyView->invisibleRootItem(), p.toList());
+    }
+    case QMetaType::QVariantList: {
+      // we got a QList with Properties of several objects
+      //  each element is a QMap with all properties stored as [key]->value
+      auto data = p.toList();
+      treeCreator.ParseList(ui->propertyView->invisibleRootItem(), data);
+      if (data.length()>0) {
+        // we take the Title from the first list element, ignoring all other
+        this->setWindowTitle(data[0].toMap().value("id", "Properties").toString());
+      }
       break;
+    }
     default:
       qWarning("Trying to display scalar value as a property");
       break;

--- a/properties.ui
+++ b/properties.ui
@@ -11,11 +11,15 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Properties Dialog</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLineEdit" name="lineEdit"/>
+    <widget class="QLineEdit" name="lineEdit">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QTreeWidget" name="propertyView">
@@ -25,11 +29,11 @@
      <attribute name="headerVisible">
       <bool>true</bool>
      </attribute>
-     <attribute name="headerDefaultSectionSize">
-      <number>150</number>
-     </attribute>
      <attribute name="headerMinimumSectionSize">
       <number>25</number>
+     </attribute>
+     <attribute name="headerDefaultSectionSize">
+      <number>150</number>
      </attribute>
      <column>
       <property name="text">


### PR DESCRIPTION
This changes show spawners in "dungeons" as normal structure overlays. (fixes #146)

From saved file perspective they do not belong to structures, but from user perspective they are also some pre-generated structure found in the world.

It would be possible to parse chests the same way, but some refactoring is necessary before these information can be handled in Minutor.

The properties dialog was also modified:
* set title based on object we show
* disabled the "not used" line edit on top (to be reactivated later)