### PR TITLE
Fix macOS modifier keys

### DIFF
--- a/mapview.cpp
+++ b/mapview.cpp
@@ -270,15 +270,18 @@ void MapView::wheelEvent(QWheelEvent *event) {
   Qt::KeyboardModifier modifier4DepthSlider = Qt::KeyboardModifier(QSettings().value("modifier4DepthSlider", Qt::ShiftModifier).toUInt());
   Qt::KeyboardModifier modifier4ZoomOut     = Qt::KeyboardModifier(QSettings().value("modifier4ZoomOut",     Qt::ControlModifier).toUInt());
 
+  // ignore if vertical/horizontal scroll wheel was used
+  float angle = (event->angleDelta().x() + event->angleDelta().y()) / 120.0;
+
   if ((event->modifiers() & modifier4DepthSlider) == modifier4DepthSlider) {
     // change depth
-    emit demandDepthChange(event->angleDelta().y() / 120.0);
+    emit demandDepthChange(angle);
   } else if ((event->modifiers() & modifier4ZoomOut) == modifier4ZoomOut) {
     // allow change zoom also to zoom OUT
-    adjustZoom(event->angleDelta().y() / 120.0, true, true);
+    adjustZoom(angle, true, true);
   } else {
     // normal change zoom
-    adjustZoom(event->angleDelta().y() / 120.0, false, true);
+    adjustZoom(angle, false, true);
   }
 }
 

--- a/settings.cpp
+++ b/settings.cpp
@@ -7,6 +7,15 @@
 
 Settings::Settings(QWidget *parent) : QDialog(parent) {
   m_ui.setupUi(this);
+
+  // macOS dependand button renaming
+  #ifdef Q_OS_MAC
+  m_ui.radioButton_depth_ctrl->setText("Command");
+  m_ui.radioButton_depth_alt ->setText("Option");
+  m_ui.radioButton_zoom_ctrl ->setText("Command");
+  m_ui.radioButton_zoom_alt  ->setText("Option");
+  #endif
+
   // remove "question mark" in title bar
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 

--- a/settings.cpp
+++ b/settings.cpp
@@ -61,8 +61,8 @@ Settings::Settings(QWidget *parent) : QDialog(parent) {
   autoUpdate    = info.value("autoupdate", true).toBool();
   verticalDepth = info.value("verticaldepth", true).toBool();
   zoomFollowsCursor = info.value("zoomFollowsCursor", true).toBool();
-  modifier4DepthSlider = Qt::KeyboardModifier(info.value("modifier4DepthSlider", 0x02000000).toUInt());
-  modifier4ZoomOut     = Qt::KeyboardModifier(info.value("modifier4ZoomOut",     0x04000000).toUInt());
+  modifier4DepthSlider = Qt::KeyboardModifier(info.value("modifier4DepthSlider", Qt::ShiftModifier  ).toUInt());
+  modifier4ZoomOut     = Qt::KeyboardModifier(info.value("modifier4ZoomOut",     Qt::ControlModifier).toUInt());
 
   // Set the UI to the current settings' values:
   m_ui.lineEdit_Location->setText(mcpath);


### PR DESCRIPTION
ignore if vertical or horizontal scroll wheel was used when processing scroll wheel events

modifier keys have different name on macOS, so rename the text to reflect that

is part of #319