### PR TITLE
macOS memory management

### DIFF
--- a/chunkcache.cpp
+++ b/chunkcache.cpp
@@ -8,6 +8,9 @@
 #include <unistd.h>
 #elif defined(_WIN32) || defined(WIN32)
 #include <windows.h>
+#elif __APPLE__
+#include <unistd.h>
+#include <sys/sysctl.h>
 #endif
 
 ChunkCache::ChunkCache() {
@@ -32,6 +35,12 @@ ChunkCache::ChunkCache() {
   status.dwLength = sizeof(status);
   GlobalMemoryStatusEx(&status);
   DWORDLONG available = qMin(status.ullAvailPhys, status.ullAvailVirtual);
+  chunks   = available / sizeChunkMax;
+  maxcache = available / sizeChunkTypical;  // most chunks are less filled with sections
+#elif __APPLE__
+  uint64_t available;
+  size_t len = sizeof(available);
+  sysctlbyname("hw.memsize", &available, &len, NULL, 0);
   chunks   = available / sizeChunkMax;
   maxcache = available / sizeChunkTypical;  // most chunks are less filled with sections
 #endif


### PR DESCRIPTION
macOS does not set `unix` during precompilation, so on a Mac, Minutor was always using a cache of 10,000 chunks. This PR reads the Mac's physical memory size and computes the cache from that instead.

This improves the behavior of https://github.com/mrkite/minutor/issues/319 (but does not completely address it).
