### PR TITLE
Use a double to store state of LabelledSlider

### DIFF
--- a/labelledslider.cpp
+++ b/labelledslider.cpp
@@ -38,15 +38,14 @@ int LabelledSlider::value() const {
 // public slot
 void LabelledSlider::setValue(double v) {
   preciseValue = v;
+  if (preciseValue < slider->minimum()) preciseValue = slider->minimum();
+  if (preciseValue > slider->maximum()) preciseValue = slider->maximum();
   slider->setValue((int)(v + 0.5));
 }
 
 // public slot
 void LabelledSlider::changeValue(double v) {
-  preciseValue += v;
-  if (preciseValue < slider->minimum()) preciseValue = slider->minimum();
-  if (preciseValue > slider->maximum()) preciseValue = slider->maximum();
-  slider->setValue(preciseValue);
+  this->setValue(preciseValue + v);
 }
 
 // public slot

--- a/labelledslider.cpp
+++ b/labelledslider.cpp
@@ -1,5 +1,6 @@
 /** Copyright (c) 2013, Sean Kasun */
 #include <QVBoxLayout>
+#include <cmath>
 #include "labelledslider.h"
 
 LabelledSlider::LabelledSlider(Qt::Orientation orientation, QWidget *parent) :
@@ -40,7 +41,7 @@ void LabelledSlider::setValue(double v) {
   preciseValue = v;
   if (preciseValue < slider->minimum()) preciseValue = slider->minimum();
   if (preciseValue > slider->maximum()) preciseValue = slider->maximum();
-  slider->setValue((int)(v + 0.5));
+  slider->setValue(static_cast<int>(floor(v + 0.5)));
 }
 
 // public slot

--- a/labelledslider.cpp
+++ b/labelledslider.cpp
@@ -36,13 +36,17 @@ int LabelledSlider::value() const {
 }
 
 // public slot
-void LabelledSlider::setValue(int v) {
-  slider->setValue(v);
+void LabelledSlider::setValue(double v) {
+  preciseValue = v;
+  slider->setValue((int)(v + 0.5));
 }
 
 // public slot
-void LabelledSlider::changeValue(int v) {
-  slider->setValue(slider->value() + v);
+void LabelledSlider::changeValue(double v) {
+  preciseValue += v;
+  if (preciseValue < slider->minimum()) preciseValue = slider->minimum();
+  if (preciseValue > slider->maximum()) preciseValue = slider->maximum();
+  slider->setValue(preciseValue);
 }
 
 // public slot
@@ -58,13 +62,14 @@ void LabelledSlider::intValueChange(int v) {
 }
 
 void LabelledSlider::wheelEvent(QWheelEvent* event) {
-  slider->wheelEvent(event);
+  this->changeValue(event->angleDelta().y() / 120.0); // in order to make wheel intuitive
 }
 
 MSlider::MSlider(Qt::Orientation orientation, QWidget* parent) :
   QSlider(orientation, parent) {}
 
+// catch the wheelEvent to prevent it from scrolling the slider
+// ignore the event to allow it to bubble up to the LabelledSlider
 void  MSlider::wheelEvent(QWheelEvent* event) {
-  int delta = event->delta() / 120;  // in order to make wheel intuitive
-  this->setValue(this->value() + delta);
+  event->ignore();
 }

--- a/labelledslider.h
+++ b/labelledslider.h
@@ -16,6 +16,7 @@ class MSlider : public QSlider {
 
  public slots:
   void wheelEvent(QWheelEvent *event);
+
 };
 
 
@@ -30,8 +31,8 @@ class LabelledSlider : public QWidget {
   void valueChanged(int val);
 
  public slots:
-  void setValue(int val);                 // set absolute value
-  void changeValue(int val);              // change value relative to current
+  void setValue(double val);                 // set absolute value
+  void changeValue(double val);              // change value relative to current
   void setRange(int minVal, int maxVal);  // set slider range
 
  private slots:
@@ -43,6 +44,7 @@ class LabelledSlider : public QWidget {
  private:
   MSlider *slider;
   QLabel *label;
+  double preciseValue;
 };
 
 #endif  // LABELLEDSLIDER_H_

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -245,7 +245,7 @@ void MapView::wheelEvent(QWheelEvent *event) {
 
   if ((event->modifiers() & modifier4DepthSlider) == modifier4DepthSlider) {
     // change depth
-    emit demandDepthChange(event->delta() / 120);
+    emit demandDepthChange(event->angleDelta().y() / 120.0);
   } else if ((event->modifiers() & modifier4ZoomOut) == modifier4ZoomOut) {
     // allow change zoom also to zoom OUT
     adjustZoom( event->delta() / 120.0, true );

--- a/mapview.h
+++ b/mapview.h
@@ -69,8 +69,8 @@ class MapView : public QWidget {
 
  signals:
   void hoverTextChanged(QString text);
-  void demandDepthChange(int value);
-  void demandDepthValue(int value);
+  void demandDepthChange(double value);
+  void demandDepthValue(double value);
   void showProperties(QVariant properties);
   void addOverlayItemType(QString type, QColor color);
   void coordinatesChanged(int x, int y, int z);

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -101,10 +101,10 @@ Minutor::Minutor()
 
   connect(depth, SIGNAL(valueChanged(int)),
           mapview, SLOT(setDepth(int)));
-  connect(mapview, SIGNAL(demandDepthChange(int)),
-          depth, SLOT(changeValue(int)));
-  connect(mapview, SIGNAL(demandDepthValue(int)),
-          depth, SLOT(setValue(int)));
+  connect(mapview, SIGNAL(demandDepthChange(double)),
+          depth, SLOT(changeValue(double)));
+  connect(mapview, SIGNAL(demandDepthValue(double)),
+          depth, SLOT(setValue(double)));
   connect(this, SIGNAL(worldLoaded(bool)),
           mapview, SLOT(setEnabled(bool)));
   connect(this, SIGNAL(worldLoaded(bool)),


### PR DESCRIPTION
The LabelledSlider is used to change the depth setting. Some
touchpads (e.g. on macOS) can send dozens or hundreds of scroll
events per second, each with a very small delta. Unless we keep
track of the "true" state of the slider, these deltas will be lost
when they are rounded into the integer depth setting.

Fixes #287