### PR TITLE
support other folder names for world saves

### DIFF
--- a/minutor.cpp
+++ b/minutor.cpp
@@ -561,8 +561,8 @@ QString Minutor::getWorldName(QDir path) {
 
 void Minutor::getWorldList() {
   QDir mc(dialogSettings->mcpath);
-  if (!mc.cd("saves"))
-    return;
+  if (mc.exists("saves"))
+    mc.cd("saves");
 
   QDirIterator it(mc);
   int key = 1;


### PR DESCRIPTION
At the moment we only support Minecraft worlds stored in a sub-folder called "saves".
This works well with standard installation of Minecraft.

But when worlds are collected at other locations (different folder name), it is not possible to open them directly.

This change should be save, as we only add worlds to the menu when we find the correct files.