### PR TITLE
return -1 for invalid biome offset in any case

### DIFF
--- a/chunk.cpp
+++ b/chunk.cpp
@@ -127,12 +127,12 @@ int Chunk::getBiomeID(int x, int y, int z) const {
     offset = x + 16*z;
   }
 
-  #if defined(DEBUG) || defined(_DEBUG) || defined(QT_DEBUG)
   if ((offset < 0) || ((unsigned long long)(offset) > sizeof(this->biomes)/sizeof(this->biomes[0]))) {
+    #if defined(DEBUG) || defined(_DEBUG) || defined(QT_DEBUG)
     qWarning() << "Biome index out of range!";
+    #endif
     return -1;
   }
-  #endif
   return this->biomes[offset];
 }
 

--- a/identifier/biomeidentifier.cpp
+++ b/identifier/biomeidentifier.cpp
@@ -213,7 +213,7 @@ const BiomeInfo &BiomeIdentifier::getBiomeByChunk(qint32 id) const {
 
 // new Biomes after Cliffs & Caves update (1.18)
 const BiomeInfo &BiomeIdentifier::getBiomeBySection(qint32 id) const {
-  if (id < this->biomes18.length())
+  if (0 <= id && id < this->biomes18.length())
     return *(this->biomes18.at(id));
   else
     return unknownBiome;


### PR DESCRIPTION
in case of invalid biome offset previously -1 was returned only
for Debug builds, causing undefined behavior for Release builds.

this is relevant only for Minecraft < 1.18, changed this to the
same as for 1.18+ code - return -1 in invalid case, and print
warning only for Debug builds.