### PR TITLE
sort mod menus

### DIFF
--- a/identifier/biomeidentifier.cpp
+++ b/identifier/biomeidentifier.cpp
@@ -187,7 +187,10 @@ QColor BiomeInfo::getBiomeWaterColor( QColor watercolor ) const
 // BiomeIdentifier
 // --------- --------- --------- ---------
 
-BiomeIdentifier::BiomeIdentifier() {}
+BiomeIdentifier::BiomeIdentifier() {
+  unknownBiome.watermodifier.setNamedColor("#3f76e4");
+  unknownBiome.enabledwatermodifier = true;
+}
 
 BiomeIdentifier::~BiomeIdentifier() {
   for (int i = 0; i < packs.length(); i++) {

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -21,10 +21,9 @@ MapView::MapView(QWidget *parent)
   , cache(ChunkCache::Instance())
 {
   adjustZoom(0, false, false);
-  connect(&cache, SIGNAL(chunkLoaded(int, int)),
-          this,   SLOT  (chunkUpdated(int, int)));
-  connect(&cache, SIGNAL(structureFound(QSharedPointer<GeneratedStructure>)),
-          this,   SLOT  (addStructureFromChunk(QSharedPointer<GeneratedStructure>)));
+  connect(&cache, &ChunkCache::chunkLoaded,
+          this,   &MapView::chunkUpdated);
+
   setMouseTracking(true);
   setFocusPolicy(Qt::StrongFocus);
 
@@ -612,20 +611,6 @@ void MapView::getToolTip(int x, int z) {
 #endif
 
   emit hoverTextChanged(hovertext);
-}
-
-void MapView::addStructureFromChunk(QSharedPointer<GeneratedStructure> structure) {
-  // update menu (if necessary)
-  QString structuretype = structure->type();
-  if (!structuretype.contains("minecraft:")) {
-    // not vanilla -> structure from a mod
-    QStringList mod = structuretype.split(QRegularExpression("[.:]"));
-    structuretype.insert(mod[0].size(), "." + mod[1]);
-  }
-
-  emit addOverlayItemType(structuretype, structure->color());
-  // add to list with overlays
-  addOverlayItem(structure);
 }
 
 void MapView::addOverlayItem(QSharedPointer<OverlayItem> item) {

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -616,7 +616,14 @@ void MapView::getToolTip(int x, int z) {
 
 void MapView::addStructureFromChunk(QSharedPointer<GeneratedStructure> structure) {
   // update menu (if necessary)
-  emit addOverlayItemType(structure->type(), structure->color());
+  QString structuretype = structure->type();
+  if (!structuretype.contains("minecraft:")) {
+    // not vanilla -> structure from a mod
+    QStringList mod = structuretype.split(QRegularExpression("[.:]"));
+    structuretype.insert(mod[0].size(), "." + mod[1]);
+  }
+
+  emit addOverlayItemType(structuretype, structure->color());
   // add to list with overlays
   addOverlayItem(structure);
 }

--- a/mapview.h
+++ b/mapview.h
@@ -74,7 +74,6 @@ class MapView : public QWidget {
   void demandDepthChange(double value);
   void demandDepthValue(double value);
   void showProperties(QVariant properties);
-  void addOverlayItemType(QString type, QColor color);
   void coordinatesChanged(int x, int y, int z);
 
  protected:
@@ -86,9 +85,6 @@ class MapView : public QWidget {
   void keyPressEvent(QKeyEvent *event);
   void resizeEvent(QResizeEvent *event);
   void paintEvent(QPaintEvent *event);
-
- private slots:
-  void addStructureFromChunk(QSharedPointer<GeneratedStructure> structure);
 
  private:
   void drawChunk(int x, int z);

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -32,10 +32,12 @@
 #include "overlay/village.h"
 #include "jumpto.h"
 #include "pngexport.h"
+#include "chunkcache.h"
 #include "search/searchchunksdialog.h"
 #include "search/searchentityplugin.h"
 #include "search/searchblockplugin.h"
 #include "search/statisticdialog.h"
+
 
 Minutor::Minutor()
 {
@@ -47,12 +49,17 @@ Minutor::Minutor()
           statusBar(), SLOT(showMessage(QString)));
   connect(mapview, SIGNAL(showProperties(QVariant)),
           this,    SLOT(showProperties(QVariant)));
-  connect(mapview, SIGNAL(addOverlayItemType(QString, QColor)),
-          this,    SLOT(addOverlayItemType(QString, QColor)));
+
+  ChunkCache const & cache = ChunkCache::Instance();
+  connect(&cache, &ChunkCache::structureFound,
+          this,   &Minutor::addStructureFromChunk);
+
+  // Definition manager
   dm = new DefinitionManager(this);
   mapview->attach(dm);
   connect(dm,   SIGNAL(packsChanged()),
           this, SLOT(updateDimensions()));
+  // world information
   WorldInfo & wi = WorldInfo::Instance();
   connect(&wi,  SIGNAL(dimensionChanged(const DimensionInfo &)),
           this, SLOT(viewDimension(const DimensionInfo &)));
@@ -788,40 +795,56 @@ void Minutor::rescanWorlds() {
   // on startup anyway.
 }
 
-QMenu* Minutor::addOverlayItemMenu(QString type) {
+QMenu* Minutor::addOverlayItemMenu(QString path) {
+  // for vanilla the path is empty (minecraft:)
+  if ((path == "") || (path == "minecraft"))
+    return m_ui.menu_Overlay;
+
   // split type name to get nested menu levels
-  QList<QString> path = type.split('.');
-  QList<QString>::const_iterator pathIt, nextIt;
-  nextIt = path.begin();
-  nextIt++;  // skip first part "Structure."
-  pathIt = nextIt++;
+  QList<QString> pathlist = path.split('.');
 
   // generate a nested menu structure to match the path
   QMenu* menu = m_ui.menu_Overlay;
-  while (nextIt != path.end()) {
-    QMenu* submenu = menu->findChild<QMenu*>(*pathIt);
+  for (auto &p: pathlist) {
+    QMenu* submenu = menu->findChild<QMenu*>(p);
     if (!submenu) {
       // create new sub-menu
-      QMenu * submenu = new QMenu("&" + *pathIt, menu);
-      submenu->setObjectName(*pathIt);
-      menu->insertMenu(separatorEntityOverlay, submenu);
+      QMenu * submenu = new QMenu("&" + p, menu);
+      submenu->setObjectName(p);
+      // insert at alphabetical correct position
+      QList<QMenu *> menulist = menu->findChildren<QMenu*>();
+      QAction * insertBeforeAction;
+      for (QAction * action: menu->actions()) {
+        if (action == separatorEntityOverlay) {
+          // insert at least before Entities
+          insertBeforeAction = separatorEntityOverlay;
+          break;
+        } else if (action->menu()) {
+          // sub-menu means nested structures from a mod -> place before
+          if (action->text() > submenu->title()) {
+            insertBeforeAction = action;
+            break;
+          }
+        } // ignore all other actions
+      }
+      menu->insertMenu(insertBeforeAction, submenu);
       menu = submenu;
     } else {
       // continue with this sub-menu as parent
       menu = submenu;
     }
-    pathIt = nextIt++;
   }
   return menu;
 }
 
-void Minutor::addOverlayItemType(QString type, QColor color,
+void Minutor::addOverlayItemType(QString path, QString type,
+                                 QColor color,
                                  QString dimension) {
   if (!overlayItemTypes.contains(type)) {
     overlayItemTypes.insert(type);
 
-    // generate a nested menu structure to match the type path
-    QMenu* menu = addOverlayItemMenu(type);
+    // generate a nested menu structure to match the path
+    QMenu* menu = addOverlayItemMenu(path);
 
     // generate a unique keyboard shortcut
     QString actionName = type.split('.').last();
@@ -875,9 +898,26 @@ void Minutor::addOverlayItemType(QString type, QColor color,
   }
 }
 
+void Minutor::addStructureFromChunk(QSharedPointer<GeneratedStructure> structure) {
+  // update menu (if necessary)
+  QString type = structure->type();
+  QString path;
+  if (!type.contains("minecraft:")) {
+    // not vanilla -> structure from a mod
+    QStringList mod = type.split(QRegularExpression("[.:]"));
+    path = mod[1];
+  }
+
+  addOverlayItemType(path, type, structure->color());
+  // add to list with overlays
+  mapview->addOverlayItem(structure);
+}
+
 void Minutor::addOverlayItem(QSharedPointer<OverlayItem> item) {
   // create menu entries (if necessary)
-  addOverlayItemType(item->type(), item->color(), item->dimension());
+  QString type = item->type();
+  QString path;
+  addOverlayItemType(path, type, item->color(), item->dimension());
 
 //  const OverlayItem::Point& p = item->midpoint();
 //  overlayItems[item->type()].insertMulti(QPair<int, int>(p.x, p.z), item);

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -418,6 +418,8 @@ void Minutor::viewDimension(const DimensionInfo &dim) {
   // clear current map & update scale
   QString path = QDir(currentWorld).absoluteFilePath(dim.path);
   mapview->setDimension(path, dim.scale);
+  // reload structures for that dimension (old format from data directory)
+  loadStructures(path);
 }
 
 void Minutor::about() {
@@ -745,11 +747,6 @@ void Minutor::loadWorld(QDir path) {
     path.cdUp();
   }
 
-  if (path.cd("data")) {
-    loadStructures(path);
-    path.cdUp();
-  }
-
   // create Dimensions menu
   WorldInfo::Instance().getDimensionsInWorld(path, m_ui.menu_Dimension, this);
 
@@ -1000,11 +997,14 @@ void Minutor::updateSearchResultPositions(QVector<QSharedPointer<OverlayItem> > 
   mapview->redraw();
 }
 
-void Minutor::loadStructures(const QDir &dataPath) {
+void Minutor::loadStructures(QDir path) {
+  // check if data directory is present
+  if (!path.cd("data")) return;
+
   // attempt to parse all of the files in the data directory, looking for
   // generated structures
-  for (auto &fileName : dataPath.entryList(QStringList() << "*.dat")) {
-    NBT file(dataPath.filePath(fileName));
+  for (auto &fileName : path.entryList(QStringList() << "*.dat")) {
+    NBT file(path.filePath(fileName));
     auto data = file.at("data");
 
     auto items = GeneratedStructure::tryParseDatFile(data);

--- a/minutor.h
+++ b/minutor.h
@@ -85,6 +85,7 @@ private slots:
   void saveProgress(QString status, double value);
   void saveFinished();
   void addOverlayItem(QSharedPointer<OverlayItem> item);
+  QMenu* addOverlayItemMenu(QString type);
   void addOverlayItemType(QString type, QColor color, QString dimension = "");
   void showProperties(QVariant props);
 

--- a/minutor.h
+++ b/minutor.h
@@ -109,7 +109,7 @@ signals:
   void createActions();
   void createMenus();
   void createStatusBar();
-  void loadStructures(const QDir &dataPath);
+  void loadStructures(QDir path);
   QKeySequence generateUniqueKeyboardShortcut(QString *actionName);
 
   void getWorldList();

--- a/minutor.h
+++ b/minutor.h
@@ -12,7 +12,7 @@
 #include <QWidgetAction>
 
 #include "ui_minutor.h"
-#include "generatedstructure.h"
+#include "overlay/generatedstructure.h"
 
 class QAction;
 class QActionGroup;

--- a/minutor.h
+++ b/minutor.h
@@ -12,6 +12,7 @@
 #include <QWidgetAction>
 
 #include "ui_minutor.h"
+#include "generatedstructure.h"
 
 class QAction;
 class QActionGroup;
@@ -84,9 +85,10 @@ private slots:
   void rescanWorlds();
   void saveProgress(QString status, double value);
   void saveFinished();
+  void addStructureFromChunk(QSharedPointer<GeneratedStructure> structure);
   void addOverlayItem(QSharedPointer<OverlayItem> item);
-  QMenu* addOverlayItemMenu(QString type);
-  void addOverlayItemType(QString type, QColor color, QString dimension = "");
+  QMenu* addOverlayItemMenu(QString path);
+  void addOverlayItemType(QString path, QString type, QColor color, QString dimension = "");
   void showProperties(QVariant props);
 
   void openSearchEntityDialog();


### PR DESCRIPTION
As reported in #350:
Also sort the overlay sub-menus for mods alphabetically.
Fix modded structures not shown by refactoring the way path and type are used.

Refactor how structures get from Chunk to menu, now they skip the extra step in MapView.