### PR TITLE
fix skip of Section

### DIFF
--- a/chunkrenderer.cpp
+++ b/chunkrenderer.cpp
@@ -82,7 +82,7 @@ void ChunkRenderer::renderChunk(QSharedPointer<Chunk> chunk) {
         int sec = y >> 4;
         const ChunkSection *section = chunk->getSectionByIdx(sec);
         if (!section) {
-          y = (sec << 4) - 1;  // skip whole section
+          y = (sec << 4);  // skip whole section (for loop will do an additional decrement)
           continue;
         }
 


### PR DESCRIPTION
When skipping an empty intermediate Section new Y was set to topmost of next Section and also decremented by for loop. This results in skipping the first Block of the next populated section.
This could happen for pre 1.18 worlds when there are empty Sections in the Chunk. Meaning, something in higher layers, then some empty Sections and also some stuff in lower Sections again.

Will fix #347