### PR TITLE
extend number of usable Biomes to 16bit

### DIFF
--- a/chunk.cpp
+++ b/chunk.cpp
@@ -591,7 +591,7 @@ bool Chunk::loadSection_decodeBiomePalette(ChunkSection * cs, const Tag * biomes
     for (int j = 0; j < biomePaletteLength; j++) {
       biomePalette[j].name = paletteTag->at(j)->toString();
       // query BiomeIdentifer for that Biome
-      quint8 bID = bi.getBiome(biomePalette[j].name).id;
+      quint32 bID = bi.getBiomeByName(biomePalette[j].name).id;
       // get name and hash it to hid
       biomePalette[j].hid  = bID;
     }
@@ -658,20 +658,20 @@ const PaletteEntry & ChunkSection::getPaletteEntry(int offset) const {
     return blockPalette[0];
 }
 
-quint8 ChunkSection::getBiome(int x, int y, int z) const {
+quint16 ChunkSection::getBiome(int x, int y, int z) const {
   int xoffset = x;
   int yoffset = (y & 0x0f) << 8;
   int zoffset = z << 4;
   return getBiome(xoffset + yoffset + zoffset);
 }
 
-quint8 ChunkSection::getBiome(int offset, int y) const {
+quint16 ChunkSection::getBiome(int offset, int y) const {
   int yoffset = (y & 0x0f) << 8;
   return getBiome(offset + yoffset);
 }
 
 inline
-quint8 ChunkSection::getBiome(int offset) const {
+quint16 ChunkSection::getBiome(int offset) const {
   return biomes[offset];
 }
 

--- a/chunk.h
+++ b/chunk.h
@@ -19,9 +19,9 @@ class ChunkSection {
   const PaletteEntry & getPaletteEntry(int x, int y, int z) const;
   const PaletteEntry & getPaletteEntry(int offset, int y) const;
   const PaletteEntry & getPaletteEntry(int offset) const;
-  quint8 getBiome(int x, int y, int z) const;
-  quint8 getBiome(int offset, int y) const;
-  quint8 getBiome(int offset) const;
+  quint16 getBiome(int x, int y, int z) const;
+  quint16 getBiome(int offset, int y) const;
+  quint16 getBiome(int offset) const;
   //quint8 getSkyLight(int x, int y, int z);
   //quint8 getSkyLight(int offset, int y);
   //quint8 getSkyLight(int offset);
@@ -34,7 +34,7 @@ class ChunkSection {
   bool       blockPaletteIsShared;
 
   quint16 blocks[16*16*16];       // index into blockPalette for each Block
-  quint8  biomes[4*4*4];          // key into BiomeIdentifer for each 4x4x4 volume of Blocks defining the Biome
+  quint16 biomes[4*4*4];          // key into BiomeIdentifer for each 4x4x4 volume of Blocks defining the Biome
 //quint8  skyLight[16*16*16/2];   // not needed in Minutor
   quint8  blockLight[16*16*16/2]; // light value for each Block
 };
@@ -85,7 +85,7 @@ class Chunk : public QObject {
   long long inhabitedTime;
 
   QMap<qint8, ChunkSection*> sections;
-  qint32 biomes[16 * 16 * 4];
+  qint32 biomes[16 * 16 * 4]; // before "The Flattining" it was 1*16*16*Bytes, then it got 16*4*4*4*Int before it moved into Sections
   uchar  image[16 * 16 * 4];  // cached render: RGBA for 16*16 Blocks
   short  depth[16 * 16];      // cached depth map to create shadow
   EntityMap entities;

--- a/chunkrenderer.cpp
+++ b/chunkrenderer.cpp
@@ -111,8 +111,8 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
 
         // get Biome
         const BiomeInfo &biome = (chunk->version >=2800) ?
-            BiomeIdentifier::Instance().getBiome((quint8)chunk->getBiomeID(x,y,z)) :
-            BiomeIdentifier::Instance().getBiome((qint32)chunk->getBiomeID(x,y,z));
+            BiomeIdentifier::Instance().getBiomeBySection(chunk->getBiomeID(x,y,z)) :
+            BiomeIdentifier::Instance().getBiomeByChunk  (chunk->getBiomeID(x,y,z));
         // get current block color
         QColor blockcolor = block.colors[15];  // get the color from Block definition
         if (block.biomeWater()) {

--- a/identifier/biomeidentifier.cpp
+++ b/identifier/biomeidentifier.cpp
@@ -202,7 +202,7 @@ BiomeIdentifier& BiomeIdentifier::Instance() {
 }
 
 // legacy Biomes
-const BiomeInfo &BiomeIdentifier::getBiome(int id) const {
+const BiomeInfo &BiomeIdentifier::getBiomeByChunk(qint32 id) const {
   auto itr = this->biomes.find(id);
   if (itr == this->biomes.end()) {
     return unknownBiome;
@@ -212,14 +212,14 @@ const BiomeInfo &BiomeIdentifier::getBiome(int id) const {
 }
 
 // new Biomes after Cliffs & Caves update (1.18)
-const BiomeInfo &BiomeIdentifier::getBiome(quint8 id) const {
+const BiomeInfo &BiomeIdentifier::getBiomeBySection(qint32 id) const {
   if (id < this->biomes18.length())
     return *(this->biomes18.at(id));
   else
     return unknownBiome;
 }
 
-const BiomeInfo &BiomeIdentifier::getBiome(QString id) const {
+const BiomeInfo &BiomeIdentifier::getBiomeByName(QString id) const {
   for (const BiomeInfo* biome : this->biomes18) {
     if (biome->nid == id) return *(biome);
   }

--- a/identifier/biomeidentifier.h
+++ b/identifier/biomeidentifier.h
@@ -60,9 +60,9 @@ class BiomeIdentifier {
   void enableDefinitions(int id);
   void disableDefinitions(int id);
   void updateBiomeDefinition();
-  const BiomeInfo &getBiome(int id) const;
-  const BiomeInfo &getBiome(quint8 id) const;
-  const BiomeInfo &getBiome(QString id) const;
+  const BiomeInfo &getBiomeByChunk  (qint32 id) const;
+  const BiomeInfo &getBiomeBySection(qint32 id) const;
+  const BiomeInfo &getBiomeByName   (QString id) const;
 
 private:
   // singleton: prevent access to constructor and copyconstructor
@@ -71,7 +71,7 @@ private:
   BiomeIdentifier(const BiomeIdentifier &);
   BiomeIdentifier &operator=(const BiomeIdentifier &);
 
-  void parseBiomeDefinitions0000(QJsonArray data, int pack);
+  void parseBiomeDefinitions0000(QJsonArray data,   int pack);
   void parseBiomeDefinitions2800(QJsonArray data18, int pack);
   void guessSpecialBiomes(QJsonObject b, BiomeInfo *biome);
 

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -570,8 +570,8 @@ void MapView::getToolTip(int x, int z) {
     }
     int biomeID = chunk->getBiomeID((x & 0xf), y, (z & 0xf));
     const BiomeInfo &biome = (chunk->version >=2800) ?
-        BiomeIdentifier::Instance().getBiome((quint8)biomeID) :
-        BiomeIdentifier::Instance().getBiome((qint32)biomeID);
+        BiomeIdentifier::Instance().getBiomeBySection(biomeID) :
+        BiomeIdentifier::Instance().getBiomeByChunk  (biomeID);
     biomename = biome.name;
 
     // count Entity of each display type


### PR DESCRIPTION
We had used 8bit to store Biomes per Chunk Section, this is sufficient for Vanilla Minecraft with about 70 Biomes.
This change uses 16bit to store the Biomes, so that mods may add more Biomes than 256.
 
will fix #325 

Memory impact is negligible as most storage is used for Blocks.

BiomeIdentifier is using 32bit IDs, this change is just the storage format per Chunk Section.