### PR TITLE
When zooming with pointing device, zoom into cursor location

### DIFF
--- a/mapview.h
+++ b/mapview.h
@@ -94,7 +94,7 @@ class MapView : public QWidget {
   void getToolTip(int x, int z);
   int getY(int x, int z);
   QList<QSharedPointer<OverlayItem>> getItems(int x, int y, int z);
-  void adjustZoom(double steps, bool allowZoomOut);
+  void adjustZoom(double steps, bool allowZoomOut, bool cursorSource);
 
   template<typename ListT>
   void drawOverlayItems(const ListT& list, const OverlayItem::Cuboid& cuboid, double x1, double z1, QPainter& canvas);
@@ -108,6 +108,7 @@ class MapView : public QWidget {
   double zoomLevel;
   double zoom;
   int flags;
+  int lastMouseX = -1, lastMouseY = -1;
   ChunkCache &cache;
   QImage imageChunks;
   QImage imageOverlays;

--- a/settings.cpp
+++ b/settings.cpp
@@ -60,6 +60,7 @@ Settings::Settings(QWidget *parent) : QDialog(parent) {
   }
   autoUpdate    = info.value("autoupdate", true).toBool();
   verticalDepth = info.value("verticaldepth", true).toBool();
+  zoomFollowsCursor = info.value("zoomFollowsCursor", true).toBool();
   modifier4DepthSlider = Qt::KeyboardModifier(info.value("modifier4DepthSlider", 0x02000000).toUInt());
   modifier4ZoomOut     = Qt::KeyboardModifier(info.value("modifier4ZoomOut",     0x04000000).toUInt());
 

--- a/settings.h
+++ b/settings.h
@@ -14,6 +14,7 @@ class Settings : public QDialog {
   QString mcpath;
   bool verticalDepth;
   bool autoUpdate;
+  bool zoomFollowsCursor;
   Qt::KeyboardModifier modifier4DepthSlider;
   Qt::KeyboardModifier modifier4ZoomOut;
 


### PR DESCRIPTION
Before this commit, zooming always zooms into the center of the
view. After this commit, we zoom in such a way that the point under
the cursor represents the same location on the map before and after
the zoom. The imitates the behavior of most online mapping tools,
e.g. OpenStreetMaps.

The new zooming approach only applies when using the scroll wheel,
not when zooming with the keyboard. It is also dependent on a
QSetting. If desired, a future commit could expose this setting in
the GUI, making it possible to disable the new zoom behavior.

Fixes #294.