### PR TITLE
Fix snapping zoom to minimum when scrolling

### DIFF
--- a/mapview.cpp
+++ b/mapview.cpp
@@ -152,8 +152,10 @@ void MapView::adjustZoom(double steps, bool allowZoomOut, bool cursorSource)
   const int zoomMin = allowZoomOut ? -4 : 0;
   const int zoomMax = (sizeof(zoomTable) / sizeof(float)) -1;
 
-  if (zoomLevel < zoomMin) zoomLevel = zoomMin;
-  if (zoomLevel > zoomMax) zoomLevel = zoomMax;
+  // snap the zoom level to bounds when the user scrolls too far
+  // do not force zoom-in when trying to zoom-out with allowZoomOut=false
+  if (zoomLevel < zoomMin && steps < 0) zoomLevel = std::min(zoomMin, oldZoomIndex);
+  else if (zoomLevel > zoomMax) zoomLevel = zoomMax;
 
   int zoomIndex = (int)(floor(zoomLevel + 0.5 ));
 
@@ -162,7 +164,7 @@ void MapView::adjustZoom(double steps, bool allowZoomOut, bool cursorSource)
   if (zoomIndex == oldZoomIndex && steps != 0) return;
 
   // determine minimal zoomed value that is allowed
-  // with current window size and available pyhiscal memory
+  // with current window size and available physical memory
   bool restrictZoom = true;
   int maxchunks = cache.getMemoryMax();
   int chunks    = cache.getCacheMax();

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -182,8 +182,12 @@ void MapView::adjustZoom(double steps, bool allowZoomOut, bool cursorSource)
     chunks = cx * cz;
     if ((1.2 * chunks) <= maxchunks)
       restrictZoom = false; // everything matches with a low margin of 20%
-    else
-      zoomIndex++;          // restrict zoom
+    else {
+      // restrict zoom
+      zoomIndex++;
+      // since zoom index is forced, reset stored zoom level to be the same value
+      zoomLevel = static_cast<double>(zoomIndex);
+    }
   } while (restrictZoom);
 
   // we try to set higher margin than above (100%)!


### PR DESCRIPTION
This code is designed to prevent zooming past the minimum or maximum, but it doesn't work properly in one important case. When zoom out (zoom levels < 1:1) is enabled via a modifier key, and zoom out has occurred (the current zoom is less than 0), and then the modifier key is released, further attempts to zoom out will instead zoom in as the zoom is snapped to the reduced maximum.

This is observable if you scroll by mistake, but the bigger issue is with high resolution touchpads, when generate numerous scroll events and usually have "momentum", meaning they continue generating scroll events after the user's fingers are off the touchpad. This means the user can do everything "right", and release the modifier key after they stop scrolling, but the momentum scroll events will result in an annoying snap-in zoom.

This commit works around the issue without side effects (I think):

 * We only snap the zoom level *in* when the user is zooming *out*.

 * In case the previous zoom level is lower than the current minimum zoom level, we keep the previous zoom level instead of snapping.

Also fixes a typo.