### PR TITLE
marked a lot of getters in BlockInfo/BlockIdentifier const

### DIFF
--- a/chunkrenderer.cpp
+++ b/chunkrenderer.cpp
@@ -84,7 +84,7 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
         }
 
         // get BlockInfo from block value
-        BlockInfo &block = BlockIdentifier::Instance().getBlockInfo(section->getPaletteEntry(offset, y).hid);
+        const BlockInfo &block = BlockIdentifier::Instance().getBlockInfo(section->getPaletteEntry(offset, y).hid);
         if (block.alpha == 0.0) continue;
 
         if (this->flags & MapView::flgSeaGround && block.isLiquid()) continue;
@@ -157,10 +157,10 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
           if (sectionB) {
             blidB = sectionB->getPaletteEntry(offset, y-1).hid;
           }
-          BlockInfo &block2 = BlockIdentifier::Instance().getBlockInfo(blid2);
-          BlockInfo &block1 = BlockIdentifier::Instance().getBlockInfo(blid1);
-          BlockInfo &block0 = block;
-          BlockInfo &blockB = BlockIdentifier::Instance().getBlockInfo(blidB);
+          const BlockInfo &block2 = BlockIdentifier::Instance().getBlockInfo(blid2);
+          const BlockInfo &block1 = BlockIdentifier::Instance().getBlockInfo(blid1);
+          const BlockInfo &block0 = block;
+          const BlockInfo &blockB = BlockIdentifier::Instance().getBlockInfo(blidB);
           int light0 = section->getBlockLight(offset, y);
 
            // spawn check #1: on top of solid block
@@ -275,7 +275,7 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
           const ChunkSection *section = chunk->getSectionByY(y);
           if (!section) continue;
           // get BlockInfo from block value
-          BlockInfo &block = BlockIdentifier::Instance().getBlockInfo(section->getPaletteEntry(offset, y).hid);
+          const BlockInfo &block = BlockIdentifier::Instance().getBlockInfo(section->getPaletteEntry(offset, y).hid);
           if (block.transparent) {
             cave_factor -= CaveShade::getShade(cave_test);
           }

--- a/identifier/blockidentifier.cpp
+++ b/identifier/blockidentifier.cpp
@@ -70,16 +70,16 @@ void BlockInfo::setName(const QString & newname) {
          || this->name.contains("Bubble_Column", Qt::CaseInsensitive);
 }
 
-const QString & BlockInfo::getName() { return name; }
+const QString & BlockInfo::getName() const { return name; }
 
 
-bool BlockInfo::isBedrock()  { return bedrock; }
-bool BlockInfo::isHopper()   { return hopper; }
-bool BlockInfo::isSnow()     { return snow; }
+bool BlockInfo::isBedrock() const  { return bedrock; }
+bool BlockInfo::isHopper() const   { return hopper; }
+bool BlockInfo::isSnow() const     { return snow; }
 
-bool BlockInfo::biomeWater()   { return water; }
-bool BlockInfo::biomeGrass()   { return grass; }
-bool BlockInfo::biomeFoliage() { return foliage; }
+bool BlockInfo::biomeWater() const   { return water; }
+bool BlockInfo::biomeGrass() const   { return grass; }
+bool BlockInfo::biomeFoliage() const { return foliage; }
 
 void BlockInfo::setBiomeGrass(bool value)   { grass = value; }
 void BlockInfo::setBiomeFoliage(bool value) { foliage = value; }
@@ -109,7 +109,7 @@ BlockIdentifier& BlockIdentifier::Instance() {
   return singleton;
 }
 
-BlockInfo &BlockIdentifier::getBlockInfo(uint hid) {
+const BlockInfo &BlockIdentifier::getBlockInfo(uint hid) const {
   auto iter = blocks.find(hid);
   if (iter != blocks.end())
     return *iter.value();
@@ -117,7 +117,7 @@ BlockInfo &BlockIdentifier::getBlockInfo(uint hid) {
   return unknownBlock;
 }
 
-bool BlockIdentifier::hasBlockInfo(uint hid) {
+bool BlockIdentifier::hasBlockInfo(uint hid) const {
   return blocks.contains(hid);
 }
 

--- a/identifier/blockidentifier.h
+++ b/identifier/blockidentifier.h
@@ -27,21 +27,21 @@ class BlockInfo {
   bool canProvidePower() const;
 
   // special block type used during mob spawning detection
-  bool isBedrock();
-  bool isHopper();
-  bool isStairs();
-  bool isHalfSlab();
-  bool isSnow();
+  bool isBedrock() const;
+  bool isHopper() const;
+  bool isStairs() const;
+  bool isHalfSlab() const;
+  bool isSnow() const;
 
   // special blocks with Biome based Grass, Foliage and Water colors
-  bool biomeWater();
-  bool biomeGrass();
-  bool biomeFoliage();
+  bool biomeWater() const;
+  bool biomeGrass() const;
+  bool biomeFoliage() const;
 
   void setName(const QString &newname);
   void setBiomeGrass(bool value);
   void setBiomeFoliage(bool value);
-  const QString &getName();
+  const QString &getName() const;
 
   // enabled for complete definition pack
   bool    enabled;
@@ -77,8 +77,8 @@ class BlockIdentifier {
   int  addDefinitions(JSONArray *, int pack = -1);
   void enableDefinitions(int id);
   void disableDefinitions(int id);
-  BlockInfo &getBlockInfo(uint hid);
-  bool       hasBlockInfo(uint hid);
+  const BlockInfo &getBlockInfo(uint hid) const;
+  bool             hasBlockInfo(uint hid) const;
 
   QList<quint32> getKnownIds() const;
 


### PR DESCRIPTION
mostly cosmetic change rather than something practical, just to follow style. in most places getters are const as they should be, only these 2 classes I found had "unusual" getters (not market as const but const by its nature as it should be)
also, returning non-const references is considered bad practice, and should be avoided, even the Google Code Style Guide that projects follows (as written in README) states that.