### PR TITLE
Fix modded biomes

### DIFF
--- a/definitions/readme_biomes.txt
+++ b/definitions/readme_biomes.txt
@@ -3,7 +3,50 @@ FAQ and detailed description for vanilla_biomes.json
 
 The biome definition file contains all data needed to describe available Biomes.
 
-Inside the "data" tag available biomes are defined:
+Starting with Minecraft 1.18 Biomes are stored as string. To be backwards compatible
+the new tag "data18" is used to define Biomes:
+
+  "data18": [
+    {
+      "id": "minecraft:ocean",
+      "name": "Ocean",
+      "color": "#000070"
+    },
+    {
+      "id": "minecraft:plains",
+      "color": "#8db360",
+      "temperature": 0.8,
+      "humidity": 0.4
+    },
+    [...]
+
+
+"id"    - the named string ID used by Minecraft
+"name"  - used for display purpose, can be ommited and will be guessed from "id"
+"color" - color used in Biome Overlay (e.g. AMIDST color code)
+ if color is omitted a pseudo random color is calculated based on the hashed name
+
+
+Some special values can be derived from the Minecraft source code:
+
+"watermodifier" - special color of water (in swamps)
+"temperature"   - default 0.5
+"humidity"      - default 0.5
+
+
+Some stuff is hard coded inside Minecraft source code. To handle these edge cases,
+some flags are guessed based on the name of a Biome. To override these guesses
+some additional boolean flags can be used:
+
+"ocean"      - used for Drawned spawn detection (guess trigger is "ocean")
+"river"      - used for Drawned spawn detection (guess trigger is "river")
+"swamp"      - used for hard coded foliage colors (guess trigger is "swamp")
+"darkforest" - used for hard coded foliage colors (guess trigger is "dark forest")
+"badlands"   - used for hard coded foliage colors (guess trigger is "badlands" and "mesa")
+
+
+For Minecraft up to 1.17 Biomes were stored as numerical ID for that we have
+the "data" tag to define Biomes:
 
   "data": [
     {
@@ -24,14 +67,7 @@ Inside the "data" tag available biomes are defined:
   ]
 
 "id"    - the SaveGameID used by Minecraft
-"color" - color used in Biome Overlay (e.g. AMIDST color code)
- if color is omitted a pseudo random color is calculated based on the hashed name
-
-some special values can be derived from the Minecraft source code:
-
-"watermodifier" - special color of water (in swamps)
-"temperature"   - default 0.5
-"humidity"      - default 0.5
+all others like with "data18"
 
 
 

--- a/identifier/biomeidentifier.cpp
+++ b/identifier/biomeidentifier.cpp
@@ -370,7 +370,7 @@ void BiomeIdentifier::parseBiomeDefinitions2800(JSONArray *data18, int pack) {
         biome->name = b->at("name")->asString();
       else {
         // construct the name from NID
-        QString nid = QString(biome->nid).replace("minecraft:","").replace("_"," ");
+        QString nid = QString(biome->nid).replace("minecraft:","").replace("_"," ").replace(":",": ");
         QStringList parts = nid.toLower().split(' ', QString::SkipEmptyParts);
         for (int i = 0; i < parts.size(); i++)
           parts[i].replace(0, 1, parts[i][0].toUpper());

--- a/identifier/biomeidentifier.cpp
+++ b/identifier/biomeidentifier.cpp
@@ -284,7 +284,8 @@ void BiomeIdentifier::guessSpecialBiomes(JSONObject *b, BiomeInfo *biome)
   }
   if (b->has("badlands")) {
     biome->badlands = b->at("badlands")->asBool();
-  } else if (biome->name.contains("badlands", Qt::CaseInsensitive)) {
+  } else if ((biome->name.contains("mesa", Qt::CaseInsensitive)) ||
+             (biome->name.contains("badlands", Qt::CaseInsensitive))) {
     biome->badlands = true;
   }
 }

--- a/identifier/biomeidentifier.cpp
+++ b/identifier/biomeidentifier.cpp
@@ -344,7 +344,6 @@ void BiomeIdentifier::parseBiomeDefinitions2800(JSONArray *data18, int pack) {
       BiomeInfo *biome = new BiomeInfo();
       biome->enabled = true;
       biome->nid = b->at("id")->asString();
-      biome->id = i;
 
       if (b->has("name"))
         biome->name = b->at("name")->asString();
@@ -438,6 +437,7 @@ void BiomeIdentifier::updateBiomeDefinition()
     for (int i = 0; i < packs18[pack].length(); i++) {
       BiomeInfo *bi = packs18[pack][i];
       if (bi->enabled) {
+        bi->id = biomes18.length();
         biomes18.append(bi);
       }
     }

--- a/identifier/biomeidentifier.cpp
+++ b/identifier/biomeidentifier.cpp
@@ -24,6 +24,9 @@ BiomeInfo::BiomeInfo()
   , enabled(false)
   , ocean(false)
   , river(false)
+  , swamp(false)
+  , darkforest(false)
+  , badlands(false)
   , temperature(0.5)
   , humidity(0.5)
   , enabledwatermodifier(false)
@@ -124,29 +127,27 @@ QColor BiomeInfo::mixColor( QColor colorizer, QColor blockcolor )
 QColor BiomeInfo::getBiomeGrassColor( QColor blockcolor, int elevation ) const
 {
   QColor colorizer;
-  // remove variants from ID
-  int id = this->id & 0x7f;
   // swampland
-  if (id == 6) {
+  if (this->swamp) {
     // perlin noise generator omitted due to performance reasons
     // otherwise the random temperature distribution selects
     // (below -0.1°C) ‭4C.76.3C‬ or ‭6A.70.39 (above -0.1°C)
     colorizer = QColor::fromRgb(0x6a,0x70,0x39);  // hard wired
   }
-  // roofed forest
-  else if (id == 29) {
+  // mesa / badlands
+  else if (this->badlands) {
+    colorizer = QColor::fromRgb(0x90,0x81,0x4d);  // hard wired
+  } else {
+    // standard way
     colorizer = getBiomeColor( this->temperature, this->humidity, elevation, grassCorners );
+  }
+  // dark forest
+  if (this->darkforest) {
     // average with 0x28340A
     colorizer.setRed  ( (colorizer.red()   + 0x28)>>1 );
     colorizer.setGreen( (colorizer.green() + 0x34)>>1 );
     colorizer.setBlue ( (colorizer.blue()  + 0x0A)>>1 );
   }
-  // mesa
-  else if ((id == 37) || (id == 38) || (id == 39)) {
-    colorizer = QColor::fromRgb(0x90,0x81,0x4d);  // hard wired
-  } else
-    // standard way
-    colorizer = getBiomeColor( this->temperature, this->humidity, elevation, grassCorners );
 
   return mixColor( colorizer, blockcolor );
 }
@@ -154,14 +155,12 @@ QColor BiomeInfo::getBiomeGrassColor( QColor blockcolor, int elevation ) const
 QColor BiomeInfo::getBiomeFoliageColor( QColor blockcolor, int elevation ) const
 {
   QColor colorizer;
-  // remove variants from ID
-  int id = this->id & 0x7f;
   // swampland
-  if (id == 6) {
+  if (this->swamp) {
     colorizer = QColor::fromRgb(0x6a,0x70,0x39);  // hard wired
   }
-  // mesa
-  else if ((id == 37) || (id == 38) || (id == 39)) {
+  // mesa / badlands
+  else if (this->badlands) {
     colorizer = QColor::fromRgb(0x9e,0x81,0x4d);  // hard wired
   } else
     // standard way
@@ -260,6 +259,36 @@ int BiomeIdentifier::addDefinitions(JSONArray *data, JSONArray *data18, int pack
   return pack;
 }
 
+// define some special Biome category by (optional) tag or guess from name
+void BiomeIdentifier::guessSpecialBiomes(JSONObject *b, BiomeInfo *biome)
+{
+  if (b->has("ocean")) {
+    biome->ocean = b->at("ocean")->asBool();
+  } else if (biome->name.contains("ocean", Qt::CaseInsensitive)) {
+    biome->ocean = true;
+  }
+  if (b->has("river")) {
+    biome->river = b->at("river")->asBool();
+  } else if (biome->name.contains("river", Qt::CaseInsensitive)) {
+    biome->river = true;
+  }
+  if (b->has("swamp")) {
+    biome->swamp = b->at("swamp")->asBool();
+  } else if (biome->name.contains("swamp", Qt::CaseInsensitive)) {
+    biome->swamp = true;
+  }
+  if (b->has("darkforest")) {
+    biome->darkforest = b->at("darkforest")->asBool();
+  } else if (biome->name.contains("dark forest", Qt::CaseInsensitive)) {
+    biome->darkforest = true;
+  }
+  if (b->has("badlands")) {
+    biome->badlands = b->at("badlands")->asBool();
+  } else if (biome->name.contains("badlands", Qt::CaseInsensitive)) {
+    biome->badlands = true;
+  }
+}
+
 // legacy Biome definitions before Cliffs & Caves (up to 1.17)
 void BiomeIdentifier::parseBiomeDefinitions0000(JSONArray *data, int pack) {
   int len = data->length();
@@ -274,17 +303,8 @@ void BiomeIdentifier::parseBiomeDefinitions0000(JSONArray *data, int pack) {
       if (b->has("name"))
         biome->name = b->at("name")->asString();
 
-      // define ocean / river Biome category by (optional) tag or guess from name
-      if (b->has("ocean")) {
-        biome->ocean = b->at("ocean")->asBool();
-      } else if (biome->name.contains("ocean", Qt::CaseInsensitive)) {
-        biome->ocean = true;
-      }
-      if (b->has("river")) {
-        biome->ocean = b->at("river")->asBool();
-      } else if (biome->name.contains("river", Qt::CaseInsensitive)) {
-        biome->river = true;
-      }
+      // define some special Biome category by (optional) tag or guess from name
+      guessSpecialBiomes(b, biome);
 
       // get temperature definition
       if (b->has("temperature"))
@@ -356,17 +376,8 @@ void BiomeIdentifier::parseBiomeDefinitions2800(JSONArray *data18, int pack) {
         biome->name = parts.join(" ");
       }
 
-      // define ocean / river Biome category by (optional) tag or guess from name
-      if (b->has("ocean")) {
-        biome->ocean = b->at("ocean")->asBool();
-      } else if (biome->name.contains("ocean", Qt::CaseInsensitive)) {
-        biome->ocean = true;
-      }
-      if (b->has("river")) {
-        biome->ocean = b->at("river")->asBool();
-      } else if (biome->name.contains("river", Qt::CaseInsensitive)) {
-        biome->river = true;
-      }
+      // define some special Biome category by (optional) tag or guess from name
+      guessSpecialBiomes(b, biome);
 
       // get temperature definition
       if (b->has("temperature"))

--- a/identifier/biomeidentifier.h
+++ b/identifier/biomeidentifier.h
@@ -7,6 +7,7 @@
 #include <QString>
 #include <QColor>
 class JSONArray;
+class JSONObject;
 
 
 class BiomeInfo {
@@ -28,6 +29,9 @@ class BiomeInfo {
   bool    enabled;
   bool    ocean;
   bool    river;
+  bool    swamp;
+  bool    darkforest;
+  bool    badlands;
   double  temperature;
   double  humidity;
   bool    enabledwatermodifier;
@@ -69,6 +73,7 @@ private:
 
   void parseBiomeDefinitions0000(JSONArray *data, int pack);
   void parseBiomeDefinitions2800(JSONArray *data18, int pack);
+  void guessSpecialBiomes(JSONObject *b, BiomeInfo *biome);
 
   // legacy Biomes
   QHash<int, BiomeInfo*>    biomes;   // consolidated Biome mapping


### PR DESCRIPTION
fixes #298 

* When using multiple Biome definitions (packs) the index was not guaranteed to be unique, but starting from 0 for each pack.
* Also fix the use of hard encoded Biome IDs for special Biome detection. This was needed for the old format, but does not work after the Cliffs & Caves update.
* update readme for format of Biome definition files
* better way to construct display name out of string ID of Biome (in case of data pack/modded Biomes)