### PR TITLE
use QPalette::Base color as backround when nothing to draw

### DIFF
--- a/mapview.cpp
+++ b/mapview.cpp
@@ -364,6 +364,7 @@ void MapView::redraw() {
   if (!this->isEnabled()) {
     // blank
     imageChunks.fill(palette().color(QPalette::Base));
+    imageOverlays.fill(Qt::transparent);
     update();
     return;
   }

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -363,7 +363,7 @@ void MapView::paintEvent(QPaintEvent * /* event */) {
 void MapView::redraw() {
   if (!this->isEnabled()) {
     // blank
-    imageChunks.fill(0xeeeeee);
+    imageChunks.fill(palette().color(QPalette::Base));
     update();
     return;
   }


### PR DESCRIPTION
just a cosmetic changes making the app look better with dark themes on Linux, see attached screenshot
![Screenshot_20220610_013352](https://user-images.githubusercontent.com/947647/172962812-186f4186-2767-4b50-acc2-739abb597087.png)
the second commit fixes little artifacts noticeable in the top left corner on the screenshot above