### PR TITLE
Fix PNG export ranges

### DIFF
--- a/pngexport.cpp
+++ b/pngexport.cpp
@@ -50,23 +50,27 @@ void PngExport::setBoundsFromChunks(int top, int left, int bottom, int right)
 
 void PngExport::setBoundsFromBlocks(int top, int left, int bottom, int right)
 {
-  // extend to next region boundary
+  // restrict range of spin boxes to world dimension
+  // -> extend to next region boundary
   int e_top    = 512* std::floor(float(top)/512.0);
   int e_left   = 512* std::floor(float(left)/512.0);
   int e_bottom = 512*(std::floor(float(bottom)/512.0) +1) -1;
   int e_right  = 512*(std::floor(float(right)/512.0) +1) -1;
-
-  // restrict range of spin boxes to world dimension
   ui->spinBox_top   ->setRange(e_top, e_bottom-(snapDistance-1));
   ui->spinBox_left  ->setRange(e_left, e_right-(snapDistance-1));
   ui->spinBox_bottom->setRange(e_top+(snapDistance-1), e_bottom);
   ui->spinBox_right ->setRange(e_left+(snapDistance-1), e_right);
 
   // initialize spin boxes to complete world dimension
-  ui->spinBox_top   ->setValue(top);
-  ui->spinBox_left  ->setValue(left);
-  ui->spinBox_bottom->setValue(bottom);
-  ui->spinBox_right ->setValue(right);
+  // -> extended to next snapDistance
+  e_top    = snapDistance* std::floor(float(top)/float(snapDistance));
+  e_left   = snapDistance* std::floor(float(left)/float(snapDistance));
+  e_bottom = snapDistance*(std::floor(float(bottom)/float(snapDistance)) +1) -1;
+  e_right  = snapDistance*(std::floor(float(right)/float(snapDistance)) +1) -1;
+  ui->spinBox_top   ->setValue(e_top);
+  ui->spinBox_left  ->setValue(e_left);
+  ui->spinBox_bottom->setValue(e_bottom);
+  ui->spinBox_right ->setValue(e_right);
 }
 
 

--- a/pngexport.cpp
+++ b/pngexport.cpp
@@ -73,6 +73,18 @@ void PngExport::setBoundsFromBlocks(int top, int left, int bottom, int right)
   ui->spinBox_right ->setValue(e_right);
 }
 
+QString PngExport::getLabelText(int value)
+{
+  QString text;
+  if (snapDistance == 16) {
+    text = "C: " + QString::number(value >> 4);
+  }
+  if (snapDistance == 512) {
+    text = "R: " + QString::number(value >> 9);
+  }
+  return text;
+}
+
 
 void PngExport::checkTop(int value)
 {
@@ -80,6 +92,8 @@ void PngExport::checkTop(int value)
   ui->spinBox_top->setValue(value);
   if (value+(snapDistance-1) > ui->spinBox_bottom->value())
     ui->spinBox_bottom->setValue(value+(snapDistance-1));
+  // update Chunk/Region label
+  ui->label_top->setText(getLabelText(value));
 }
 
 void PngExport::checkLeft(int value)
@@ -88,6 +102,8 @@ void PngExport::checkLeft(int value)
   ui->spinBox_left->setValue(value);
   if (value+(snapDistance-1) > ui->spinBox_right->value())
     ui->spinBox_right->setValue(value+(snapDistance-1));
+  // update Chunk/Region label
+  ui->label_left->setText(getLabelText(value));
 }
 
 void PngExport::checkBottom(int value)
@@ -96,6 +112,8 @@ void PngExport::checkBottom(int value)
   ui->spinBox_bottom->setValue(value);
   if (value-(snapDistance-1) < ui->spinBox_top->value())
     ui->spinBox_top->setValue(value-(snapDistance-1));
+  // update Chunk/Region label
+  ui->label_bottom->setText(getLabelText(value));
 }
 
 void PngExport::checkRight(int value)
@@ -104,6 +122,8 @@ void PngExport::checkRight(int value)
   ui->spinBox_right->setValue(value);
   if (value-(snapDistance-1) < ui->spinBox_left->value())
     ui->spinBox_left->setValue(value-(snapDistance-1));
+  // update Chunk/Region label
+  ui->label_right->setText(getLabelText(value));
 }
 
 void PngExport::setSingleStep()

--- a/pngexport.h
+++ b/pngexport.h
@@ -38,6 +38,8 @@ private slots:
   void checkBottom(int value);
   void checkRight(int value);
 
+  QString getLabelText(int value);
+
   void setSingleStep();
 };
 

--- a/pngexport.ui
+++ b/pngexport.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>240</width>
-    <height>303</height>
+    <width>246</width>
+    <height>302</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -43,20 +43,34 @@
          </spacer>
         </item>
         <item>
-         <widget class="QSpinBox" name="spinBox_top">
-          <property name="keyboardTracking">
-           <bool>false</bool>
-          </property>
-          <property name="minimum">
-           <number>-4096</number>
-          </property>
-          <property name="maximum">
-           <number>4095</number>
-          </property>
-          <property name="singleStep">
-           <number>16</number>
-          </property>
-         </widget>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <widget class="QSpinBox" name="spinBox_top">
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
+            <property name="minimum">
+             <number>-4096</number>
+            </property>
+            <property name="maximum">
+             <number>4095</number>
+            </property>
+            <property name="singleStep">
+             <number>16</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_top">
+            <property name="text">
+             <string>TextLabel</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <spacer name="horizontalSpacer_2">
@@ -103,20 +117,34 @@
          </spacer>
         </item>
         <item>
-         <widget class="QSpinBox" name="spinBox_left">
-          <property name="keyboardTracking">
-           <bool>false</bool>
-          </property>
-          <property name="minimum">
-           <number>-4096</number>
-          </property>
-          <property name="maximum">
-           <number>4095</number>
-          </property>
-          <property name="singleStep">
-           <number>16</number>
-          </property>
-         </widget>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="QSpinBox" name="spinBox_left">
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
+            <property name="minimum">
+             <number>-4096</number>
+            </property>
+            <property name="maximum">
+             <number>4095</number>
+            </property>
+            <property name="singleStep">
+             <number>16</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_left">
+            <property name="text">
+             <string>TextLabel</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <spacer name="horizontalSpacer_5">
@@ -132,22 +160,6 @@
          </spacer>
         </item>
         <item>
-         <widget class="QSpinBox" name="spinBox_right">
-          <property name="keyboardTracking">
-           <bool>false</bool>
-          </property>
-          <property name="minimum">
-           <number>-4096</number>
-          </property>
-          <property name="maximum">
-           <number>4095</number>
-          </property>
-          <property name="singleStep">
-           <number>16</number>
-          </property>
-         </widget>
-        </item>
-        <item>
          <spacer name="horizontalSpacer_4">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -159,6 +171,36 @@
            </size>
           </property>
          </spacer>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <item>
+           <widget class="QSpinBox" name="spinBox_right">
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
+            <property name="minimum">
+             <number>-4096</number>
+            </property>
+            <property name="maximum">
+             <number>4095</number>
+            </property>
+            <property name="singleStep">
+             <number>16</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_right">
+            <property name="text">
+             <string>TextLabel</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <widget class="QLabel" name="label_4">
@@ -192,20 +234,34 @@
          </spacer>
         </item>
         <item>
-         <widget class="QSpinBox" name="spinBox_bottom">
-          <property name="keyboardTracking">
-           <bool>false</bool>
-          </property>
-          <property name="minimum">
-           <number>-4096</number>
-          </property>
-          <property name="maximum">
-           <number>4095</number>
-          </property>
-          <property name="singleStep">
-           <number>16</number>
-          </property>
-         </widget>
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <item>
+           <widget class="QSpinBox" name="spinBox_bottom">
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
+            <property name="minimum">
+             <number>-4096</number>
+            </property>
+            <property name="maximum">
+             <number>4095</number>
+            </property>
+            <property name="singleStep">
+             <number>16</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_bottom">
+            <property name="text">
+             <string>TextLabel</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <spacer name="horizontalSpacer_7">
@@ -233,53 +289,57 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="title">
-      <string>Snap to</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_4">
-      <item>
-       <widget class="QRadioButton" name="radioButton_chunk">
-        <property name="text">
-         <string>Chunk</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="radioButton_region">
-        <property name="text">
-         <string>Region</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Checkerboard pattern</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="QCheckBox" name="checkBox_chunk">
-        <property name="text">
-         <string>Chunks</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="checkBox_region">
-        <property name="text">
-         <string>Regions</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QGroupBox" name="groupBox_3">
+       <property name="title">
+        <string>Snap to</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_8">
+        <item>
+         <widget class="QRadioButton" name="radioButton_chunk">
+          <property name="text">
+           <string>Chunk</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioButton_region">
+          <property name="text">
+           <string>Region</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="title">
+        <string>Checkerboard pattern</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QCheckBox" name="checkBox_chunk">
+          <property name="text">
+           <string>Chunks</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="checkBox_region">
+          <property name="text">
+           <string>Regions</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
We had a rounding issue when creating the PNG export dialog. The position might be one snap position off the correct one.
Now the next possible "outer" snap position is calculated and used.

Might be related to #289. Add labels that show the Block positions as Chunk or Region index (based on current snap mode):
![grafik](https://user-images.githubusercontent.com/5821779/173130541-5eaa3954-fa3d-4147-8b5e-927e7c5c8e7a.png)

