### PR TITLE
don't set custom font size for search results widget

### DIFF
--- a/search/searchresultwidget.ui
+++ b/search/searchresultwidget.ui
@@ -68,11 +68,6 @@
    </item>
    <item>
     <widget class="QTreeWidget" name="treeWidget">
-     <property name="font">
-      <font>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
      <property name="rootIsDecorated">
       <bool>false</bool>
      </property>


### PR DESCRIPTION
use default font in search results window. now it is too small (especially noticeable in macOS)

<img width="400" alt="Screenshot 2022-06-12 at 12 19 07" src="https://user-images.githubusercontent.com/947647/173230086-56de90a7-2153-4e2c-bc5c-e055ce56e91c.png"> <img width="400" alt="Screenshot 2022-06-12 at 12 21 09" src="https://user-images.githubusercontent.com/947647/173230087-f1101a28-426d-4b26-9354-c7db206649ee.png">

<img width="400" alt="Screenshot_20220612_123832" src="https://user-images.githubusercontent.com/947647/173230126-370764a9-ebe8-40ff-baf5-3668d8ed3f1b.png"> <img width="400" alt="Screenshot_20220612_124023" src="https://user-images.githubusercontent.com/947647/173230127-1513657c-ee79-45d0-82a7-1ec5bc9cbfae.png">