### PR TITLE
fix exact pattern search

### DIFF
--- a/search/searchentityplugin.cpp
+++ b/search/searchentityplugin.cpp
@@ -66,7 +66,7 @@ bool SearchEntityPlugin::evaluateEntity(EntityEvaluator &entity)
   bool result = true;
 
   if (stw_entity->active()) {
-    QString id = entity.getTypeId();
+    QString id = entity.getTypeId().remove("minecraft:");
     result = result && stw_entity->matches(id);
   }
 


### PR DESCRIPTION
In case we select exact pattern search for entities, nothing is found, as the EntityIdentifer stores Entities without the namespace "minecraft:" and possible Entity still have it.
Fix is to remove "minecraft:" namespace from the Entity we try to match.

(This is different for Blocks, as we store the namespace in that case.)