### PR TITLE
Snap png export to chunk or region

### DIFF
--- a/jumpto.cpp
+++ b/jumpto.cpp
@@ -5,6 +5,8 @@
 JumpTo::JumpTo(QWidget *parent) : QDialog(parent), ui(new Ui::JumpTo)
 {
   ui->setupUi(this);
+  // remove "question mark" in title bar
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   readSettings();
 

--- a/pngexport.cpp
+++ b/pngexport.cpp
@@ -57,10 +57,10 @@ void PngExport::setBoundsFromBlocks(int top, int left, int bottom, int right)
   int e_right  = 512*(std::floor(float(right)/512.0) +1) -1;
 
   // restrict range of spin boxes to world dimension
-  ui->spinBox_top   ->setRange(e_top, e_bottom-15);
-  ui->spinBox_left  ->setRange(e_left, e_right-15);
-  ui->spinBox_bottom->setRange(e_top+15, e_bottom);
-  ui->spinBox_right ->setRange(e_left+15, e_right);
+  ui->spinBox_top   ->setRange(e_top, e_bottom-(snapDistance-1));
+  ui->spinBox_left  ->setRange(e_left, e_right-(snapDistance-1));
+  ui->spinBox_bottom->setRange(e_top+(snapDistance-1), e_bottom);
+  ui->spinBox_right ->setRange(e_left+(snapDistance-1), e_right);
 
   // initialize spin boxes to complete world dimension
   ui->spinBox_top   ->setValue(top);
@@ -124,10 +124,10 @@ void PngExport::setSingleStep()
 }
 
 
-int PngExport::getTop() const    { return ui->spinBox_top->value(); }
-int PngExport::getLeft() const   { return ui->spinBox_left->value(); }
+int PngExport::getTop() const    { return ui->spinBox_top   ->value(); }
+int PngExport::getLeft() const   { return ui->spinBox_left  ->value(); }
 int PngExport::getBottom() const { return ui->spinBox_bottom->value(); }
-int PngExport::getRight() const  { return ui->spinBox_right->value(); }
+int PngExport::getRight() const  { return ui->spinBox_right ->value(); }
 
-bool PngExport::getChunkChecker() const  { return ui->checkBox_chunk->checkState(); }
+bool PngExport::getChunkChecker() const  { return ui->checkBox_chunk ->checkState(); }
 bool PngExport::getRegionChecker() const { return ui->checkBox_region->checkState(); }

--- a/pngexport.cpp
+++ b/pngexport.cpp
@@ -1,22 +1,40 @@
 #include "pngexport.h"
 #include "ui_pngexport.h"
 
-PngExport::PngExport(QWidget *parent) :
-  QDialog(parent),
-  ui(new Ui::PngExport)
+#include <QSettings>
+#include <cmath>
+
+PngExport::PngExport(QWidget *parent)
+  : QDialog(parent)
+  , ui(new Ui::PngExport)
+  , snapDistance(16)
 {
   ui->setupUi(this);
+  // remove "question mark" in title bar
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
-  // connect value change signals to check slots
-  connect(ui->spinBox_top,    SIGNAL(valueChanged(int)),
-          this,               SLOT(checkTop(int)));
-  connect(ui->spinBox_left,   SIGNAL(valueChanged(int)),
-          this,               SLOT(checkLeft(int)));
-  connect(ui->spinBox_bottom, SIGNAL(valueChanged(int)),
-          this,               SLOT(checkBottom(int)));
-  connect(ui->spinBox_right,  SIGNAL(valueChanged(int)),
-          this,               SLOT(checkRight(int)));
+  // connect value change signals to check slots of "other" spinbox
+  connect(ui->spinBox_top,    QOverload<int>::of(&QSpinBox::valueChanged),
+          this,               &PngExport::checkTop);
+  connect(ui->spinBox_left,   QOverload<int>::of(&QSpinBox::valueChanged),
+          this,               &PngExport::checkLeft);
+  connect(ui->spinBox_bottom, QOverload<int>::of(&QSpinBox::valueChanged),
+          this,               &PngExport::checkBottom);
+  connect(ui->spinBox_right,  QOverload<int>::of(&QSpinBox::valueChanged),
+          this,               &PngExport::checkRight);
 
+  // connect radio buttons to change single-step distance
+  connect(ui->radioButton_chunk,  &QRadioButton::toggled,
+          this,                   &PngExport::setSingleStep);
+  connect(ui->radioButton_region, &QRadioButton::toggled,
+          this,                   &PngExport::setSingleStep);
+
+  // load the settings
+  QSettings settings;
+  if (settings.value("PNGExportSnapDistance", 16).toInt() == 512) {
+    snapDistance = 512;
+    ui->radioButton_region->setChecked(true);
+  }
 }
 
 PngExport::~PngExport()
@@ -32,62 +50,84 @@ void PngExport::setBoundsFromChunks(int top, int left, int bottom, int right)
 
 void PngExport::setBoundsFromBlocks(int top, int left, int bottom, int right)
 {
-  w_top    = top;
-  w_left   = left;
-  w_bottom = bottom;
-  w_right  = right;
+  // extend to next region boundary
+  int e_top    = 512* std::floor(float(top)/512.0);
+  int e_left   = 512* std::floor(float(left)/512.0);
+  int e_bottom = 512*(std::floor(float(bottom)/512.0) +1) -1;
+  int e_right  = 512*(std::floor(float(right)/512.0) +1) -1;
 
   // restrict range of spin boxes to world dimension
-  ui->spinBox_top   ->setRange(w_top, w_bottom-15);
-  ui->spinBox_left  ->setRange(w_left, w_right-15);
-  ui->spinBox_bottom->setRange(w_top+15, w_bottom);
-  ui->spinBox_right ->setRange(w_left+15, w_right);
+  ui->spinBox_top   ->setRange(e_top, e_bottom-15);
+  ui->spinBox_left  ->setRange(e_left, e_right-15);
+  ui->spinBox_bottom->setRange(e_top+15, e_bottom);
+  ui->spinBox_right ->setRange(e_left+15, e_right);
 
   // initialize spin boxes to complete world dimension
-  ui->spinBox_top   ->setValue(w_top);
-  ui->spinBox_left  ->setValue(w_left);
-  ui->spinBox_bottom->setValue(w_bottom);
-  ui->spinBox_right ->setValue(w_right);
+  ui->spinBox_top   ->setValue(top);
+  ui->spinBox_left  ->setValue(left);
+  ui->spinBox_bottom->setValue(bottom);
+  ui->spinBox_right ->setValue(right);
 }
 
 
 void PngExport::checkTop(int value)
 {
-//  value = 16*round(float(value)/16);
-//  ui->spinBox_top->setValue(value);
-  if (value+15 > ui->spinBox_bottom->value())
-    ui->spinBox_bottom->setValue(value+15);
+  value = snapDistance * std::round(float(value)/snapDistance);
+  ui->spinBox_top->setValue(value);
+  if (value+(snapDistance-1) > ui->spinBox_bottom->value())
+    ui->spinBox_bottom->setValue(value+(snapDistance-1));
 }
 
 void PngExport::checkLeft(int value)
 {
-//  value = 16*round(float(value)/16);
-//  ui->spinBox_left->setValue(value);
-  if (value+15 > ui->spinBox_right->value())
-    ui->spinBox_right->setValue(value+15);
+  value = snapDistance * std::round(float(value)/snapDistance);
+  ui->spinBox_left->setValue(value);
+  if (value+(snapDistance-1) > ui->spinBox_right->value())
+    ui->spinBox_right->setValue(value+(snapDistance-1));
 }
 
 void PngExport::checkBottom(int value)
 {
-//  value = 16*round(float(value)/16);
-//  ui->spinBox_bottom->setValue(value);
-  if (value-15 < ui->spinBox_top->value())
-    ui->spinBox_top->setValue(value-15);
+  value = snapDistance * std::round(float(value)/snapDistance) -1;
+  ui->spinBox_bottom->setValue(value);
+  if (value-(snapDistance-1) < ui->spinBox_top->value())
+    ui->spinBox_top->setValue(value-(snapDistance-1));
 }
 
 void PngExport::checkRight(int value)
 {
-//  value = 16*round(float(value)/16);
-//  ui->spinBox_right->setValue(value);
-  if (value-15 < ui->spinBox_left->value())
-    ui->spinBox_left->setValue(value-15);
+  value = snapDistance * std::round(float(value)/snapDistance) -1;
+  ui->spinBox_right->setValue(value);
+  if (value-(snapDistance-1) < ui->spinBox_left->value())
+    ui->spinBox_left->setValue(value-(snapDistance-1));
+}
+
+void PngExport::setSingleStep()
+{
+  if (ui->radioButton_chunk ->isChecked()) snapDistance = 16;
+  if (ui->radioButton_region->isChecked()) snapDistance = 512;
+  // change single step behavior
+  ui->spinBox_top   ->setSingleStep(snapDistance);
+  ui->spinBox_left  ->setSingleStep(snapDistance);
+  ui->spinBox_bottom->setSingleStep(snapDistance);
+  ui->spinBox_right ->setSingleStep(snapDistance);
+
+  // validate current values
+  checkTop   (ui->spinBox_top   ->value());
+  checkLeft  (ui->spinBox_left  ->value());
+  checkBottom(ui->spinBox_bottom->value());
+  checkRight (ui->spinBox_right ->value());
+
+  // store the settings
+  QSettings settings;
+  settings.setValue("PNGExportSnapDistance", snapDistance);
 }
 
 
-int PngExport::getTop()    { return ui->spinBox_top->value(); }
-int PngExport::getLeft()   { return ui->spinBox_left->value(); }
-int PngExport::getBottom() { return ui->spinBox_bottom->value(); }
-int PngExport::getRight()  { return ui->spinBox_right->value(); }
+int PngExport::getTop() const    { return ui->spinBox_top->value(); }
+int PngExport::getLeft() const   { return ui->spinBox_left->value(); }
+int PngExport::getBottom() const { return ui->spinBox_bottom->value(); }
+int PngExport::getRight() const  { return ui->spinBox_right->value(); }
 
-bool PngExport::getChunkChecker()  { return ui->checkBox_chunk->checkState(); }
-bool PngExport::getRegionChecker() { return ui->checkBox_region->checkState(); }
+bool PngExport::getChunkChecker() const  { return ui->checkBox_chunk->checkState(); }
+bool PngExport::getRegionChecker() const { return ui->checkBox_region->checkState(); }

--- a/pngexport.h
+++ b/pngexport.h
@@ -19,27 +19,26 @@ public:
   void setBoundsFromChunks(int top, int left, int bottom, int right);
   void setBoundsFromBlocks(int top, int left, int bottom, int right);
 
-  int getTop();
-  int getLeft();
-  int getBottom();
-  int getRight();
+  int getTop() const;
+  int getLeft() const;
+  int getBottom() const;
+  int getRight() const;
 
-  bool getChunkChecker();
-  bool getRegionChecker();
+  bool getChunkChecker() const;
+  bool getRegionChecker() const;
 
 private:
   Ui::PngExport *ui;
 
-  int w_top;
-  int w_left;
-  int w_bottom;
-  int w_right;
+  int  snapDistance;
 
 private slots:
   void checkTop(int value);
   void checkLeft(int value);
   void checkBottom(int value);
   void checkRight(int value);
+
+  void setSingleStep();
 };
 
 #endif // PNGEXPORT_H

--- a/pngexport.ui
+++ b/pngexport.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>240</width>
-    <height>237</height>
+    <height>303</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Export region</string>
+      <string>Export range</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
@@ -44,6 +44,9 @@
         </item>
         <item>
          <widget class="QSpinBox" name="spinBox_top">
+          <property name="keyboardTracking">
+           <bool>false</bool>
+          </property>
           <property name="singleStep">
            <number>16</number>
           </property>
@@ -95,6 +98,9 @@
         </item>
         <item>
          <widget class="QSpinBox" name="spinBox_left">
+          <property name="keyboardTracking">
+           <bool>false</bool>
+          </property>
           <property name="singleStep">
            <number>16</number>
           </property>
@@ -115,6 +121,9 @@
         </item>
         <item>
          <widget class="QSpinBox" name="spinBox_right">
+          <property name="keyboardTracking">
+           <bool>false</bool>
+          </property>
           <property name="singleStep">
            <number>16</number>
           </property>
@@ -166,6 +175,9 @@
         </item>
         <item>
          <widget class="QSpinBox" name="spinBox_bottom">
+          <property name="keyboardTracking">
+           <bool>false</bool>
+          </property>
           <property name="singleStep">
            <number>16</number>
           </property>
@@ -192,6 +204,32 @@
          </widget>
         </item>
        </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Snap to</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <item>
+       <widget class="QRadioButton" name="radioButton_chunk">
+        <property name="text">
+         <string>Chunk</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButton_region">
+        <property name="text">
+         <string>Region</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/pngexport.ui
+++ b/pngexport.ui
@@ -47,6 +47,12 @@
           <property name="keyboardTracking">
            <bool>false</bool>
           </property>
+          <property name="minimum">
+           <number>-4096</number>
+          </property>
+          <property name="maximum">
+           <number>4095</number>
+          </property>
           <property name="singleStep">
            <number>16</number>
           </property>
@@ -101,6 +107,12 @@
           <property name="keyboardTracking">
            <bool>false</bool>
           </property>
+          <property name="minimum">
+           <number>-4096</number>
+          </property>
+          <property name="maximum">
+           <number>4095</number>
+          </property>
           <property name="singleStep">
            <number>16</number>
           </property>
@@ -123,6 +135,12 @@
          <widget class="QSpinBox" name="spinBox_right">
           <property name="keyboardTracking">
            <bool>false</bool>
+          </property>
+          <property name="minimum">
+           <number>-4096</number>
+          </property>
+          <property name="maximum">
+           <number>4095</number>
           </property>
           <property name="singleStep">
            <number>16</number>
@@ -177,6 +195,12 @@
          <widget class="QSpinBox" name="spinBox_bottom">
           <property name="keyboardTracking">
            <bool>false</bool>
+          </property>
+          <property name="minimum">
+           <number>-4096</number>
+          </property>
+          <property name="maximum">
+           <number>4095</number>
           </property>
           <property name="singleStep">
            <number>16</number>

--- a/settings.cpp
+++ b/settings.cpp
@@ -7,6 +7,8 @@
 
 Settings::Settings(QWidget *parent) : QDialog(parent) {
   m_ui.setupUi(this);
+  // remove "question mark" in title bar
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   setWindowTitle(tr("%1 Settings").arg(qApp->applicationName()));
 


### PR DESCRIPTION
This adds a selection to "snap" the export range to Chunks or Regions.
In the past it was silently forced to Chunks, as we only support exporting whole Chunks.

The selection is stored in settings.
Behavior of up/down arrows of spinboxes is controlled to match the selection.
Possible export range is extended to full Region files. (Spinboxes have extended min/max.)

This solves some of the stuff mentioned in #289 

Off topic fix: removed all "question marks" in dialog title bars, as we do not support context help.