### PR TITLE
Cleaner structure overlay menu

### DIFF
--- a/mapview.cpp
+++ b/mapview.cpp
@@ -616,7 +616,14 @@ void MapView::getToolTip(int x, int z) {
 
 void MapView::addStructureFromChunk(QSharedPointer<GeneratedStructure> structure) {
   // update menu (if necessary)
-  emit addOverlayItemType(structure->type(), structure->color());
+  QString structuretype = structure->type();
+  if (!structuretype.contains("minecraft:")) {
+    // not vanilla -> structure from a mod
+    QStringList mod = structuretype.split(QRegularExpression("[.:]"));
+    structuretype.insert(mod[0].size(), "." + mod[1]);
+  }
+
+  emit addOverlayItemType(structuretype, structure->color());
   // add to list with overlays
   addOverlayItem(structure);
 }

--- a/minutor.h
+++ b/minutor.h
@@ -85,6 +85,7 @@ private slots:
   void saveProgress(QString status, double value);
   void saveFinished();
   void addOverlayItem(QSharedPointer<OverlayItem> item);
+  QMenu* addOverlayItemMenu(QString type);
   void addOverlayItemType(QString type, QColor color, QString dimension = "");
   void showProperties(QVariant props);
 


### PR DESCRIPTION
Addresses suggestions from #350 

* When a new Structure type is found, the new overlay menu is created at alphabetical correct position instead of simple appending.
* When a structure is from a (non-vanilla) mod, a nested sub-menu is created for that mod. This reduces the amount of entries for each menu.