### PR TITLE
drop unncessary attributes in .ui files

### DIFF
--- a/minutor.ui
+++ b/minutor.ui
@@ -10,9 +10,6 @@
     <height>450</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>MainWindow</string>
-  </property>
   <widget class="QWidget" name="centralwidget"/>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
@@ -75,8 +72,6 @@
     <property name="title">
      <string>&amp;Overlay</string>
     </property>
-    <addaction name="separator"/>
-    <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="menu_Search">
     <property name="title">

--- a/overlay/properties.ui
+++ b/overlay/properties.ui
@@ -26,9 +26,6 @@
      <property name="columnCount">
       <number>2</number>
      </property>
-     <attribute name="headerVisible">
-      <bool>true</bool>
-     </attribute>
      <attribute name="headerMinimumSectionSize">
       <number>25</number>
      </attribute>

--- a/search/searchchunkswidget.ui
+++ b/search/searchchunkswidget.ui
@@ -10,9 +10,6 @@
     <height>703</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="plugin_context">
@@ -84,11 +81,7 @@
          </layout>
         </item>
         <item row="4" column="1">
-         <widget class="QProgressBar" name="progressBar">
-          <property name="value">
-           <number>0</number>
-          </property>
-         </widget>
+         <widget class="QProgressBar" name="progressBar"/>
         </item>
         <item row="4" column="0">
          <widget class="QPushButton" name="pb_search">

--- a/search/searchresultwidget.ui
+++ b/search/searchresultwidget.ui
@@ -10,9 +10,6 @@
     <height>300</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
     <number>0</number>

--- a/search/searchtextwidget.ui
+++ b/search/searchtextwidget.ui
@@ -10,9 +10,6 @@
     <height>25</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="leftMargin">
     <number>0</number>


### PR DESCRIPTION
- window title for custom widgets (aka "Form"). it is meaningless and never visible, so useless
- modified but has default value attributes. just to not keep extra info in UI XML files and easy to find changed properties in creator

just a cleanup, no any logic or visual changes