### PR TITLE
fix rendering of only top half filled sections

### DIFF
--- a/chunk.cpp
+++ b/chunk.cpp
@@ -401,7 +401,7 @@ bool Chunk::loadSection1343(ChunkSection *cs, const Tag *section) {
 
   // check if some Block is different to minecraft:air
   bool sectionContainsData = false;
-  for (int i = 0; i < 2048; i++) {
+  for (int i = 0; i < 4096; i++) {
     sectionContainsData |= (cs->blocks[i] != 0);
   }
   return sectionContainsData;


### PR DESCRIPTION
For old versions (before 1.13 "The Flattening") sections that contain only data in upper half are not rendered anymore.
Fix is just to check all Blocks in that Section to judge if it contains data (not lower half) . . .
( fixes #280 )