### PR TITLE
add WorldInfo as central information collection point

### DIFF
--- a/definitions/vanilla_dims.json
+++ b/definitions/vanilla_dims.json
@@ -1,7 +1,7 @@
 {
   "name": "Vanilla",
   "type": "dimension",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "data": [
     {
       "name": "Overworld",
@@ -16,8 +16,8 @@
       "name": "The Nether",
       "id": "minecraft:the_nether",
       "path": "DIM-1",
-      "minY": -64,
-      "maxY": 319,
+      "minY": 0,
+      "maxY": 255,
       "defaultY": 95,
       "scale": 8
     },
@@ -25,8 +25,8 @@
       "name": "The End",
       "id": "minecraft:the_end",
       "path": "DIM1",
-      "minY": -64,
-      "maxY": 319,
+      "minY": 0,
+      "maxY": 255,
       "defaultY": 255,
       "scale": 0
     }

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -592,7 +592,7 @@ void Minutor::loadWorld(QDir path) {
 
   WorldInfo & wi(WorldInfo::Instance());
   wi.parseFolder(path);
-  //wi.parseDimensions();
+  wi.parseDimensions();
 
   // add level name to window title
   setWindowTitle(qApp->applicationName() + " - " + wi.getLevelName());

--- a/minutor.h
+++ b/minutor.h
@@ -105,7 +105,6 @@ signals:
   void loadStructures(const QDir &dataPath);
   QKeySequence generateUniqueKeyboardShortcut(QString *actionName);
 
-  QString getWorldName(QDir path);
   void getWorldList();
 
   MapView *mapview;
@@ -126,7 +125,6 @@ signals:
   Settings *dialogSettings;
   JumpTo *dialogJumpTo;
   QDir currentWorld;
-  int  currentWorldVersion;
   QNetworkAccessManager qnam;
 
   QSet<QString> overlayItemTypes;

--- a/minutor.pro
+++ b/minutor.pro
@@ -55,6 +55,7 @@ HEADERS += \
     search/searchresultwidget.h \
     search/searchtextwidget.h \
     settings.h \
+    worldinfo.h \
     worldsave.h \
     zipreader.h
 SOURCES += \
@@ -92,6 +93,7 @@ SOURCES += \
     search/searchresultwidget.cpp \
     search/searchtextwidget.cpp \
     settings.cpp \
+    worldinfo.cpp \
     worldsave.cpp \
     zipreader.cpp
 RESOURCES = minutor.qrc

--- a/nbt/tag.cpp
+++ b/nbt/tag.cpp
@@ -125,8 +125,8 @@ qint32 Tag_Int::toInt() const {
   return data;
 }
 
-unsigned int Tag_Int::toUInt() const {
-  return (unsigned int)data;
+quint32 Tag_Int::toUInt() const {
+  return (quint32)data;
 }
 
 const QString Tag_Int::toString() const {
@@ -154,6 +154,18 @@ double Tag_Long::toDouble() const {
 
 qint32 Tag_Long::toInt() const {
   return static_cast<qint32>(data);
+}
+
+quint32 Tag_Long::toUInt() const {
+  return static_cast<quint32>(data);
+}
+
+qint64 Tag_Long::toLong() const {
+  return static_cast<qint64>(data);
+}
+
+quint64 Tag_Long::toULong() const {
+  return static_cast<quint64>(data);
 }
 
 const QString Tag_Long::toString() const {

--- a/nbt/tag.h
+++ b/nbt/tag.h
@@ -74,7 +74,7 @@ class Tag_Int : public Tag {
   explicit Tag_Int(TagDataStream *s);
 
   qint32         toInt() const override;
-  unsigned int   toUInt() const;
+  quint32        toUInt() const;
   double         toDouble() const override;
   const QString  toString() const override;
   const QVariant getData() const override;
@@ -87,6 +87,9 @@ class Tag_Long : public Tag {
   explicit Tag_Long(TagDataStream *s);
 
   qint32         toInt() const override;
+  quint32        toUInt() const;
+  qint64         toLong() const;
+  quint64        toULong() const;
   double         toDouble() const override;
   const QString  toString() const override;
   const QVariant getData() const override;

--- a/worldinfo.cpp
+++ b/worldinfo.cpp
@@ -1,0 +1,59 @@
+/** Copyright (c) 2022, EtlamGit */
+
+#include "worldinfo.h"
+
+#include "nbt/nbt.h"
+
+
+WorldInfo::WorldInfo()
+{
+  clear();
+}
+
+WorldInfo::~WorldInfo() {}
+
+WorldInfo& WorldInfo::Instance() {
+  static WorldInfo singleton;
+  return singleton;
+}
+
+
+bool WorldInfo::parseFolder(const QDir &path)
+{
+  clear();
+  if (!path.exists("level.dat")) // no level.dat?  no world
+    return false;
+
+  folder = path;
+
+  NBT level(path.filePath("level.dat"));
+  auto data = level.at("Data");
+
+  if (data->has("LevelName"))
+    levelName = data->at("LevelName")->toString();
+
+  if (data->has("DataVersion"))
+    dataVersion = dynamic_cast<const Tag_Int *>(data->at("DataVersion"))->toUInt();
+
+  if (data->has("DayTime"))
+    dayTime = dynamic_cast<const Tag_Long *>(data->at("DayTime"))->toULong();
+
+  // Dimension Data
+
+  // Spawn
+  spawnX = data->at("SpawnX")->toInt();
+  spawnZ = data->at("SpawnZ")->toInt();
+
+  return true;
+}
+
+void WorldInfo::clear()
+{
+  folder = QDir();
+  levelName   = "unknown world name";
+  dataVersion = 0;
+  dayTime     = 0;
+
+  spawnX      = 0;
+  spawnZ      = 0;
+}

--- a/worldinfo.cpp
+++ b/worldinfo.cpp
@@ -3,6 +3,8 @@
 #include "worldinfo.h"
 
 #include "nbt/nbt.h"
+#include "zipreader.h"
+#include "json/json.h"
 
 
 WorldInfo::WorldInfo()
@@ -38,14 +40,83 @@ bool WorldInfo::parseFolder(const QDir &path)
   if (data->has("DayTime"))
     dayTime = dynamic_cast<const Tag_Long *>(data->at("DayTime"))->toULong();
 
-  // Dimension Data
-
   // Spawn
   spawnX = data->at("SpawnX")->toInt();
   spawnZ = data->at("SpawnZ")->toInt();
 
   return true;
 }
+
+
+bool WorldInfo::parseDimensions()
+{
+  if (!folder.exists("level.dat")) // no level.dat?  no world
+    return false;
+
+  NBT level(folder.filePath("level.dat"));
+  auto data = level.at("Data");
+
+  // check all enabled datapacks for custom dimensions
+  if (data->has("DataPacks") && data->at("DataPacks")->has("Enabled")) {
+    auto datapacks = data->at("DataPacks")->at("Enabled");
+    int num = datapacks->length();
+    for (int d = 0; d < num; d++) {
+      QString dp = datapacks->at(d)->toString();
+      // Vanilla Dimensions
+      if (dp == "vanilla") {
+        continue;
+      }
+      // we only support this style "file/<packname>.zip" -> skip otherwise
+      if (!dp.startsWith("file")) continue;
+      QStringRef packname(&dp, 5, dp.size()-5-4);
+
+      // parse custom Dimension Data
+      // located in ./datapacks/<packname>.zip -> ./data/<packname>/dimension_type/<dimensions>.json
+      ZipReader zip(folder.path() + "/datapacks/" + packname + ".zip");
+      if (zip.open()) {
+        for (auto & file: zip.getFileList()) {
+          if (file.startsWith("data/" + packname + "/dimension_type/") &&
+              file.endsWith(".json")) {
+            std::unique_ptr<JSONData> json;
+            try {
+              json = JSON::parse(zip.get(file));
+            } catch (JSONParseException e) {
+              // file was not parsable -> silently try next one
+              continue;
+            }
+            // now 'json' should contain the Dimension description
+            QFileInfo f(file);
+            DimensionInfo dim;
+            dim.path = "./dimensions/" + packname + "/" + f.baseName();
+            if (json->has("name"))
+              dim.name = json->at("name")->asString();
+
+            // build height
+            if (json->has("min_y"))
+              dim.minY = json->at("min_y")->asNumber();
+            if (json->has("height"))
+              dim.maxY = json->at("height")->asNumber() + dim.minY;
+
+            if (json->has("coordinate_scale"))
+              dim.scale = json->at("coordinate_scale")->asNumber();
+
+            dim.defaultY = dim.maxY;
+            if ((json->has("has_ceiling")) && (json->at("has_ceiling")->asBool()))
+              dim.defaultY = (dim.minY + dim.maxY) / 2;
+
+            // store it in list
+            dimensions.append(dim);
+          }
+        }
+
+        zip.close();
+      }
+    }
+  }
+
+  return true;
+}
+
 
 void WorldInfo::clear()
 {
@@ -56,4 +127,6 @@ void WorldInfo::clear()
 
   spawnX      = 0;
   spawnZ      = 0;
+
+  dimensions.clear();
 }

--- a/worldinfo.h
+++ b/worldinfo.h
@@ -2,7 +2,11 @@
 #ifndef WORLDINFO_H
 #define WORLDINFO_H
 
+#include <QString>
 #include <QDir>
+#include <QList>
+
+#include "identifier/dimensionidentifier.h"
 
 
 class WorldInfo
@@ -13,12 +17,15 @@ class WorldInfo
 
   void clear();
   bool parseFolder(const QDir &path);
+  bool parseDimensions();
 
   QString             getLevelName() const   { return levelName; };
   unsigned int        getDataVersion() const { return dataVersion; };
   unsigned long long  getDayTime() const     { return dayTime; };
   int                 getSpawnX() const      { return spawnX; };
   int                 getSpawnZ() const      { return spawnZ; };
+
+  const QList<DimensionInfo> & getDimensions() const { return dimensions; };
 
  private:
   // singleton: prevent access to constructor and copyconstructor
@@ -27,12 +34,14 @@ class WorldInfo
   WorldInfo(const WorldInfo &);
   WorldInfo &operator=(const WorldInfo &);
 
-  QDir                folder;       // base folder of world
-  QString             levelName;    // custom world name
-  unsigned int        dataVersion;
-  unsigned long long  dayTime;
-  int                 spawnX;
-  int                 spawnZ;
+  QDir                  folder;       // base folder of world
+  QString               levelName;    // custom world name
+  unsigned int          dataVersion;
+  unsigned long long    dayTime;
+  int                   spawnX;
+  int                   spawnZ;
+
+  QList<DimensionInfo>  dimensions;
 };
 
 #endif // WORLDINFO_H

--- a/worldinfo.h
+++ b/worldinfo.h
@@ -1,0 +1,38 @@
+/** Copyright (c) 2022, EtlamGit */
+#ifndef WORLDINFO_H
+#define WORLDINFO_H
+
+#include <QDir>
+
+
+class WorldInfo
+{
+ public:
+  // singleton: access to global usable instance
+  static WorldInfo &Instance();
+
+  void clear();
+  bool parseFolder(const QDir &path);
+
+  QString             getLevelName() const   { return levelName; };
+  unsigned int        getDataVersion() const { return dataVersion; };
+  unsigned long long  getDayTime() const     { return dayTime; };
+  int                 getSpawnX() const      { return spawnX; };
+  int                 getSpawnZ() const      { return spawnZ; };
+
+ private:
+  // singleton: prevent access to constructor and copyconstructor
+  WorldInfo();
+  ~WorldInfo();
+  WorldInfo(const WorldInfo &);
+  WorldInfo &operator=(const WorldInfo &);
+
+  QDir                folder;       // base folder of world
+  QString             levelName;    // custom world name
+  unsigned int        dataVersion;
+  unsigned long long  dayTime;
+  int                 spawnX;
+  int                 spawnZ;
+};
+
+#endif // WORLDINFO_H

--- a/zipreader.cpp
+++ b/zipreader.cpp
@@ -2,10 +2,14 @@
 #include <zlib.h>
 #include "zipreader.h"
 
-ZipReader::ZipReader(const QString filename) : f(filename) {
-}
 
-bool ZipReader::open() {
+ZipReader::ZipReader(const QString filename)
+  : f(filename)
+{}
+
+
+bool ZipReader::open()
+{
   if (!f.open(QIODevice::ReadOnly))
     return false;
 
@@ -67,7 +71,10 @@ bool ZipReader::open() {
   }
   return true;
 }
-QByteArray ZipReader::get(const QString filename) {
+
+
+QByteArray ZipReader::get(const QString filename)
+{
   if (!files.contains(filename))
     return QByteArray();
   ZipFileHeader &zfh = files[filename];
@@ -109,7 +116,16 @@ QByteArray ZipReader::get(const QString filename) {
   inflateEnd(&strm);
   return result;
 }
-void ZipReader::close() {
+
+
+QStringList ZipReader::getFileList() const
+{
+  return QStringList(files.keys());
+}
+
+
+void ZipReader::close()
+{
   files.clear();  // erase all headers
   f.close();
 }

--- a/zipreader.h
+++ b/zipreader.h
@@ -15,10 +15,11 @@ struct ZipFileHeader {
 
 class ZipReader {
  public:
-  explicit ZipReader(const QString filename);
-  bool open();
-  void close();
-  QByteArray get(const QString filename);
+  explicit    ZipReader(const QString filename);
+  bool        open();
+  void        close();
+  QByteArray  get(const QString filename);
+  QStringList getFileList() const;
  private:
   QFile f;
   QHash<QString, struct ZipFileHeader> files;


### PR DESCRIPTION
To support some features we need a place to store information that is common for the complete world. Up to know we only have Definitions which are common to all worlds and Chunk data that is common only to a single Chunk. Some exceptions were solved with extra variables.
(Example features are: World name, Spawn coordinates, last saved data version, Custom Dimensions and Local Difficulty Highlight.)

Here I started to add the class WorldInfo to hold all these world common information.
Then I migrated all the extra complicated stuff, what went smooth.
And tested some custom dimensions, what was working faster then expected.

@mrkite: adding the Custom Dimensions to the menu feels still a bit ugly. Do you have some better idea for that part?

It is the first step to solve #269, #255 and #242.
Here a first quick test worked with custom Dimensions. Maybe it was all, but I think we will need some deeper testing.