### PR TITLE
Store zoom level as a double

### DIFF
--- a/mapview.cpp
+++ b/mapview.cpp
@@ -2,6 +2,7 @@
 #include <QPainter>
 #include <QResizeEvent>
 #include <QMessageBox>
+#include <cmath>
 #include <assert.h>
 
 #include "mapview.h"
@@ -140,7 +141,7 @@ void MapView::clearCache() {
 void MapView::adjustZoom(double steps, bool allowZoomOut)
 {
   // get current zoom level as an index, rounded to nearest int
-  int oldZoomIndex = zoomLevel + 0.5;
+  int oldZoomIndex = (int)(floor(zoomLevel + 0.5));
   zoomLevel += steps;
 
   // use Fibonacci numbers to get natural zoom behaviour
@@ -151,7 +152,7 @@ void MapView::adjustZoom(double steps, bool allowZoomOut)
   if (zoomLevel < zoomMin) zoomLevel = zoomMin;
   if (zoomLevel > zoomMax) zoomLevel = zoomMax;
 
-  int zoomIndex = zoomLevel + 0.5;
+  int zoomIndex = (int)(floor(zoomLevel + 0.5 ));
 
   // check whether zoomIndex has changed since last adjustZoom call
   // don't return early if steps == 0, this is used for initialization

--- a/mapview.h
+++ b/mapview.h
@@ -104,7 +104,7 @@ class MapView : public QWidget {
   int depth;
   double x, z;
   int scale;
-  int zoomIndex;
+  double zoomLevel;
   double zoom;
   int flags;
   ChunkCache &cache;


### PR DESCRIPTION
This changes the way that the current zoom level is stored by the
program. Previously, only the integer index of the zoom level was
stored. This leads to an issue: when you have many scroll events
firing every second, each individual scroll event will only have
a tiny delta. Most of these deltas will not be large enough to
change the zoom level, but they should build up over time. The
previous implementation lost these deltas because of rounding.

With this change, we store the zoom level as a double, and only
convert this to an index (by rounding) when this is needed to
change the scaling factor.

I also fixed a couple of tiny issues:

1. changed delta -> angleDelta to fix QT deprecation warnings.

2. preventing having to call redraw() for every scroll event

Fixes #224