### PR TITLE
fix Linux builds on many systems

### DIFF
--- a/chunk.cpp
+++ b/chunk.cpp
@@ -1,6 +1,7 @@
 /** Copyright (c) 2013, Sean Kasun */
 
 #include <algorithm>    // std::max
+#include <typeinfo>     // typeid
 
 #include "chunk.h"
 #include "identifier/flatteningconverter.h"

--- a/minutor.pro
+++ b/minutor.pro
@@ -23,37 +23,37 @@ HEADERS += \
     chunkcache.h \
     chunkloader.h \
     chunkrenderer.h \
-    identifier\biomeidentifier.h \
-    identifier\blockidentifier.h \
-    identifier\definitionmanager.h \
-    identifier\definitionupdater.h \
-    identifier\dimensionidentifier.h \
-    identifier\entityidentifier.h \
-    identifier\flatteningconverter.h \
+    identifier/biomeidentifier.h \
+    identifier/blockidentifier.h \
+    identifier/definitionmanager.h \
+    identifier/definitionupdater.h \
+    identifier/dimensionidentifier.h \
+    identifier/entityidentifier.h \
+    identifier/flatteningconverter.h \
     jumpto.h \
-    json\json.h \
+    json/json.h \
     mapview.h \
     minutor.h \
-    nbt\nbt.h \
-    nbt\tag.h \
-    nbt\tagdatastream.h \
-    overlay\entity.h \
-    overlay\generatedstructure.h \
-    overlay\overlayitem.h \
-    overlay\properties.h \
-    overlay\propertietreecreator.h \
-    overlay\village.h \
+    nbt/nbt.h \
+    nbt/tag.h \
+    nbt/tagdatastream.h \
+    overlay/entity.h \
+    overlay/generatedstructure.h \
+    overlay/overlayitem.h \
+    overlay/properties.h \
+    overlay/propertietreecreator.h \
+    overlay/village.h \
     paletteentry.h \
     pngexport.h \
-    search\entityevaluator.h \
-    search\range.h \
-    search\rectangleinnertoouteriterator.h \
-    search\searchblockpluginwidget.h \
-    search\searchchunkswidget.h \
-    search\searchentitypluginwidget.h \
-    search\searchplugininterface.h \
-    search\searchresultwidget.h \
-    search\searchtextwidget.h \
+    search/entityevaluator.h \
+    search/range.h \
+    search/rectangleinnertoouteriterator.h \
+    search/searchblockpluginwidget.h \
+    search/searchchunkswidget.h \
+    search/searchentitypluginwidget.h \
+    search/searchplugininterface.h \
+    search/searchresultwidget.h \
+    search/searchtextwidget.h \
     settings.h \
     worldsave.h \
     zipreader.h
@@ -64,33 +64,33 @@ SOURCES += \
     chunkcache.cpp \
     chunkloader.cpp \
     chunkrenderer.cpp \
-    identifier\biomeidentifier.cpp \
-    identifier\blockidentifier.cpp \
-    identifier\definitionmanager.cpp \
-    identifier\definitionupdater.cpp \
-    identifier\dimensionidentifier.cpp \
-    identifier\entityidentifier.cpp \
-    identifier\flatteningconverter.cpp \
+    identifier/biomeidentifier.cpp \
+    identifier/blockidentifier.cpp \
+    identifier/definitionmanager.cpp \
+    identifier/definitionupdater.cpp \
+    identifier/dimensionidentifier.cpp \
+    identifier/entityidentifier.cpp \
+    identifier/flatteningconverter.cpp \
     jumpto.cpp \
-    json\json.cpp \
+    json/json.cpp \
     main.cpp \
     mapview.cpp \
     minutor.cpp \
-    nbt\nbt.cpp \
-    nbt\tag.cpp \
-    nbt\tagdatastream.cpp \
-    overlay\entity.cpp \
-    overlay\generatedstructure.cpp \
-    overlay\properties.cpp \
-    overlay\propertietreecreator.cpp \
-    overlay\village.cpp \
+    nbt/nbt.cpp \
+    nbt/tag.cpp \
+    nbt/tagdatastream.cpp \
+    overlay/entity.cpp \
+    overlay/generatedstructure.cpp \
+    overlay/properties.cpp \
+    overlay/propertietreecreator.cpp \
+    overlay/village.cpp \
     pngexport.cpp \
-    search\entityevaluator.cpp \
-    search\searchblockpluginwidget.cpp \
-    search\searchchunkswidget.cpp \
-    search\searchentitypluginwidget.cpp \
-    search\searchresultwidget.cpp \
-    search\searchtextwidget.cpp \
+    search/entityevaluator.cpp \
+    search/searchblockpluginwidget.cpp \
+    search/searchchunkswidget.cpp \
+    search/searchentitypluginwidget.cpp \
+    search/searchresultwidget.cpp \
+    search/searchtextwidget.cpp \
     settings.cpp \
     worldsave.cpp \
     zipreader.cpp
@@ -141,8 +141,8 @@ FORMS += \
     minutor.ui \
     jumpto.ui \
     pngexport.ui \
-    overlay\properties.ui \
-    search\searchchunkswidget.ui \
-    search\searchresultwidget.ui \
-    search\searchtextwidget.ui \
+    overlay/properties.ui \
+    search/searchchunkswidget.ui \
+    search/searchresultwidget.ui \
+    search/searchtextwidget.ui \
     settings.ui


### PR DESCRIPTION
see commits messages for details

Ubuntu 16.04 build error
```
[   90s] g++ -c -m64 -pipe -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -std=c++1y -Wall -W -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CONCURRENT_LIB -DQT_CORE_LIB -I. -I../../../include/x86_64-linux-gnu/qt5 -I../../../include/x86_64-linux-gnu/qt5/QtWidgets -I../../../include/x86_64-linux-gnu/qt5/QtGui -I../../../include/x86_64-linux-gnu/qt5/QtNetwork -I../../../include/x86_64-linux-gnu/qt5/QtConcurrent -I../../../include/x86_64-linux-gnu/qt5/QtCore -I. -I. -I../../../lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++-64 -o chunk.o chunk.cpp
[   92s] chunk.cpp: In member function 'void Chunk::loadLevelTag(const Tag*)':
[   92s] chunk.cpp:170:17: error: must #include <typeinfo> before using typeid
[   92s]      if (typeid(*biomesTag) == typeid(Tag_Int_Array)) {
[   92s]                  ^
[   92s] chunk.cpp:170:51: error: must #include <typeinfo> before using typeid
[   92s]      if (typeid(*biomesTag) == typeid(Tag_Int_Array)) {
[   92s]                                                    ^
[   92s] chunk.cpp:177:24: error: must #include <typeinfo> before using typeid
[   92s]      } else if (typeid(*biomesTag) == typeid(Tag_Byte_Array)) {
[   92s]                         ^
[   92s] chunk.cpp:177:59: error: must #include <typeinfo> before using typeid
[   92s]      } else if (typeid(*biomesTag) == typeid(Tag_Byte_Array)) {
[   92s]                                                            ^
[   93s] Makefile:4103: recipe for target 'chunk.o' failed
[   93s] make[1]: *** [chunk.o] Error 1
```

Debian 11 (and others) build error (filename my vary, depending on generated targets order)
```
[  193s] make[1]: *** No rule to make target 'identifier\biomeidentifier.cpp', needed by 'biomeidentifier.o'.  Stop.
```