### PR TITLE
use Biome color for empty Blocks in single layer

### DIFF
--- a/chunkrenderer.cpp
+++ b/chunkrenderer.cpp
@@ -85,7 +85,7 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
 
         // get BlockInfo from block value
         const BlockInfo &block = BlockIdentifier::Instance().getBlockInfo(section->getPaletteEntry(offset, y).hid);
-        if (block.alpha == 0.0) continue;
+        if ((block.alpha == 0.0) && !(this->flags & MapView::flgBiomeColors)) continue;
 
         if (this->flags & MapView::flgSeaGround && block.isLiquid()) continue;
 


### PR DESCRIPTION
For normal rendering we use Biome color of the "highest" Block at each XZ position.

This change adds a new mode (when Biome Color Overlay and Single Layer are both selected):
Then the Biome color is derived from the Block at current Y depth, even when the Block is air.

In case you plan farms or builds in caves or skyblock worlds it is crucial to know the Biome for each Block even at specific depth layer (Biome is height dependent). With this new mode you can analyze Biome layer by layer.