### PR TITLE
Search Dialog layout improvement

### DIFF
--- a/minutor.cpp
+++ b/minutor.cpp
@@ -877,12 +877,14 @@ SearchChunksWidget* Minutor::prepareSearchForm(const QSharedPointer<SearchPlugin
 void Minutor::openSearchBlockWidget() {
   auto searchPlugin = QSharedPointer<SearchBlockPluginWidget>::create();
   auto searchBlockForm = prepareSearchForm(searchPlugin);
+  searchBlockForm->setWindowTitle(m_ui.action_SearchBlock->statusTip());
   searchBlockForm->showNormal();
 }
 
 void Minutor::openSearchEntityWidget() {
   auto searchPlugin = QSharedPointer<SearchEntityPluginWidget>::create();
   auto searchEntityForm = prepareSearchForm(searchPlugin);
+  searchEntityForm->setWindowTitle(m_ui.action_SearchEntity->statusTip());
   searchEntityForm->showNormal();
 }
 

--- a/search/searchchunkswidget.cpp
+++ b/search/searchchunkswidget.cpp
@@ -11,7 +11,7 @@
 #include <QtConcurrent/QtConcurrent>
 
 SearchChunksWidget::SearchChunksWidget(QSharedPointer<SearchPluginI> searchPlugin_, QWidget *parent)
-  : QWidget(parent)
+  : QDialog(parent)
   , ui(new Ui::SearchChunksWidget)
   , searchPlugin(searchPlugin_)
 {

--- a/search/searchchunkswidget.cpp
+++ b/search/searchchunkswidget.cpp
@@ -18,6 +18,7 @@ SearchChunksWidget::SearchChunksWidget(QSharedPointer<SearchPluginI> searchPlugi
   ui->setupUi(this);
 
   auto layout = new QHBoxLayout(ui->plugin_context);
+  layout->setContentsMargins(0, 0, 0, 0);
   ui->plugin_context->setLayout(layout);
   layout->setSizeConstraint(QLayout::SizeConstraint::SetMinimumSize);
   layout->addWidget(&searchPlugin->getWidget());

--- a/search/searchchunkswidget.h
+++ b/search/searchchunkswidget.h
@@ -8,7 +8,7 @@
 #include "search/searchplugininterface.h"
 #include "chunkid.h"
 
-#include <QWidget>
+#include <QDialog>
 #include <QFuture>
 #include <QVector3D>
 
@@ -22,7 +22,7 @@ class ChunkCache;
 class Chunk;
 class SearchResultWidget;
 
-class SearchChunksWidget : public QWidget
+class SearchChunksWidget : public QDialog
 {
   Q_OBJECT
 

--- a/search/searchchunkswidget.ui
+++ b/search/searchchunkswidget.ui
@@ -13,11 +13,11 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="plugin_context">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="title">
       <string>Search for:</string>
@@ -26,71 +26,95 @@
    </item>
    <item>
     <widget class="QGroupBox" name="groupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="title">
       <string>Search in:</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QFormLayout" name="formLayout">
-        <item row="1" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Radius</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QSpinBox" name="sb_radius">
-          <property name="maximum">
-           <number>999999999</number>
-          </property>
-          <property name="value">
-           <number>2000</number>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QCheckBox" name="check_range_y">
-          <property name="text">
-           <string>Range Y</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <item>
-           <widget class="QSpinBox" name="sb_y_start">
-            <property name="minimum">
-             <number>-999999999</number>
-            </property>
-            <property name="maximum">
-             <number>999999999</number>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="sb_y_end">
-            <property name="minimum">
-             <number>-999999999</number>
-            </property>
-            <property name="maximum">
-             <number>999999999</number>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="4" column="1">
-         <widget class="QProgressBar" name="progressBar"/>
-        </item>
-        <item row="4" column="0">
-         <widget class="QPushButton" name="pb_search">
-          <property name="text">
-           <string>Search</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Radius</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="sb_radius">
+        <property name="maximum">
+         <number>999999999</number>
+        </property>
+        <property name="value">
+         <number>2000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="3">
+       <widget class="QCheckBox" name="check_range_y">
+        <property name="text">
+         <string>Range Y</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QSpinBox" name="sb_y_start">
+        <property name="minimum">
+         <number>-999999999</number>
+        </property>
+        <property name="maximum">
+         <number>999999999</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <widget class="QSpinBox" name="sb_y_end">
+        <property name="minimum">
+         <number>-999999999</number>
+        </property>
+        <property name="maximum">
+         <number>999999999</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="6">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>30</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="7">
+       <widget class="QPushButton" name="pb_search">
+        <property name="text">
+         <string>Search</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="8">
+       <widget class="QProgressBar" name="progressBar"/>
       </item>
      </layout>
     </widget>

--- a/search/searchchunkswidget.ui
+++ b/search/searchchunkswidget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>SearchChunksWidget</class>
- <widget class="QWidget" name="SearchChunksWidget">
+ <widget class="QDialog" name="SearchChunksWidget">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/search/searchtextwidget.ui
+++ b/search/searchtextwidget.ui
@@ -10,7 +10,7 @@
     <height>25</height>
    </rect>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,4,0">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -32,12 +32,6 @@
    </item>
    <item>
     <widget class="QComboBox" name="comboBox_text">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
      <property name="editable">
       <bool>true</bool>
      </property>


### PR DESCRIPTION
layout only changes, no logic changed:
- completely new "Search in" block layout
- improved (padding and alignment) "Search for" layout
- set title for search dialogs

macOS
<img width="400" alt="Screenshot 2022-06-12 at 12 19 07" src="https://user-images.githubusercontent.com/947647/173229790-5009529c-ac33-48e6-a9f9-5d68ddc250e5.png"> <img width="400" alt="Screenshot 2022-06-12 at 12 19 30" src="https://user-images.githubusercontent.com/947647/173229792-98114ad1-fd19-4437-8aea-367a47d550e5.png">

Linux (KDE)
<img width="400" alt="Screenshot_20220612_123832" src="https://user-images.githubusercontent.com/947647/173229794-843ac1ea-075b-4fb3-8a6a-a81aeb1108a1.png"> <img width="400" alt="Screenshot_20220612_123902" src="https://user-images.githubusercontent.com/947647/173229795-299c31ee-8991-4c3d-9fe9-b825296b87b9.png">
