### PR TITLE
don't allow to resize JumpTo dialog, it is useless

### DIFF
--- a/jumpto.ui
+++ b/jumpto.ui
@@ -14,6 +14,9 @@
    <string>Location</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
+   </property>
    <item>
     <layout class="QGridLayout" name="gridLayout" columnstretch="0,2,1,2">
      <item row="0" column="1">


### PR DESCRIPTION
just a small cosmetic change, nothing more.
there are no any benefits to have this particular dialog resizable, even it looks strange somehow. and it costs nothing to disable it (just change one property), so why not?

dialog size will be set to `sizeHint()` , so it always will have sufficient size, no worries. even this size depends on platform / theme / some other platform-specific look and feel settings.