### PR TITLE
mob spawn highlighting for water mobs

### DIFF
--- a/chunkrenderer.cpp
+++ b/chunkrenderer.cpp
@@ -161,8 +161,9 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
              colg = (colg + 0) / 2;
              colb = (colb + 256) / 2;
            }
-           // water spawn check for Drowned
-           if (((biome.isOceanBiome() && (y < 58)) || biome.isRiverBiome()) &&
+           // water spawn check for Drowned, introduced with "Update Aquatic" (1.13)
+           if ((chunk->version >= 1519) &&
+               ((biome.isOceanBiome() && (y < 58)) || biome.isRiverBiome()) &&
                (light0 < lightSpawnSave) &&
                block0.biomeWater() &&
                block1.biomeWater() ) {

--- a/chunkrenderer.cpp
+++ b/chunkrenderer.cpp
@@ -151,7 +151,7 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
              colb = (colb + 192) / 2;
            }
            // spawn check #2: current block is transparent,
-           // but mob can spawn through (e.g. snow)
+           // but mob can spawn through from block below (e.g. snow)
            if (blockB.doesBlockHaveSolidTopSurface() &&
                !blockB.isBedrock() && light0 < lightSpawnSave &&
                !block0.isBlockNormalCube() && block0.spawninside &&
@@ -161,7 +161,17 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
              colg = (colg + 0) / 2;
              colb = (colb + 256) / 2;
            }
+           // water spawn check for Drowned
+           if (((biome.isOceanBiome() && (y < 58)) || biome.isRiverBiome()) &&
+               (light0 < lightSpawnSave) &&
+               block0.biomeWater() &&
+               block1.biomeWater() ) {
+             colr = (colr + 256) / 2;
+             colg = (colg + 0) / 2;
+             colb = (colb + 128) / 2;
+           }
         }
+
         if (flags & MapView::flgBiomeColors) {
           colr = biome.colors[light].red();
           colg = biome.colors[light].green();

--- a/chunkrenderer.cpp
+++ b/chunkrenderer.cpp
@@ -162,7 +162,7 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
              colb = (colb + 256) / 2;
            }
            // water spawn check for Drowned, introduced with "Update Aquatic" (1.13)
-           if ((chunk->version >= 1519) &&
+           if ((chunk->version >= 1478) &&
                ((biome.isOceanBiome() && (y < 58)) || biome.isRiverBiome()) &&
                (light0 < lightSpawnSave) &&
                block0.biomeWater() &&

--- a/identifier/biomeidentifier.cpp
+++ b/identifier/biomeidentifier.cpp
@@ -274,6 +274,18 @@ void BiomeIdentifier::parseBiomeDefinitions0000(JSONArray *data, int pack) {
       if (b->has("name"))
         biome->name = b->at("name")->asString();
 
+      // define ocean / river Biome category by (optional) tag or guess from name
+      if (b->has("ocean")) {
+        biome->ocean = b->at("ocean")->asBool();
+      } else if (biome->name.contains("ocean", Qt::CaseInsensitive)) {
+        biome->ocean = true;
+      }
+      if (b->has("river")) {
+        biome->ocean = b->at("river")->asBool();
+      } else if (biome->name.contains("river", Qt::CaseInsensitive)) {
+        biome->river = true;
+      }
+
       // get temperature definition
       if (b->has("temperature"))
         biome->temperature = b->at("temperature")->asNumber();
@@ -349,12 +361,12 @@ void BiomeIdentifier::parseBiomeDefinitions2800(JSONArray *data18, int pack) {
       if (b->has("ocean")) {
         biome->ocean = b->at("ocean")->asBool();
       } else if (biome->name.contains("ocean", Qt::CaseInsensitive)) {
-          biome->ocean = true;
+        biome->ocean = true;
       }
       if (b->has("river")) {
         biome->ocean = b->at("river")->asBool();
       } else if (biome->name.contains("river", Qt::CaseInsensitive)) {
-          biome->river = true;
+        biome->river = true;
       }
 
       // get temperature definition

--- a/identifier/biomeidentifier.cpp
+++ b/identifier/biomeidentifier.cpp
@@ -22,6 +22,8 @@ BiomeInfo::BiomeInfo()
   , nid("")
   , name("Unknown Biome")
   , enabled(false)
+  , ocean(false)
+  , river(false)
   , temperature(0.5)
   , humidity(0.5)
   , enabledwatermodifier(false)
@@ -235,6 +237,7 @@ void BiomeIdentifier::enableDefinitions(int pack) {
     packs[pack][i]->enabled = true;
   updateBiomeDefinition();
 }
+
 void BiomeIdentifier::disableDefinitions(int pack) {
   if (pack < 0) return;
   int len = packs[pack].length();
@@ -340,6 +343,18 @@ void BiomeIdentifier::parseBiomeDefinitions2800(JSONArray *data18, int pack) {
         for (int i = 0; i < parts.size(); i++)
           parts[i].replace(0, 1, parts[i][0].toUpper());
         biome->name = parts.join(" ");
+      }
+
+      // define ocean / river Biome category by (optional) tag or guess from name
+      if (b->has("ocean")) {
+        biome->ocean = b->at("ocean")->asBool();
+      } else if (biome->name.contains("ocean", Qt::CaseInsensitive)) {
+          biome->ocean = true;
+      }
+      if (b->has("river")) {
+        biome->ocean = b->at("river")->asBool();
+      } else if (biome->name.contains("river", Qt::CaseInsensitive)) {
+          biome->river = true;
       }
 
       // get temperature definition

--- a/identifier/biomeidentifier.h
+++ b/identifier/biomeidentifier.h
@@ -17,12 +17,17 @@ class BiomeInfo {
   QColor getBiomeFoliageColor( QColor blockcolor, int elevation ) const;
   QColor getBiomeWaterColor( QColor watercolor ) const;
 
+  bool   isOceanBiome() const { return ocean; };
+  bool   isRiverBiome() const { return river; };
+
   // public members
  public:
   int     id;   // numerical ID
   QString nid;  // namespace ID
   QString name;
   bool    enabled;
+  bool    ocean;
+  bool    river;
   double  temperature;
   double  humidity;
   bool    enabledwatermodifier;

--- a/identifier/blockidentifier.cpp
+++ b/identifier/blockidentifier.cpp
@@ -45,8 +45,9 @@ bool BlockInfo::doesBlockHaveSolidTopSurface() const {
 }
 
 bool BlockInfo::isBlockNormalCube() const {
-  return this->isOpaque() && this->renderAsNormalBlock() &&
-      !this->canProvidePower();
+  return this->isOpaque() &&
+         this->renderAsNormalBlock() &&
+         !this->canProvidePower();
 }
 
 bool BlockInfo::renderAsNormalBlock() const {


### PR DESCRIPTION
Hostile Drowned can spawn in water in Ocean or River Biomes.
This adds an additional spawn check for them.

In case we might miss-detect Ocean or River for future Biomes, a new JSON tag in vanilla_biomes.json is supported to tag that correctly.