### PR TITLE
drop strange invisible unicode characters

### DIFF
--- a/identifier/biomeidentifier.cpp
+++ b/identifier/biomeidentifier.cpp
@@ -131,7 +131,7 @@ QColor BiomeInfo::getBiomeGrassColor( QColor blockcolor, int elevation ) const
   if (this->swamp) {
     // perlin noise generator omitted due to performance reasons
     // otherwise the random temperature distribution selects
-    // (below -0.1°C) ‭4C.76.3C‬ or ‭6A.70.39 (above -0.1°C)
+    // (below -0.1°C) 4C.76.3C or 6A.70.39 (above -0.1°C)
     colorizer = QColor::fromRgb(0x6a,0x70,0x39);  // hard wired
   }
   // mesa / badlands


### PR DESCRIPTION
compiler (GCC 12.2.0) produced warning about some "unmatched" strange Unicode characters on line with comment:

```
../minutor/identifier/biomeidentifier.cpp:134:57: warning: unpaired UTF-8 bidirectional control character detected [-Wbidi-chars=]
  134 |     // (below -0.1<U+00B0>C) <U+202D>4C.76.3C<U+202C> or <U+202D>6A.70.39 (above -0.1<U+00B0>C)
      |                                                          ~~~~~~~~                             ^
      |                                                          |                                    |
      |                                                          U+202D (LEFT-TO-RIGHT OVERRIDE)      end of bidirectional context
```

these invisible characters very likely were copied from some web page.
I don't see any reason to keep them in source file and fix their usage, so just dropped them.