### PR TITLE
Two step parsing of custom dimensions

### DIFF
--- a/identifier/dimensionidentifier.cpp
+++ b/identifier/dimensionidentifier.cpp
@@ -28,7 +28,10 @@ DimensionInfo::DimensionInfo()
 
 DimensionIdentifier::DimensionIdentifier()
   : menuActionGroup(NULL)
-{}
+{
+  dummy_dimension.enabled = false;
+  dummy_dimension.name    = "Dummy Dimension";
+}
 
 DimensionIdentifier::~DimensionIdentifier() {
   for (int i = 0; i < packs.length(); i++) {
@@ -177,6 +180,15 @@ void DimensionIdentifier::getDimensionsInWorld(QDir path, QMenu *menu, QObject *
     }
     menu->setEnabled(true);
   }
+}
+
+const DimensionInfo & DimensionIdentifier::getDimensionInfo(const QString & dim_name) const
+{
+  for (DimensionInfo * dim: definitions) {
+    if (dim->id == dim_name)
+      return *dim;
+  }
+  return dummy_dimension;
 }
 
 

--- a/identifier/dimensionidentifier.h
+++ b/identifier/dimensionidentifier.h
@@ -39,9 +39,11 @@ class DimensionIdentifier : public QObject {
   int  addDefinitions(JSONArray *, int pack = -1);
   void enableDefinitions(int id);
   void disableDefinitions(int id);
-  // Dimesnion view menu
+  // Dimension view menu
   void clearDimensionsMenu(QMenu *menu);
   void getDimensionsInWorld(QDir path, QMenu *menu, QObject *parent);
+
+  const DimensionInfo & getDimensionInfo(const QString & dim_name) const;
 
  signals:
   void dimensionChanged(const DimensionInfo &dim);    // dimension changed in menu
@@ -65,6 +67,8 @@ class DimensionIdentifier : public QObject {
   // dimension storage
   QList<DimensionInfo*>         definitions;  // definition of possible Dimensions
   QList<QList<DimensionInfo*> > packs;
+
+  DimensionInfo dummy_dimension; // dummy in case no matching dimension is available
 };
 
 #endif  // DIMENSIONIDENTIFIER_H_

--- a/identifier/dimensionidentifier.h
+++ b/identifier/dimensionidentifier.h
@@ -7,10 +7,8 @@
 #include <QHash>
 #include <QDir>
 
-class QMenu;
-class QAction;
-class QActionGroup;
-class JSONArray;
+#include "json/json.h"
+
 
 class DimensionInfo {
  public:
@@ -28,9 +26,7 @@ class DimensionInfo {
 };
 
 
-class DimensionIdentifier : public QObject {
-  Q_OBJECT
-
+class DimensionIdentifier {
  public:
   // singleton: access to global usable instance
   static DimensionIdentifier &Instance();
@@ -39,17 +35,10 @@ class DimensionIdentifier : public QObject {
   int  addDefinitions(JSONArray *, int pack = -1);
   void enableDefinitions(int id);
   void disableDefinitions(int id);
-  // Dimension view menu
-  void clearDimensionsMenu(QMenu *menu);
-  void getDimensionsInWorld(QDir path, QMenu *menu, QObject *parent);
 
+  int getDimensionIndex(const QString & dim_name) const;
+  const DimensionInfo & getDimensionInfo(int index) const;
   const DimensionInfo & getDimensionInfo(const QString & dim_name) const;
-
- signals:
-  void dimensionChanged(const DimensionInfo &dim);    // dimension changed in menu
-
- private slots:
-  void changeViewToDimension();                       // dimension changed in menu
 
  private:
   // singleton: prevent access to constructor and copyconstructor
@@ -58,12 +47,6 @@ class DimensionIdentifier : public QObject {
   DimensionIdentifier(const DimensionIdentifier &);
   DimensionIdentifier &operator=(const DimensionIdentifier &);
 
-  void addDimensionMenu(QDir path, QString dir, QString name, QObject *parent);
-
-  // GUI menu
-  QList<QAction *> currentMenuActions;
-  QActionGroup *   menuActionGroup;
-  QList<QString>   foundDimensionDirs;  // all directories where we already found a Dimension
   // dimension storage
   QList<DimensionInfo*>         definitions;  // definition of possible Dimensions
   QList<QList<DimensionInfo*> > packs;

--- a/labelledslider.cpp
+++ b/labelledslider.cpp
@@ -12,7 +12,6 @@ LabelledSlider::LabelledSlider(Qt::Orientation orientation, QWidget *parent) :
 
   label = new QLabel();
   label->setAlignment(Qt::AlignCenter | Qt::AlignVCenter);
-  label->setFixedWidth(label->fontMetrics().width("888"));
   label->setNum(255);
 
   connect(slider, SIGNAL(valueChanged(int)),

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -41,24 +41,24 @@ Minutor::Minutor()
 
   // central MapView wiget
   mapview = new MapView;
-  connect(mapview, SIGNAL(hoverTextChanged(QString)),
+  connect(mapview,     SIGNAL(hoverTextChanged(QString)),
           statusBar(), SLOT(showMessage(QString)));
   connect(mapview, SIGNAL(showProperties(QVariant)),
-          this, SLOT(showProperties(QVariant)));
+          this,    SLOT(showProperties(QVariant)));
   connect(mapview, SIGNAL(addOverlayItemType(QString, QColor)),
-          this, SLOT(addOverlayItemType(QString, QColor)));
+          this,    SLOT(addOverlayItemType(QString, QColor)));
   dm = new DefinitionManager(this);
   mapview->attach(dm);
   connect(dm,   SIGNAL(packsChanged()),
           this, SLOT(updateDimensions()));
-  DimensionIdentifier *dimensions = &DimensionIdentifier::Instance();
-  connect(dimensions, SIGNAL(dimensionChanged(const DimensionInfo &)),
+  WorldInfo & wi = WorldInfo::Instance();
+  connect(&wi,  SIGNAL(dimensionChanged(const DimensionInfo &)),
           this, SLOT(viewDimension(const DimensionInfo &)));
 
   // "Settings" dialog
   dialogSettings = new Settings(this);
   connect(dialogSettings, SIGNAL(settingsUpdated()),
-          this, SLOT(rescanWorlds()));
+          this,           SLOT(rescanWorlds()));
 
   // "Jump To" dialog
   dialogJumpTo = new JumpTo(this);
@@ -234,7 +234,7 @@ void Minutor::closeWorld() {
   m_ui.menu_JumpPlayer->setEnabled(false);
 
   // clear "Dimensions" menu
-  DimensionIdentifier::Instance().clearDimensionsMenu(m_ui.menu_Dimension);
+  WorldInfo::Instance().clearDimensionsMenu(m_ui.menu_Dimension);
   // clear overlays
   mapview->clearOverlayItems();
   // clear other stuff
@@ -382,7 +382,7 @@ void Minutor::about() {
 }
 
 void Minutor::updateDimensions() {
-  DimensionIdentifier::Instance().getDimensionsInWorld(currentWorld, m_ui.menu_Dimension, this);
+  WorldInfo::Instance().getDimensionsInWorld(currentWorld, m_ui.menu_Dimension, this);
 }
 
 void Minutor::createActions() {
@@ -691,7 +691,7 @@ void Minutor::loadWorld(QDir path) {
   }
 
   // create Dimensions menu
-  DimensionIdentifier::Instance().getDimensionsInWorld(path, m_ui.menu_Dimension, this);
+  WorldInfo::Instance().getDimensionsInWorld(path, m_ui.menu_Dimension, this);
 
   // finalize
   emit worldLoaded(true);

--- a/worldinfo.h
+++ b/worldinfo.h
@@ -5,12 +5,15 @@
 #include <QString>
 #include <QDir>
 #include <QList>
+#include <QMenu>
 
 #include "identifier/dimensionidentifier.h"
 
 
-class WorldInfo
+class WorldInfo : public QObject
 {
+  Q_OBJECT
+
  public:
   // singleton: access to global usable instance
   static WorldInfo &Instance();
@@ -26,6 +29,16 @@ class WorldInfo
   int                 getSpawnZ() const      { return spawnZ; };
 
   const QList<DimensionInfo> & getDimensions() const { return dimensions; };
+
+  // Dimension view menu
+  void clearDimensionsMenu(QMenu *menu);
+  void getDimensionsInWorld(QDir path, QMenu *menu, QObject *parent);
+
+ signals:
+  void dimensionChanged(const DimensionInfo &dim);    // dimension changed in menu
+
+ private slots:
+  void changeViewToDimension();                       // dimension changed in menu
 
  private:
   // singleton: prevent access to constructor and copyconstructor
@@ -44,6 +57,13 @@ class WorldInfo
   int                   spawnZ;
 
   QList<DimensionInfo>  dimensions;
+
+  // Dimension view menu
+  void addDimensionToMenu(QDir path, QString dir, QString name, QObject *parent);
+
+  QList<QAction *> currentMenuActions;
+  QActionGroup *   menuActionGroup;
+  QList<QString>   foundDimensionDirs;  // all directories where we already found a Dimension
 };
 
 #endif // WORLDINFO_H

--- a/worldinfo.h
+++ b/worldinfo.h
@@ -34,6 +34,8 @@ class WorldInfo
   WorldInfo(const WorldInfo &);
   WorldInfo &operator=(const WorldInfo &);
 
+  bool parseDimensionType(DimensionInfo & dim, const QString & dim_type_id);
+
   QDir                  folder;       // base folder of world
   QString               levelName;    // custom world name
   unsigned int          dataVersion;


### PR DESCRIPTION
according to discussion in #269 we have to parse Custom Dimensions with a two-step approach:
* A the dimension description always references a dimension_type description.

[Code Refactoring]
Also moves all Dimension menu stuff to WorldInfo to get DimensionIdentifer as clean as all other *Identifiers.