### PR TITLE
Block statistics

### DIFF
--- a/chunk.cpp
+++ b/chunk.cpp
@@ -73,6 +73,8 @@ const Chunk::EntityMap &Chunk::getEntityMap() const {
 
 //inline
 const ChunkSection *Chunk::getSectionByY(int y) const {
+  if (y < -2048) return NULL;
+  if (y >= 2048) return NULL;
   qint8 section_idx = (y >> 4);
   return getSectionByIdx(section_idx);
 }

--- a/chunk.cpp
+++ b/chunk.cpp
@@ -8,6 +8,7 @@
 #include "identifier/blockidentifier.h"
 #include "identifier/biomeidentifier.h"
 
+
 template<typename ValueT>
 inline void* safeMemCpy(void* dest, const std::vector<ValueT>& srcVec, size_t length)
 {
@@ -651,7 +652,6 @@ const PaletteEntry & ChunkSection::getPaletteEntry(int offset, int y) const {
   return getPaletteEntry(offset + yoffset);
 }
 
-inline
 const PaletteEntry & ChunkSection::getPaletteEntry(int offset) const {
   quint16 blockid = blocks[offset];
   if (blockid < blockPaletteLength)
@@ -672,7 +672,6 @@ quint16 ChunkSection::getBiome(int offset, int y) const {
   return getBiome(offset + yoffset);
 }
 
-inline
 quint16 ChunkSection::getBiome(int offset) const {
   return biomes[offset];
 }

--- a/chunk.h
+++ b/chunk.h
@@ -4,13 +4,13 @@
 
 #include <QtCore>
 #include <QVector>
+#include <array>
 
 #include "nbt/nbt.h"
 #include "overlay/entity.h"
 #include "overlay/generatedstructure.h"
 #include "paletteentry.h"
 
-#include <array>
 
 class ChunkSection {
  public:

--- a/identifier/definitionmanager.cpp
+++ b/identifier/definitionmanager.cpp
@@ -38,7 +38,7 @@ static quint32 stableHash(const quint8 *data, int size)
 static quint32 stableHash(const char *data, int size = -1)
 {
   if (size < 0)
-    size = strlen(data);
+    size = static_cast<int>(strlen(data));
   return stableHash(reinterpret_cast<const quint8 *>(data), size);
 }
 

--- a/labelledslider.cpp
+++ b/labelledslider.cpp
@@ -54,6 +54,27 @@ void LabelledSlider::setRange(int minVal, int maxVal)
   slider->setRange(minVal, maxVal);
 }
 
+void LabelledSlider::setMinimum(int minVal)
+{
+  slider->setMinimum(minVal);
+}
+
+void LabelledSlider::setMaximum(int maxVal)
+{
+  slider->setMaximum(maxVal);
+}
+
+int LabelledSlider::minimum() const
+{
+  return slider->minimum();
+}
+
+int LabelledSlider::maximum() const
+{
+  return slider->maximum();
+}
+
+
 // private slot
 void LabelledSlider::intValueChange(int v) {
   // update preciceValue in case slider is moved by other means

--- a/labelledslider.h
+++ b/labelledslider.h
@@ -31,9 +31,13 @@ class LabelledSlider : public QWidget {
   void valueChanged(int val);
 
  public slots:
-  void setValue(double val);                 // set absolute value
-  void changeValue(double val);              // change value relative to current
-  void setRange(int minVal, int maxVal);  // set slider range
+  void setValue(double val);                // set absolute value
+  void changeValue(double val);             // change value relative to current
+  void setRange(int minVal, int maxVal);    // set slider range
+  void setMinimum(int minVal);              // set slider range minimum
+  void setMaximum(int maxVal);              // set slider range maximum
+  int  minimum() const;                     // get slider range minimum
+  int  maximum() const;                     // get slider range maximum
 
  private slots:
   void intValueChange(int val);

--- a/mapview.h
+++ b/mapview.h
@@ -28,7 +28,7 @@ class MapView : public QWidget {
     flgInhabitedTime  = 1 << 8
   };
 
-  typedef struct {
+  typedef struct struct_BlockLocation {
     float x, y, z;
     int scale;
     QVector3D getPos3D() const {

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -101,16 +101,16 @@ Minutor::Minutor()
   mainLayout->setSpacing(0);
   mainLayout->setContentsMargins(0, 0, 0, 0);
 
-  connect(depth, SIGNAL(valueChanged(int)),
-          mapview, SLOT(setDepth(int)));
+  connect(depth,   SIGNAL(valueChanged(int)),
+          mapview, SLOT  (setDepth(int)));
   connect(mapview, SIGNAL(demandDepthChange(double)),
-          depth, SLOT(changeValue(double)));
+          depth,   SLOT  (changeValue(double)));
   connect(mapview, SIGNAL(demandDepthValue(double)),
-          depth, SLOT(setValue(double)));
-  connect(this, SIGNAL(worldLoaded(bool)),
-          mapview, SLOT(setEnabled(bool)));
-  connect(this, SIGNAL(worldLoaded(bool)),
-          depth, SLOT(setEnabled(bool)));
+          depth,   SLOT  (setValue(double)));
+  connect(this,    SIGNAL(worldLoaded(bool)),
+          mapview, SLOT  (setEnabled(bool)));
+  connect(this,    SIGNAL(worldLoaded(bool)),
+          depth,   SLOT  (setEnabled(bool)));
 
   m_ui.centralwidget->setLayout(mainLayout);
   layout()->setContentsMargins(0, 0, 0, 0);
@@ -856,44 +856,60 @@ void Minutor::showProperties(QVariant props) {
 }
 
 SearchChunksDialog* Minutor::prepareSearchForm(const QSharedPointer<SearchPluginI>& searchPlugin) {
-  SearchChunksDialog* form = new SearchChunksDialog(searchPlugin);
+  SearchChunksDialog* form = new SearchChunksDialog(searchPlugin, this);
 
   form->setAttribute(Qt::WA_DeleteOnClose);
 
-  const auto currentLocation = mapview->getLocation();
-  form->setSearchCenter(currentLocation->x, currentLocation->y, currentLocation->z);
+  form->setSearchCenter(mapview->getLocation()->getPos3D());
 
-  connect(mapview, SIGNAL(coordinatesChanged(int,int,int)),
-          form, SLOT(setSearchCenter(int,int,int))
-          );
+  // map is moved
+  connect(mapview, &MapView::coordinatesChanged,
+          form,    qOverload<int,int,int>(&SearchChunksDialog::setSearchCenter) );
+  // item from result list is highlighted -> jump
+  connect(form,    &SearchChunksDialog::jumpTo,
+          this,    &Minutor::triggerJumpToPosition );
+  // update overlay elements
+  connect(form,    &SearchChunksDialog::updateSearchResultPositions,
+          this,    &Minutor::updateSearchResultPositions );
 
-  connect(form, SIGNAL(jumpTo(QVector3D)),
-          this, SLOT(triggerJumpToPosition(QVector3D))
-          );
-
-  connect(form, SIGNAL(updateSearchResultPositions(QVector<QSharedPointer<OverlayItem> >)),
-          this, SLOT(updateSearchResultPositions(QVector<QSharedPointer<OverlayItem> >))
-          );
+  // pre-fill depth range
+  form->setRangeY(depth->minimum(), depth->maximum());
 
   return form;
 }
 
 void Minutor::openSearchEntityDialog() {
+  // prepare dialog
   auto searchPlugin = QSharedPointer<SearchEntityPlugin>::create();
   auto searchEntityForm = prepareSearchForm(searchPlugin);
+  // show dialog
   searchEntityForm->setWindowTitle(m_ui.action_SearchEntity->statusTip());
   searchEntityForm->showNormal();
 }
 
 void Minutor::openSearchBlockDialog() {
+  // prepare dialog
   auto searchPlugin = QSharedPointer<SearchBlockPlugin>::create();
   auto searchBlockForm = prepareSearchForm(searchPlugin);
+  // show dialog
   searchBlockForm->setWindowTitle(m_ui.action_SearchBlock->statusTip());
   searchBlockForm->showNormal();
 }
 
 void Minutor::openStatisticBlockDialog() {
+  // prepare dialog
   StatisticDialog *dialog = new StatisticDialog(this);
+
+  // update current location
+  dialog->setSearchCenter(mapview->getLocation()->getPos3D());
+
+  connect(mapview, &MapView::coordinatesChanged,
+          dialog,  qOverload<int,int,int>(&StatisticDialog::setSearchCenter) );
+
+  // pre-fill depth range
+  dialog->setRangeY(depth->minimum(), depth->maximum());
+
+  // show dialog
   dialog->setWindowTitle(m_ui.action_StatisticBlock->statusTip());
   dialog->showNormal();
 }

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -32,10 +32,10 @@
 #include "overlay/village.h"
 #include "jumpto.h"
 #include "pngexport.h"
-#include "search/searchchunkswidget.h"
-#include "search/searchentitypluginwidget.h"
-#include "search/searchblockpluginwidget.h"
-#include "search/searchresultwidget.h"
+#include "search/searchchunksdialog.h"
+#include "search/searchentityplugin.h"
+#include "search/searchblockplugin.h"
+#include "search/statisticdialog.h"
 
 Minutor::Minutor()
 {
@@ -493,15 +493,20 @@ void Minutor::createActions() {
           mapview,             SLOT(clearCache()));
 
   // [Search]
-  connect(m_ui.action_SearchEntity, SIGNAL(triggered()),
-          this,                     SLOT(openSearchEntityWidget()));
-  connect(this,                     SIGNAL(worldLoaded(bool)),
-          m_ui.action_SearchEntity, SLOT(setEnabled(bool)));
+  connect(m_ui.action_SearchEntity,   &QAction::triggered,
+          this,                       &Minutor::openSearchEntityDialog);
+  connect(this,                       &Minutor::worldLoaded,
+          m_ui.action_SearchEntity,   &QAction::setEnabled);
 
-  connect(m_ui.action_SearchBlock, SIGNAL(triggered()), this,
-                                   SLOT(openSearchBlockWidget()));
-  connect(this,                    SIGNAL(worldLoaded(bool)),
-          m_ui.action_SearchBlock, SLOT(setEnabled(bool)));
+  connect(m_ui.action_SearchBlock,    &QAction::triggered,
+          this,                       &Minutor::openSearchBlockDialog);
+  connect(this,                       &Minutor::worldLoaded,
+          m_ui.action_SearchBlock,    &QAction::setEnabled);
+
+  connect(m_ui.action_StatisticBlock, &QAction::triggered,
+          this,                       &Minutor::openStatisticBlockDialog);
+  connect(this,                       &Minutor::worldLoaded,
+          m_ui.action_StatisticBlock, &QAction::setEnabled);
 
   // [Help]
   m_ui.action_About->setStatusTip(tr("About %1").arg(qApp->applicationName()));
@@ -850,8 +855,8 @@ void Minutor::showProperties(QVariant props) {
   }
 }
 
-SearchChunksWidget* Minutor::prepareSearchForm(const QSharedPointer<SearchPluginI>& searchPlugin) {
-  SearchChunksWidget* form = new SearchChunksWidget(searchPlugin);
+SearchChunksDialog* Minutor::prepareSearchForm(const QSharedPointer<SearchPluginI>& searchPlugin) {
+  SearchChunksDialog* form = new SearchChunksDialog(searchPlugin);
 
   form->setAttribute(Qt::WA_DeleteOnClose);
 
@@ -873,18 +878,24 @@ SearchChunksWidget* Minutor::prepareSearchForm(const QSharedPointer<SearchPlugin
   return form;
 }
 
-void Minutor::openSearchBlockWidget() {
-  auto searchPlugin = QSharedPointer<SearchBlockPluginWidget>::create();
+void Minutor::openSearchEntityDialog() {
+  auto searchPlugin = QSharedPointer<SearchEntityPlugin>::create();
+  auto searchEntityForm = prepareSearchForm(searchPlugin);
+  searchEntityForm->setWindowTitle(m_ui.action_SearchEntity->statusTip());
+  searchEntityForm->showNormal();
+}
+
+void Minutor::openSearchBlockDialog() {
+  auto searchPlugin = QSharedPointer<SearchBlockPlugin>::create();
   auto searchBlockForm = prepareSearchForm(searchPlugin);
   searchBlockForm->setWindowTitle(m_ui.action_SearchBlock->statusTip());
   searchBlockForm->showNormal();
 }
 
-void Minutor::openSearchEntityWidget() {
-  auto searchPlugin = QSharedPointer<SearchEntityPluginWidget>::create();
-  auto searchEntityForm = prepareSearchForm(searchPlugin);
-  searchEntityForm->setWindowTitle(m_ui.action_SearchEntity->statusTip());
-  searchEntityForm->showNormal();
+void Minutor::openStatisticBlockDialog() {
+  StatisticDialog *dialog = new StatisticDialog(this);
+  dialog->setWindowTitle(m_ui.action_StatisticBlock->statusTip());
+  dialog->showNormal();
 }
 
 void Minutor::triggerJumpToPosition(QVector3D pos) {

--- a/minutor.h
+++ b/minutor.h
@@ -27,7 +27,7 @@ class WorldSave;
 class Properties;
 class OverlayItem;
 class JumpTo;
-class SearchChunksWidget;
+class SearchChunksDialog;
 class SearchPluginI;
 
 class Location {
@@ -88,8 +88,9 @@ private slots:
   void addOverlayItemType(QString type, QColor color, QString dimension = "");
   void showProperties(QVariant props);
 
-  void openSearchBlockWidget();
-  void openSearchEntityWidget();
+  void openSearchEntityDialog();
+  void openSearchBlockDialog();
+  void openStatisticBlockDialog();
 
   void triggerJumpToPosition(QVector3D pos);
 
@@ -100,7 +101,7 @@ signals:
 
  private:
   Ui::Minutor m_ui;
-  SearchChunksWidget* prepareSearchForm(const QSharedPointer<SearchPluginI> &searchPlugin);
+  SearchChunksDialog* prepareSearchForm(const QSharedPointer<SearchPluginI> &searchPlugin);
 
   void createActions();
   void createMenus();

--- a/minutor.pro
+++ b/minutor.pro
@@ -56,6 +56,8 @@ HEADERS += \
     search/searchresultwidget.h \
     search/searchtextwidget.h \
     search/statisticdialog.h \
+    search/statisticlabel.h \
+    search/statisticresultitem.h \
     settings.h \
     worldinfo.h \
     worldsave.h \

--- a/minutor.pro
+++ b/minutor.pro
@@ -48,12 +48,14 @@ HEADERS += \
     search/entityevaluator.h \
     search/range.h \
     search/rectangleinnertoouteriterator.h \
-    search/searchblockpluginwidget.h \
-    search/searchchunkswidget.h \
-    search/searchentitypluginwidget.h \
+    search/searchblockplugin.h \
+    search/searchchunksdialog.h \
+    search/searchentityplugin.h \
     search/searchplugininterface.h \
+    search/searchrangewidget.h \
     search/searchresultwidget.h \
     search/searchtextwidget.h \
+    search/statisticdialog.h \
     settings.h \
     worldinfo.h \
     worldsave.h \
@@ -87,11 +89,13 @@ SOURCES += \
     overlay/village.cpp \
     pngexport.cpp \
     search/entityevaluator.cpp \
-    search/searchblockpluginwidget.cpp \
-    search/searchchunkswidget.cpp \
-    search/searchentitypluginwidget.cpp \
+    search/searchblockplugin.cpp \
+    search/searchchunksdialog.cpp \
+    search/searchentityplugin.cpp \
+    search/searchrangewidget.cpp \
     search/searchresultwidget.cpp \
     search/searchtextwidget.cpp \
+    search/statisticdialog.cpp \
     settings.cpp \
     worldinfo.cpp \
     worldsave.cpp \
@@ -144,7 +148,9 @@ FORMS += \
     jumpto.ui \
     pngexport.ui \
     overlay/properties.ui \
-    search/searchchunkswidget.ui \
+    search/searchchunksdialog.ui \
+    search/searchrangewidget.ui \
     search/searchresultwidget.ui \
     search/searchtextwidget.ui \
+    search/statisticdialog.ui \
     settings.ui

--- a/minutor.ui
+++ b/minutor.ui
@@ -79,6 +79,7 @@
     </property>
     <addaction name="action_SearchEntity"/>
     <addaction name="action_SearchBlock"/>
+    <addaction name="action_StatisticBlock"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
     <property name="title">
@@ -382,6 +383,14 @@ but keeps the same position / dimension</string>
    </property>
    <property name="statusTip">
     <string>toggle inhabited time on/off</string>
+   </property>
+  </action>
+  <action name="action_StatisticBlock">
+   <property name="text">
+    <string>Statistic for Block</string>
+   </property>
+   <property name="statusTip">
+    <string>Statistic for Block</string>
    </property>
   </action>
  </widget>

--- a/search/range.h
+++ b/search/range.h
@@ -7,11 +7,14 @@
 template <typename ValueT>
 class Range
 {
-  public:
+public:
   Range(ValueT start_including, ValueT end_including)
-    : start(start_including)
-    , end(end_including)
+    : m_begin(start_including)
+    , m_end(end_including)
   {}
+
+  ValueT begin() const {return m_begin;};
+  ValueT end() const   {return m_end;};
 
   static Range createFromUnorderedParams(ValueT v1, ValueT v2)
   {
@@ -28,13 +31,13 @@ class Range
     return Range(std::numeric_limits<ValueT>::lowest(), std::numeric_limits<ValueT>::max());
   }
 
-  const ValueT start;
-  const ValueT end;
-
   bool isInsideRange(ValueT value) const
   {
-    return (value >= start) && (value <= end);
+    return (value >= m_begin) && (value <= m_end);
   }
+private:
+  ValueT m_begin;
+  ValueT m_end;
 };
 
 #endif // RANGE_H

--- a/search/rectangleinnertoouteriterator.h
+++ b/search/rectangleinnertoouteriterator.h
@@ -3,6 +3,8 @@
 
 #include <QRect>
 #include <QPoint>
+#include <QVector3D>
+
 
 class RectangleInnerToOuterIterator
 {
@@ -10,11 +12,19 @@ class RectangleInnerToOuterIterator
   RectangleInnerToOuterIterator(const QRect& rect_)
     : rect(rect_)
     , center(rect_.center())
-    , currentPos(0,0)
-    , shellNr(0)
-    , subNr(0)
-    , stepNr(0)
   {
+    reset();
+  }
+
+  RectangleInnerToOuterIterator(const QVector3D searchCenter, const unsigned int radius)
+  {
+    // determine Chunks to be searched
+    const QPoint radius2d(radius, radius);
+    QPoint poi(int(searchCenter.x()) >> 4, int(searchCenter.z()) >> 4);
+
+    rect = QRect((poi - radius2d), (poi + radius2d));
+    center = rect.center();
+
     reset();
   }
 

--- a/search/searchblockplugin.cpp
+++ b/search/searchblockplugin.cpp
@@ -77,19 +77,23 @@ SearchPluginI::ResultListT SearchBlockPlugin::searchChunk(const Chunk &chunk)
     return results;
   }
 
-  for (int z = 0; z < 16; z++) {
-    for (int y = chunk.getLowest(); y < chunk.getHighest() ; y++) {
-      for (int x = 0; x < 16; x++) {
-        const uint blockHid = chunk.getBlockHID(x,y,z);
-        const auto it = m_searchForIds.find(blockHid);
-        if (it != m_searchForIds.end()) {
-          auto info = BlockIdentifier::Instance().getBlockInfo(blockHid);
+  for (int y = chunk.getLowest(); y < chunk.getHighest() ; y++) {
+    int offset = (y & 0x0f) * (16*16);
+    const ChunkSection * const section = chunk.getSectionByY(y);
+    if (section) {
+      for (int z = 0; z < 16; z++) {
+        for (int x = 0; x < 16; x++, offset++) {
+          quint16 blockHid = section->getPaletteEntry(offset).hid;
+          const auto it = m_searchForIds.find(blockHid);
+          if (it != m_searchForIds.end()) {
+            auto info = BlockIdentifier::Instance().getBlockInfo(blockHid);
 
-          SearchResultItem item;
-          item.name = info.getName();
-          item.pos = QVector3D(chunk.getChunkX() * 16 + x, y, chunk.getChunkZ() * 16 + z) + QVector3D(0.5,0.0,0.5); // mark center of block, not origin
-          item.entity = QSharedPointer<Entity>::create(OverlayItem::Point(item.pos));
-          results.push_back(item);
+            SearchResultItem item;
+            item.name = info.getName();
+            item.pos = QVector3D(chunk.getChunkX() * 16 + x, y, chunk.getChunkZ() * 16 + z) + QVector3D(0.5,0.0,0.5); // mark center of block, not origin
+            item.entity = QSharedPointer<Entity>::create(OverlayItem::Point(item.pos));
+            results.push_back(item);
+          }
         }
       }
     }

--- a/search/searchblockplugin.cpp
+++ b/search/searchblockplugin.cpp
@@ -1,4 +1,4 @@
-#include "search/searchblockpluginwidget.h"
+#include "search/searchblockplugin.h"
 #include "search/searchresultwidget.h"
 
 #include "chunk.h"
@@ -6,13 +6,16 @@
 
 #include <algorithm>
 
-SearchBlockPluginWidget::SearchBlockPluginWidget(QWidget* parent)
+SearchBlockPlugin::SearchBlockPlugin(QWidget* parent)
   : QWidget(parent)
   , layout(new QVBoxLayout(this))
 {
 
   layout->addWidget(stw_blockId   = new SearchTextWidget("block id"));
   layout->addWidget(stw_blockName = new SearchTextWidget("block name"));
+  stw_blockName->setActive(true);
+  //stw_blockName->hideActive(true);
+  stw_blockName->setExactMatch(true);
 
   // add suggestions for "block name"
   auto idList = BlockIdentifier::Instance().getKnownIds();
@@ -31,21 +34,21 @@ SearchBlockPluginWidget::SearchBlockPluginWidget(QWidget* parent)
   }
 }
 
-SearchBlockPluginWidget::~SearchBlockPluginWidget()
+SearchBlockPlugin::~SearchBlockPlugin()
 {
   delete layout;
 }
 
-QWidget &SearchBlockPluginWidget::getWidget()
+QWidget &SearchBlockPlugin::getWidget()
 {
   return *this;
 }
 
-bool SearchBlockPluginWidget::initSearch()
+bool SearchBlockPlugin::initSearch()
 {
   m_searchForIds.clear();
 
-  if (stw_blockId->isActive()) {
+  if (stw_blockId->active()) {
     bool ok = true;
     m_searchForIds.insert(stw_blockId->getSearchText().toUInt());
     if (!ok) {
@@ -53,7 +56,7 @@ bool SearchBlockPluginWidget::initSearch()
     }
   }
 
-  if (stw_blockName->isActive()) {
+  if (stw_blockName->active()) {
     auto idList = BlockIdentifier::Instance().getKnownIds();
     for (auto id: idList) {
       auto blockInfo = BlockIdentifier::Instance().getBlockInfo(id);
@@ -66,7 +69,7 @@ bool SearchBlockPluginWidget::initSearch()
   return (m_searchForIds.size() > 0);
 }
 
-SearchPluginI::ResultListT SearchBlockPluginWidget::searchChunk(const Chunk &chunk)
+SearchPluginI::ResultListT SearchBlockPlugin::searchChunk(const Chunk &chunk)
 {
   SearchPluginI::ResultListT results;
 

--- a/search/searchblockplugin.h
+++ b/search/searchblockplugin.h
@@ -18,7 +18,8 @@ class SearchBlockPlugin : public QWidget, public SearchPluginI
   ~SearchBlockPlugin();
 
   QWidget &getWidget() override;
-  bool initSearch() override;
+
+  bool    initSearch() override;
   SearchPluginI::ResultListT searchChunk(const Chunk &chunk) override;
 
  private:

--- a/search/searchblockplugin.h
+++ b/search/searchblockplugin.h
@@ -1,5 +1,5 @@
-#ifndef SEARCHBLOCKPLUGINWIDGET_H
-#define SEARCHBLOCKPLUGINWIDGET_H
+#ifndef SEARCHBLOCKPLUGIN_H
+#define SEARCHBLOCKPLUGIN_H
 
 #include "search/searchplugininterface.h"
 #include "search/searchtextwidget.h"
@@ -9,13 +9,13 @@
 #include <set>
 
 
-class SearchBlockPluginWidget : public QWidget, public SearchPluginI
+class SearchBlockPlugin : public QWidget, public SearchPluginI
 {
   Q_OBJECT
 
  public:
-  explicit SearchBlockPluginWidget(QWidget* parent = nullptr);
-  ~SearchBlockPluginWidget();
+  explicit SearchBlockPlugin(QWidget* parent = nullptr);
+  ~SearchBlockPlugin();
 
   QWidget &getWidget() override;
   bool initSearch() override;
@@ -30,4 +30,4 @@ class SearchBlockPluginWidget : public QWidget, public SearchPluginI
   std::set<quint32> m_searchForIds;
 };
 
-#endif // SEARCHBLOCKPLUGINWIDGET_H
+#endif // SEARCHBLOCKPLUGIN_H

--- a/search/searchchunksdialog.h
+++ b/search/searchchunksdialog.h
@@ -1,5 +1,5 @@
-#ifndef SEARCHENTITYWIDGET_H
-#define SEARCHENTITYWIDGET_H
+#ifndef SEARCHENTITYDIALOG_H
+#define SEARCHENTITYDIALOG_H
 
 #include "overlay/overlayitem.h"
 #include "overlay/propertietreecreator.h"
@@ -14,20 +14,20 @@
 
 #include <set>
 
-#include "ui_searchchunkswidget.h"
+#include "ui_searchchunksdialog.h"
 
 
 class ChunkCache;
 class Chunk;
 class SearchResultWidget;
 
-class SearchChunksWidget : public QDialog
+class SearchChunksDialog : public QDialog
 {
   Q_OBJECT
 
  public:
-  explicit SearchChunksWidget(QSharedPointer<SearchPluginI> searchPlugin, QWidget *parent = nullptr);
-  ~SearchChunksWidget();
+  explicit SearchChunksDialog(QSharedPointer<SearchPluginI> searchPlugin, QWidget *parent = nullptr);
+  ~SearchChunksDialog();
 
  public slots:
   void setSearchCenter(int x, int y, int z);
@@ -45,14 +45,14 @@ class SearchChunksWidget : public QDialog
   void displayResultsOfSingleChunk(QSharedPointer<SearchPluginI::ResultListT> results);
 
  private:
-  Ui::SearchChunksWidget *ui;
+  Ui::SearchChunksDialog *ui;
   QSharedPointer<SearchPluginI> searchPlugin;
   QVector3D searchCenter;
 
   class AsyncSearch
   {
    public:
-    AsyncSearch(SearchChunksWidget& parent_,
+    AsyncSearch(SearchChunksDialog& parent_,
                 const Range<float>& range_y_,
                 const QWeakPointer<SearchPluginI>& searchPlugin_)
       : parent(parent_)
@@ -67,7 +67,7 @@ class SearchChunksWidget : public QDialog
     QSharedPointer<SearchPluginI::ResultListT> searchExistingChunk_async(const QSharedPointer<Chunk> &chunk);
 
    private:
-    SearchChunksWidget& parent;
+    SearchChunksDialog& parent;
     const Range<float> range_y;
     QWeakPointer<SearchPluginI> searchPlugin;
   };
@@ -80,4 +80,4 @@ class SearchChunksWidget : public QDialog
   void cancelSearch();
 };
 
-#endif // SEARCHENTITYWIDGET_H
+#endif // SEARCHENTITYDIALOG_H

--- a/search/searchchunksdialog.h
+++ b/search/searchchunksdialog.h
@@ -30,6 +30,8 @@ class SearchChunksDialog : public QDialog
   ~SearchChunksDialog();
 
  public slots:
+  void setRangeY(int minimum, int maximum);
+  void setSearchCenter(const QVector3D &centerPoint);
   void setSearchCenter(int x, int y, int z);
 
  signals:
@@ -44,6 +46,10 @@ class SearchChunksDialog : public QDialog
 
   void displayResultsOfSingleChunk(QSharedPointer<SearchPluginI::ResultListT> results);
 
+  void addOneToProgress();
+
+  void cancelSearch();
+
  private:
   Ui::SearchChunksDialog *ui;
   QSharedPointer<SearchPluginI> searchPlugin;
@@ -53,31 +59,25 @@ class SearchChunksDialog : public QDialog
   {
    public:
     AsyncSearch(SearchChunksDialog& parent_,
-                const Range<float>& range_y_,
+                const Range<int>& range_y_,
                 const QWeakPointer<SearchPluginI>& searchPlugin_)
       : parent(parent_)
       , range_y(range_y_)
       , searchPlugin(searchPlugin_)
     {}
 
-    void loadAndSearchChunk_async(ChunkID id);
+    void loadChunk_async(ChunkID id);
 
-    void searchLoadedChunk_async(const QSharedPointer<Chunk> &chunk);
-
-    QSharedPointer<SearchPluginI::ResultListT> searchExistingChunk_async(const QSharedPointer<Chunk> &chunk);
+    QSharedPointer<SearchPluginI::ResultListT> processChunk_async(const QSharedPointer<Chunk> &chunk);
 
    private:
     SearchChunksDialog& parent;
-    const Range<float> range_y;
+    const Range<int> range_y;
     QWeakPointer<SearchPluginI> searchPlugin;
   };
 
   QSharedPointer<AsyncSearch> currentSearch;
   QFuture<void> currentfuture;
-
-  void addOneToProgress();
-
-  void cancelSearch();
 };
 
 #endif // SEARCHENTITYDIALOG_H

--- a/search/searchchunksdialog.ui
+++ b/search/searchchunksdialog.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>SearchChunksWidget</class>
- <widget class="QDialog" name="SearchChunksWidget">
+ <class>SearchChunksDialog</class>
+ <widget class="QDialog" name="SearchChunksDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>659</width>
-    <height>703</height>
+    <width>400</width>
+    <height>600</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -22,6 +22,20 @@
      <property name="title">
       <string>Search for:</string>
      </property>
+     <layout class="QVBoxLayout" name="layout_plugin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+     </layout>
     </widget>
    </item>
    <item>
@@ -33,9 +47,21 @@
       </sizepolicy>
      </property>
      <property name="title">
-      <string>Search in:</string>
+      <string>Search Range</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <widget class="SearchRangeWidget" name="range" native="true"/>
       </item>
@@ -57,7 +83,7 @@
   <customwidget>
    <class>SearchRangeWidget</class>
    <extends>QWidget</extends>
-   <header>searchrangewidget.h</header>
+   <header>search/searchrangewidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/search/searchchunksdialog.ui
+++ b/search/searchchunksdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>500</width>
     <height>600</height>
    </rect>
   </property>

--- a/search/searchchunkswidget.h
+++ b/search/searchchunkswidget.h
@@ -14,9 +14,8 @@
 
 #include <set>
 
-namespace Ui {
-class SearchChunksWidget;
-}
+#include "ui_searchchunkswidget.h"
+
 
 class ChunkCache;
 class Chunk;
@@ -46,13 +45,9 @@ class SearchChunksWidget : public QDialog
   void displayResultsOfSingleChunk(QSharedPointer<SearchPluginI::ResultListT> results);
 
  private:
-  QSharedPointer<Ui::SearchChunksWidget> ui;
+  Ui::SearchChunksWidget *ui;
   QSharedPointer<SearchPluginI> searchPlugin;
   QVector3D searchCenter;
-
-  class AsyncSearch;
-  QSharedPointer<AsyncSearch> currentSearch;
-  QFuture<void> currentfuture;
 
   class AsyncSearch
   {
@@ -76,6 +71,9 @@ class SearchChunksWidget : public QDialog
     const Range<float> range_y;
     QWeakPointer<SearchPluginI> searchPlugin;
   };
+
+  QSharedPointer<AsyncSearch> currentSearch;
+  QFuture<void> currentfuture;
 
   void addOneToProgress();
 

--- a/search/searchchunkswidget.ui
+++ b/search/searchchunkswidget.ui
@@ -35,86 +35,9 @@
      <property name="title">
       <string>Search in:</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Radius</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QSpinBox" name="sb_radius">
-        <property name="maximum">
-         <number>999999999</number>
-        </property>
-        <property name="value">
-         <number>2000</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="3">
-       <widget class="QCheckBox" name="check_range_y">
-        <property name="text">
-         <string>Range Y</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
-       <widget class="QSpinBox" name="sb_y_start">
-        <property name="minimum">
-         <number>-999999999</number>
-        </property>
-        <property name="maximum">
-         <number>999999999</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="5">
-       <widget class="QSpinBox" name="sb_y_end">
-        <property name="minimum">
-         <number>-999999999</number>
-        </property>
-        <property name="maximum">
-         <number>999999999</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="6">
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>30</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="7">
-       <widget class="QPushButton" name="pb_search">
-        <property name="text">
-         <string>Search</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="8">
-       <widget class="QProgressBar" name="progressBar"/>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="SearchRangeWidget" name="range" native="true"/>
       </item>
      </layout>
     </widget>
@@ -129,6 +52,12 @@
    <class>SearchResultWidget</class>
    <extends>QWidget</extends>
    <header>search/searchresultwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>SearchRangeWidget</class>
+   <extends>QWidget</extends>
+   <header>searchrangewidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/search/searchentityplugin.cpp
+++ b/search/searchentityplugin.cpp
@@ -1,4 +1,4 @@
-#include "search/searchentitypluginwidget.h"
+#include "search/searchentityplugin.h"
 #include "search/searchresultwidget.h"
 
 #include "chunk.h"
@@ -6,7 +6,7 @@
 #include <set>
 
 
-SearchEntityPluginWidget::SearchEntityPluginWidget()
+SearchEntityPlugin::SearchEntityPlugin()
   : QWidget()
   , layout(new QVBoxLayout(this))
 {
@@ -33,17 +33,17 @@ SearchEntityPluginWidget::SearchEntityPluginWidget()
 
 }
 
-SearchEntityPluginWidget::~SearchEntityPluginWidget()
+SearchEntityPlugin::~SearchEntityPlugin()
 {
   delete layout;
 }
 
-QWidget &SearchEntityPluginWidget::getWidget()
+QWidget &SearchEntityPlugin::getWidget()
 {
   return *this;
 }
 
-SearchPluginI::ResultListT SearchEntityPluginWidget::searchChunk(const Chunk &chunk)
+SearchPluginI::ResultListT SearchEntityPlugin::searchChunk(const Chunk &chunk)
 {
   SearchPluginI::ResultListT results;
 
@@ -53,7 +53,7 @@ SearchPluginI::ResultListT SearchEntityPluginWidget::searchChunk(const Chunk &ch
     EntityEvaluator evaluator(
       EntityEvaluatorConfig(results,
                             entity,
-                            std::bind(&SearchEntityPluginWidget::evaluateEntity, this, std::placeholders::_1)
+                            std::bind(&SearchEntityPlugin::evaluateEntity, this, std::placeholders::_1)
                             )
       );
   }
@@ -61,37 +61,37 @@ SearchPluginI::ResultListT SearchEntityPluginWidget::searchChunk(const Chunk &ch
   return results;
 }
 
-bool SearchEntityPluginWidget::evaluateEntity(EntityEvaluator &entity)
+bool SearchEntityPlugin::evaluateEntity(EntityEvaluator &entity)
 {
   bool result = true;
 
-  if (stw_entity->isActive()) {
+  if (stw_entity->active()) {
     QString id = entity.getTypeId();
     result = result && stw_entity->matches(id);
   }
 
-  if (stw_villager->isActive()) {
+  if (stw_villager->active()) {
     QString searchFor = stw_villager->getSearchText();
     QString career = entity.getVillagerProfession();
     result = result && (career.contains(searchFor, Qt::CaseInsensitive));
   }
 
-  if (stw_buys->isActive()) {
+  if (stw_buys->active()) {
     result = result && findBuyOrSell(entity, *stw_buys, 0);
   }
 
-  if (stw_sells->isActive()) {
+  if (stw_sells->active()) {
     result = result && findBuyOrSell(entity, *stw_sells, 1);
   }
 
-  if (stw_special->isActive()) {
+  if (stw_special->active()) {
     result = result && stw_special->matches(entity.getSpecialParams());
   }
 
   return result;
 }
 
-bool SearchEntityPluginWidget::findBuyOrSell(EntityEvaluator &entity, SearchTextWidget& searchText, int index)
+bool SearchEntityPlugin::findBuyOrSell(EntityEvaluator &entity, SearchTextWidget& searchText, int index)
 {
   bool foundOffer = false;
   auto offers = entity.getVillagerOffers();

--- a/search/searchentityplugin.h
+++ b/search/searchentityplugin.h
@@ -1,5 +1,5 @@
-#ifndef SEARCHENTITYPLUGINWIDGET_H
-#define SEARCHENTITYPLUGINWIDGET_H
+#ifndef SEARCHENTITYPLUGIN_H
+#define SEARCHENTITYPLUGIN_H
 
 #include "search/entityevaluator.h"
 #include "search/searchplugininterface.h"
@@ -9,13 +9,13 @@
 #include <QLayout>
 
 
-class SearchEntityPluginWidget : public QWidget, public SearchPluginI
+class SearchEntityPlugin : public QWidget, public SearchPluginI
 {
   Q_OBJECT
 
  public:
-  explicit SearchEntityPluginWidget();
-  ~SearchEntityPluginWidget() override;
+  explicit SearchEntityPlugin();
+  ~SearchEntityPlugin() override;
 
   QWidget &getWidget() override;
 
@@ -34,4 +34,4 @@ class SearchEntityPluginWidget : public QWidget, public SearchPluginI
   bool findBuyOrSell(EntityEvaluator& entity, SearchTextWidget &searchText, int index);
 };
 
-#endif // SEARCHENTITYPLUGINWIDGET_H
+#endif // SEARCHENTITYPLUGIN_H

--- a/search/searchrangewidget.cpp
+++ b/search/searchrangewidget.cpp
@@ -2,9 +2,10 @@
 #include "ui_searchrangewidget.h"
 
 
-SearchRangeWidget::SearchRangeWidget(QWidget *parent) :
-  QWidget(parent),
-  ui(new Ui::SearchRangeWidget)
+SearchRangeWidget::SearchRangeWidget(QWidget *parent)
+  : QWidget(parent)
+  , ui(new Ui::SearchRangeWidget)
+  , max_range(-64,319)
 {
   ui->setupUi(this);
 }
@@ -25,18 +26,23 @@ unsigned int SearchRangeWidget::getRadiusChunks()
   return getRadius() / 16;
 }
 
-void SearchRangeWidget::setRangeY(Range<float> range)
+void SearchRangeWidget::setRangeY(Range<int> range)
 {
-  ui->sb_y_start->setValue(range.start);
-  ui->sb_y_end  ->setValue(range.end);
+  max_range = Range<int>(range);
+  ui->sb_y_start->setMinimum(range.begin());
+  ui->sb_y_start->setMaximum(range.end());
+  ui->sb_y_start->setValue(range.begin());
+  ui->sb_y_end  ->setMinimum(range.begin());
+  ui->sb_y_end  ->setMaximum(range.end());
+  ui->sb_y_end  ->setValue(range.end());
 }
 
-Range<float> SearchRangeWidget::getRangeY()
+Range<int> SearchRangeWidget::getRangeY()
 {
   if (!ui->check_range_y->isChecked()) {
-    return Range<float>::max();
+    return max_range;
   } else {
-    return Range<float>::createFromUnorderedParams(ui->sb_y_start->value(), ui->sb_y_end->value());
+    return Range<int>::createFromUnorderedParams(ui->sb_y_start->value(), ui->sb_y_end->value());
   }
 }
 
@@ -53,7 +59,7 @@ void SearchRangeWidget::setProgressValue(const unsigned int value)
   ui->progressBar->setValue(value);
 }
 
-void SearchRangeWidget::setProgressMax(const unsigned int value)
+void SearchRangeWidget::setProgressMaximum(const unsigned int value)
 {
   ui->progressBar->setMaximum(value);
 }

--- a/search/searchrangewidget.cpp
+++ b/search/searchrangewidget.cpp
@@ -1,0 +1,66 @@
+#include "searchrangewidget.h"
+#include "ui_searchrangewidget.h"
+
+
+SearchRangeWidget::SearchRangeWidget(QWidget *parent) :
+  QWidget(parent),
+  ui(new Ui::SearchRangeWidget)
+{
+  ui->setupUi(this);
+}
+
+SearchRangeWidget::~SearchRangeWidget()
+{
+  delete ui;
+}
+
+// search range
+unsigned int SearchRangeWidget::getRadius()
+{
+  return ui->sb_radius->value() + 1;
+}
+
+unsigned int SearchRangeWidget::getRadiusChunks()
+{
+  return getRadius() / 16;
+}
+
+void SearchRangeWidget::setRangeY(Range<float> range)
+{
+  ui->sb_y_start->setValue(range.start);
+  ui->sb_y_end  ->setValue(range.end);
+}
+
+Range<float> SearchRangeWidget::getRangeY()
+{
+  if (!ui->check_range_y->isChecked()) {
+    return Range<float>::max();
+  } else {
+    return Range<float>::createFromUnorderedParams(ui->sb_y_start->value(), ui->sb_y_end->value());
+  }
+}
+
+
+// search button
+void SearchRangeWidget::setButtonText(const QString &text)
+{
+  ui->pb_search->setText(text);
+}
+
+// progress bar
+void SearchRangeWidget::setProgressValue(const unsigned int value)
+{
+  ui->progressBar->setValue(value);
+}
+
+void SearchRangeWidget::setProgressMax(const unsigned int value)
+{
+  ui->progressBar->setMaximum(value);
+}
+
+bool SearchRangeWidget::incrementProgressValue()
+{
+  ui->progressBar->setValue(ui->progressBar->value() + 1);
+  // return true when maximum is reached
+  return (ui->progressBar->value() == ui->progressBar->maximum());
+}

--- a/search/searchrangewidget.h
+++ b/search/searchrangewidget.h
@@ -21,17 +21,18 @@ public:
   unsigned int getRadius();
   unsigned int getRadiusChunks();
 
-  void         setRangeY(Range<float> range);
-  Range<float> getRangeY();
+  void         setRangeY(Range<int> range);
+  Range<int>   getRangeY();
 
   void setButtonText(const QString &text);
 
   void setProgressValue(const unsigned int value);
-  void setProgressMax(const unsigned int value);
+  void setProgressMaximum(const unsigned int value);
   bool incrementProgressValue();
 
 private:
   Ui::SearchRangeWidget *ui;
+  Range<int>            max_range;
 };
 
 #endif // SEARCHRANGEWIDGET_H

--- a/search/searchrangewidget.h
+++ b/search/searchrangewidget.h
@@ -1,0 +1,37 @@
+#ifndef SEARCHRANGEWIDGET_H
+#define SEARCHRANGEWIDGET_H
+
+#include <QWidget>
+
+#include "search/range.h"
+
+
+namespace Ui {
+class SearchRangeWidget;
+}
+
+class SearchRangeWidget : public QWidget
+{
+  Q_OBJECT
+
+public:
+  explicit SearchRangeWidget(QWidget *parent = nullptr);
+  ~SearchRangeWidget();
+
+  unsigned int getRadius();
+  unsigned int getRadiusChunks();
+
+  void         setRangeY(Range<float> range);
+  Range<float> getRangeY();
+
+  void setButtonText(const QString &text);
+
+  void setProgressValue(const unsigned int value);
+  void setProgressMax(const unsigned int value);
+  bool incrementProgressValue();
+
+private:
+  Ui::SearchRangeWidget *ui;
+};
+
+#endif // SEARCHRANGEWIDGET_H

--- a/search/searchrangewidget.ui
+++ b/search/searchrangewidget.ui
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SearchRangeWidget</class>
+ <widget class="QWidget" name="SearchRangeWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>426</width>
+    <height>70</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="layout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Radius</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="sb_radius">
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>99999</number>
+       </property>
+       <property name="value">
+        <number>200</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="check_range_y">
+       <property name="text">
+        <string>Range Y</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="sb_y_start">
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="minimum">
+        <number>-64</number>
+       </property>
+       <property name="maximum">
+        <number>319</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="sb_y_end">
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="minimum">
+        <number>-64</number>
+       </property>
+       <property name="maximum">
+        <number>319</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pb_search">
+       <property name="text">
+        <string>Search</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+     <property name="textVisible">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/search/searchrangewidget.ui
+++ b/search/searchrangewidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>426</width>
+    <width>379</width>
     <height>70</height>
    </rect>
   </property>

--- a/search/searchresultwidget.ui
+++ b/search/searchresultwidget.ui
@@ -74,6 +74,9 @@
      <property name="sortingEnabled">
       <bool>true</bool>
      </property>
+     <attribute name="headerDefaultSectionSize">
+      <number>80</number>
+     </attribute>
      <column>
       <property name="text">
        <string>Name</string>

--- a/search/searchtextwidget.cpp
+++ b/search/searchtextwidget.cpp
@@ -14,15 +14,38 @@ SearchTextWidget::~SearchTextWidget()
   delete ui;
 }
 
-bool SearchTextWidget::isActive() const
+
+bool SearchTextWidget::active() const
 {
   return ui->checkBox_active->isChecked();
 }
+
+void SearchTextWidget::setActive(bool flag)
+{
+  ui->checkBox_active->setChecked(flag);
+}
+
+void SearchTextWidget::hideActive(bool flag)
+{
+  ui->checkBox_active->setVisible(!flag);
+}
+
 
 bool SearchTextWidget::exactMatch() const
 {
   return ui->checkBox_exact_match->isChecked();
 }
+
+void SearchTextWidget::setExactMatch(bool flag)
+{
+  ui->checkBox_exact_match->setChecked(flag);
+}
+
+void SearchTextWidget::hideExactMatch(bool flag)
+{
+  ui->checkBox_exact_match->setVisible(!flag);
+}
+
 
 void SearchTextWidget::addSuggestion(const QString &item)
 {

--- a/search/searchtextwidget.h
+++ b/search/searchtextwidget.h
@@ -15,9 +15,13 @@ class SearchTextWidget : public QWidget
   explicit SearchTextWidget(const QString& name, QWidget *parent = nullptr);
   ~SearchTextWidget();
 
-  bool isActive() const;
+  bool active() const;
+  void setActive (bool flag = true);
+  void hideActive(bool flag = true);
 
   bool exactMatch() const;
+  void setExactMatch (bool flag = true);
+  void hideExactMatch(bool flag = true);
 
   void addSuggestion(const QString& item);
 

--- a/search/searchtextwidget.ui
+++ b/search/searchtextwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>350</width>
     <height>25</height>
    </rect>
   </property>

--- a/search/statisticdialog.cpp
+++ b/search/statisticdialog.cpp
@@ -93,10 +93,10 @@ void StatisticDialog::on_pb_search_clicked() {
   const Range<int>   rangeY  = ui->range->getRangeY();
 
   // get HID for selected "block name"
-  quint16 blockHID = 0;
+  QList<quint16> blockHID;
   for (const auto hid: BlockIdentifier::Instance().getKnownIds()) {
     auto blockInfo = BlockIdentifier::Instance().getBlockInfo(hid);
-    if (blockInfo.getName() == stw_blockName->getSearchText()) blockHID = hid;
+    if (stw_blockName->matches(blockInfo.getName())) blockHID.append(hid);
   }
 
   currentStatistic = QSharedPointer<AsyncStatistic>::create(*this, rangeY, blockHID);
@@ -282,8 +282,8 @@ StatisticDialog::t_result StatisticDialog::AsyncStatistic::processChunk_async(co
         for (int z = 0; z < 16; z++) {  // n->s
           for (int x = 0; x < 16; x++, offset++) {  // e->w
             quint16 hid = section->getPaletteEntry(offset).hid;
-            if (hid != parent.air_hid) ri.air--;
-            if (hid == block_hid)      ri.count++;
+            if (hid != parent.air_hid)   ri.air--;
+            if (block_hid.contains(hid)) ri.count++;
           }
         }
       }

--- a/search/statisticdialog.cpp
+++ b/search/statisticdialog.cpp
@@ -1,0 +1,285 @@
+/** Copyright (c) 2022, EtlamGit */
+
+#include <algorithm>
+
+#include "statisticdialog.h"
+#include "ui_statisticdialog.h"
+
+#include "chunkcache.h"
+#include "identifier/blockidentifier.h"
+#include "search/rectangleinnertoouteriterator.h"
+
+#include <QtConcurrent/QtConcurrent>
+
+
+StatisticDialog::StatisticDialog(QWidget *parent)
+  : QDialog(parent)
+  , ui(new Ui::StatisticDialog)
+{
+  ui->setupUi(this);
+  ui->layout_select->addWidget(stw_blockName = new SearchTextWidget("block name"));
+  stw_blockName->setActive(true);
+  stw_blockName->hideActive(true);
+  stw_blockName->setExactMatch(true);
+
+  // add suggestions for "block name"
+  auto idList = BlockIdentifier::Instance().getKnownIds();
+
+  std::set<QString> nameList;   // std::set<> is sorted, QSet<> not
+
+  for (const auto hid: idList) {
+    auto blockInfo = BlockIdentifier::Instance().getBlockInfo(hid);
+    if (blockInfo.getName() == "minecraft:air") { air_hid = hid; continue; }
+    if (blockInfo.getName() == "minecraft:cave_air") continue;
+    nameList.insert(blockInfo.getName());
+  }
+
+  for (auto name: nameList) {
+    stw_blockName->addSuggestion(name);
+  }
+
+  setFixedSize(sizeHint());
+  //ui->tableWidget->sortByColumn(1, Qt::SortOrder::AscendingOrder);
+}
+
+StatisticDialog::~StatisticDialog()
+{
+  delete ui;
+}
+
+
+void StatisticDialog::setRangeY(int minimum, int maximum)
+{
+  ui->range->setRangeY(Range<int>(minimum, maximum));
+}
+
+
+void StatisticDialog::setSearchCenter(const QVector3D &centerPoint)
+{
+  searchCenter = centerPoint;
+  updateStatusText();
+}
+
+void StatisticDialog::setSearchCenter(int x, int y, int z)
+{
+  setSearchCenter(QVector3D(x,y,z));
+}
+
+
+// auto-magically connected via name match
+void StatisticDialog::on_pb_search_clicked() {
+  // when search is pending -> cancel and return
+  if (!currentFuture.isFinished() && !currentFuture.isCanceled()) {
+    cancelSearch();
+    return;
+  }
+
+  // determine Chunks to be searched
+  auto chunks = QSharedPointer< QList<ChunkID> >::create();
+  const int radius = ui->range->getRadiusChunks();
+  for (RectangleInnerToOuterIterator it(searchCenter, radius); it != it.end(); ++it) {
+    const ChunkID id(it->x(), it->y());
+    chunks->append(id);
+  }
+
+  // prepare UI
+  ui->range->setButtonText("Cancel");
+  ui->range->setProgressMaximum(chunks->size());
+  ui->range->setProgressValue(0);
+  clearResults();
+
+  // setup search parameters
+  const Range<int>   rangeY  = ui->range->getRangeY();
+
+  // get HID for selected "block name"
+  quint16 blockHID = 0;
+  for (const auto hid: BlockIdentifier::Instance().getKnownIds()) {
+    auto blockInfo = BlockIdentifier::Instance().getBlockInfo(hid);
+    if (blockInfo.getName() == stw_blockName->getSearchText()) blockHID = hid;
+  }
+
+  currentStatistic = QSharedPointer<AsyncStatistic>::create(*this, rangeY, blockHID);
+
+  std::function<t_result(const ChunkID &)> mapper =
+      [currentStatistic = currentStatistic, chunks /* needed to keep list alive during search */]
+      (const ChunkID &id) -> t_result
+      { return currentStatistic->loadChunk_async(id); };
+
+  currentFuture = QtConcurrent::mappedReduced(
+        *chunks,
+        mapper,
+        StatisticDialog::AsyncStatistic::reduceResults
+  );
+}
+
+
+
+
+// auto-magically connected via name match
+void StatisticDialog::on_pb_save_clicked() {
+  // todo
+}
+
+
+
+
+void StatisticDialog::updateStatusText()
+{
+  updateResultImage();
+  if (currentFuture.isFinished() && currentFuture.results().size() == 1) {
+    ui->label_result->setText(QString("%4 Blocks found around position: %1,%2,%3")
+                                .arg(searchCenter.x())
+                                .arg(searchCenter.y())
+                                .arg(searchCenter.z())
+                                .arg(resultSum.count));
+  } else
+    ui->label_result->setText(QString("Statistic around position: %1,%2,%3")
+                                .arg(searchCenter.x())
+                                .arg(searchCenter.y())
+                                .arg(searchCenter.z()));
+}
+
+
+void StatisticDialog::updateProgress() {
+  if (ui->range->incrementProgressValue()) {
+    finishSearch(); // finished
+  }
+}
+
+
+void StatisticDialog::clearResults()
+{
+//  ui->tableWidget->clear();
+}
+
+
+// search is finished
+void StatisticDialog::finishSearch() {
+  currentFuture.waitForFinished();
+  currentStatistic.reset();
+
+  // update search status
+  updateStatusText();
+  // adapt width of result columns
+//  for (int i = 0; i < ui->tableWidget->columnCount(); i++)
+//      ui->tableWidget->resizeColumnToContents(i);
+
+  ui->range->setButtonText("Search");
+}
+
+
+// search is cancelled
+void StatisticDialog::cancelSearch() {
+  if (!currentFuture.isFinished()) {
+    currentFuture.cancel();
+//    currentFuture.waitForFinished();
+  }
+  finishSearch();
+}
+
+
+void StatisticDialog::updateResultImage()
+{
+  // calculate total number
+  resultSum.count = 0;
+  resultSum.air   = 0;
+  resultSum.total = 0;
+
+  if (currentFuture.isFinished()) {
+    const auto &resultList = currentFuture.results();
+    if (resultList.size() == 1) {
+      const auto &resultMap  = resultList[0];
+
+      // get overall values
+      int min_key   = ui->range->getRangeY().end();
+      int max_key   = ui->range->getRangeY().begin();
+      int max_count = 0;
+      for (auto key: resultMap.keys()) {
+        const ResultItem &result = resultMap.value(key);
+        resultSum += result;
+        if (result.count > 0) {
+          min_key   = std::min<int>(min_key, key);
+          max_key   = std::max<int>(max_key, key);
+        }
+        max_count = std::max<int>(max_count, result.count);
+      }
+
+      // prepare image
+      int width  = ui->label_graph->width();
+      int height = ui->range->getRangeY().end() - ui->range->getRangeY().begin() + 1;
+      QImage image = QPixmap(width, height).toImage();
+      for (auto key: resultMap.keys()) {
+        int y = (height-1) - key + ui->range->getRangeY().begin();
+        const ResultItem &result = resultMap.value(key);
+        float scaleR = float(result.count) / float(max_count);
+        float scaleW = 1.0 / float(width);
+        for (int x = 0; x < width; x++) {
+          QColor color;
+          if (x*scaleW < scaleR) {
+            color = QColor(64,192,64);
+          } else {
+            color = QColor(128,128,128);
+          }
+          image.setPixelColor(x, y, color);
+        }
+      }
+      result_image = QPixmap::fromImage(image);
+      ui->label_graph->setPixmap(result_image);
+      setFixedSize(sizeHint());
+    }
+  }
+}
+
+
+// AsyncStatistic
+
+StatisticDialog::t_result StatisticDialog::AsyncStatistic::loadChunk_async(const ChunkID &id)
+{
+  QSharedPointer<Chunk> chunk = ChunkCache::Instance().getChunkSynchronously(id);
+
+  t_result results;
+
+  if (chunk) {
+    results = processChunk_async(chunk);
+  }
+
+  QMetaObject::invokeMethod(&parent, "updateProgress", Qt::QueuedConnection);
+
+  return results;
+}
+
+StatisticDialog::t_result StatisticDialog::AsyncStatistic::processChunk_async(const QSharedPointer<Chunk>& chunk)
+{
+  t_result results;
+
+  for (auto y = range_y.begin(); y <= range_y.end(); y++) {
+    ResultItem ri; // init to empty Chunk layer
+    const ChunkSection * section = chunk->getSectionByY(y);
+    if (section) {
+      int offset = (y & 0x0f) * (16*16);
+      for (int z = 0; z < 16; z++) {  // n->s
+        for (int x = 0; x < 16; x++, offset++) {  // e->w
+          quint16 hid = section->getPaletteEntry(offset).hid;
+          if (hid != parent.air_hid) ri.air--;
+          if (hid == block_hid)      ri.count++;
+        }
+      }
+    }
+    results[y] = ri;
+  }
+
+  return results;
+}
+
+void StatisticDialog::AsyncStatistic::reduceResults(t_result &result, const t_result &intermediate)
+{
+  for (auto key: intermediate.keys()) {
+    if (result.contains(key)) {
+      // combine
+      result[key] += intermediate[key];
+    } else {
+      // just move over
+      result[key] = intermediate[key];
+    }
+  }
+}

--- a/search/statisticdialog.h
+++ b/search/statisticdialog.h
@@ -81,11 +81,9 @@ class StatisticDialog : public QDialog
       , block_hid(hid_)
     {}
 
-    t_result loadChunk_async   (const ChunkID &id);
-    t_result processChunk_async(const QSharedPointer<Chunk> &chunk);
+    t_result processChunk_async(const ChunkID &id);
 
-//    static t_result mapResult(const ChunkID &id);
-    static void     reduceResults(t_result &result, const t_result &intermediate);
+    static void reduceResults(t_result &result, const t_result &intermediate);
 
    private:
     StatisticDialog& parent;

--- a/search/statisticdialog.h
+++ b/search/statisticdialog.h
@@ -75,7 +75,7 @@ class StatisticDialog : public QDialog
    public:
     AsyncStatistic(StatisticDialog  &parent_,
                    const Range<int> &range_y_,
-                   quint16           hid_)
+                   const QList<quint16> &hid_)
       : parent(parent_)
       , range_y(range_y_)
       , block_hid(hid_)
@@ -88,7 +88,7 @@ class StatisticDialog : public QDialog
    private:
     StatisticDialog& parent;
     const Range<int> range_y;
-    quint16          block_hid;
+    QList<quint16>   block_hid;
   };
 
   QSharedPointer<AsyncStatistic> currentStatistic;

--- a/search/statisticdialog.h
+++ b/search/statisticdialog.h
@@ -1,0 +1,101 @@
+#ifndef STATISTICDIALOG_H
+#define STATISTICDIALOG_H
+
+#include <QDialog>
+#include <QVector3D>
+#include <QFuture>
+#include <QSet>
+#include <set>
+
+#include "search/searchtextwidget.h"
+#include "search/range.h"
+
+#include "chunkid.h"
+#include "chunk.h"
+
+
+namespace Ui {
+class StatisticDialog;
+}
+
+class StatisticDialog : public QDialog
+{
+  Q_OBJECT
+
+ public:
+  explicit StatisticDialog(QWidget *parent = nullptr);
+  ~StatisticDialog();
+
+ public slots:
+  void setRangeY(int minimum, int maximum);
+  void setSearchCenter(const QVector3D& centerPoint);
+  void setSearchCenter(int x, int y, int z);
+
+ private slots:
+  void on_pb_search_clicked();
+  void on_pb_save_clicked();
+
+  void updateStatusText();
+  void updateProgress();
+
+  void clearResults();
+  void finishSearch();
+  void cancelSearch();
+  void updateResultImage();
+
+ private:
+  Ui::StatisticDialog *ui;
+  SearchTextWidget    *stw_blockName;
+  QVector3D           searchCenter;
+  QPixmap             result_image;
+  quint16             air_hid;
+
+  class ResultItem {
+  public:
+    ResultItem () : count(0), air(16*16), total(16*16) {}
+    ResultItem& operator+=(const ResultItem& rhs) {
+      this->count += rhs.count;
+      this->air   += rhs.air;
+      this->total += rhs.total;
+      return *this;
+    }
+    friend ResultItem operator+(ResultItem lhs, const ResultItem& rhs) {
+      lhs += rhs;
+      return lhs;
+
+    }
+    int count;
+    int air;
+    int total;
+  };
+  typedef QMap<int,ResultItem> t_result;
+
+  class AsyncStatistic
+  {
+   public:
+    AsyncStatistic(StatisticDialog  &parent_,
+                   const Range<int> &range_y_,
+                   quint16           hid_)
+      : parent(parent_)
+      , range_y(range_y_)
+      , block_hid(hid_)
+    {}
+
+    t_result loadChunk_async   (const ChunkID &id);
+    t_result processChunk_async(const QSharedPointer<Chunk> &chunk);
+
+//    static t_result mapResult(const ChunkID &id);
+    static void     reduceResults(t_result &result, const t_result &intermediate);
+
+   private:
+    StatisticDialog& parent;
+    const Range<int> range_y;
+    quint16          block_hid;
+  };
+
+  QSharedPointer<AsyncStatistic> currentStatistic;
+  QFuture<t_result>              currentFuture;
+  ResultItem                     resultSum;
+};
+
+#endif // STATISTICDIALOG_H

--- a/search/statisticdialog.h
+++ b/search/statisticdialog.h
@@ -9,6 +9,7 @@
 
 #include "search/searchtextwidget.h"
 #include "search/range.h"
+#include "search/statisticresultitem.h"
 
 #include "chunkid.h"
 #include "chunk.h"
@@ -50,26 +51,6 @@ class StatisticDialog : public QDialog
   QPixmap             result_image;
   quint16             air_hid;
 
-  class ResultItem {
-  public:
-    ResultItem () : count(0), air(16*16), total(16*16) {}
-    ResultItem& operator+=(const ResultItem& rhs) {
-      this->count += rhs.count;
-      this->air   += rhs.air;
-      this->total += rhs.total;
-      return *this;
-    }
-    friend ResultItem operator+(ResultItem lhs, const ResultItem& rhs) {
-      lhs += rhs;
-      return lhs;
-
-    }
-    int count;
-    int air;
-    int total;
-  };
-  typedef QMap<int,ResultItem> t_result;
-
   class AsyncStatistic
   {
    public:
@@ -81,9 +62,9 @@ class StatisticDialog : public QDialog
       , block_hid(hid_)
     {}
 
-    t_result processChunk_async(const ChunkID &id);
+    StatisticResultMap processChunk_async(const ChunkID &id);
 
-    static void reduceResults(t_result &result, const t_result &intermediate);
+    static void reduceResults(StatisticResultMap &result, const StatisticResultMap &intermediate);
 
    private:
     StatisticDialog& parent;
@@ -92,8 +73,8 @@ class StatisticDialog : public QDialog
   };
 
   QSharedPointer<AsyncStatistic> currentStatistic;
-  QFuture<t_result>              currentFuture;
-  ResultItem                     resultSum;
+  QFuture<StatisticResultMap>    currentFuture;
+  StatisticResultItem            resultSum;
 };
 
 #endif // STATISTICDIALOG_H

--- a/search/statisticdialog.ui
+++ b/search/statisticdialog.ui
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StatisticDialog</class>
+ <widget class="QDialog" name="StatisticDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="gb_select">
+     <property name="title">
+      <string>Statistic for Block</string>
+     </property>
+     <layout class="QVBoxLayout" name="layout_select"/>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Search Range</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="SearchRangeWidget" name="range" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label_result">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Results:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pb_save">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Save to file . . .</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_graph">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SearchRangeWidget</class>
+   <extends>QWidget</extends>
+   <header>search/searchrangewidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/search/statisticdialog.ui
+++ b/search/statisticdialog.ui
@@ -83,7 +83,10 @@
     </layout>
    </item>
    <item>
-    <widget class="QLabel" name="label_graph">
+    <widget class="StatisticLabel" name="label_graph">
+     <property name="mouseTracking">
+      <bool>true</bool>
+     </property>
      <property name="text">
       <string/>
      </property>
@@ -97,6 +100,11 @@
    <extends>QWidget</extends>
    <header>search/searchrangewidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>StatisticLabel</class>
+   <extends>QLabel</extends>
+   <header>search/statisticlabel.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/search/statisticlabel.h
+++ b/search/statisticlabel.h
@@ -1,0 +1,36 @@
+#ifndef STATISTICLABEL_H
+#define STATISTICLABEL_H
+
+#include <QLabel>
+#include <QMouseEvent>
+#include <QToolTip>
+
+#include "search/statisticresultitem.h"
+
+
+class StatisticLabel : public QLabel
+{
+  Q_OBJECT
+
+ public:
+  explicit StatisticLabel(QWidget *parent = nullptr) : QLabel(parent) {};
+
+ public slots:
+  void setResultMap(const StatisticResultMap &results, int max_key) { m_results = results; m_max_key = max_key;}
+
+  void mouseMoveEvent(QMouseEvent *event) {
+    int y = m_max_key - event->pos().y();
+    const StatisticResultItem & result = m_results[y];
+
+    QToolTip::showText(event->globalPos(),
+                       "Y:" + QString::number( y ) + " -> " + QString::number( result.count ),
+                       this, rect() );
+    QWidget::mouseMoveEvent(event);
+  }
+
+ private:
+  StatisticResultMap  m_results;
+  int                 m_max_key;
+};
+
+#endif // STATISTICLABEL_H

--- a/search/statisticresultitem.h
+++ b/search/statisticresultitem.h
@@ -1,0 +1,31 @@
+#ifndef STATISTICRESULTITEM_H
+#define STATISTICRESULTITEM_H
+
+#include <QMap>
+
+
+class StatisticResultItem {
+ public:
+  StatisticResultItem () : count(0), air(16*16), total(16*16) {}
+
+  StatisticResultItem& operator+=(const StatisticResultItem& rhs) {
+    this->count += rhs.count;
+    this->air   += rhs.air;
+    this->total += rhs.total;
+    return *this;
+  }
+
+  friend StatisticResultItem operator+(StatisticResultItem lhs, const StatisticResultItem& rhs) {
+    lhs += rhs;
+    return lhs;
+  }
+
+  int count;
+  int air;
+  int total;
+};
+
+typedef QMap<int,StatisticResultItem> StatisticResultMap;
+
+
+#endif // STATISTICRESULTITEM_H


### PR DESCRIPTION
This adds a dialog to search and count Blocks at specific depth level (Y). It is useful e.g. to analyze ore distribution.
* results can be saved as CSV data file
* total amount of found blocks is shown and each depth layer can be seen as tool-tip

As it is based on elements also used in Search, a major refactoring was done there to be able to reuse code.
The complete Search code was also refactored and cleaned-up and is hopefully better understandable now.