### PR TITLE
parse all 2x combinations of Block proberties

### DIFF
--- a/chunk.cpp
+++ b/chunk.cpp
@@ -513,12 +513,26 @@ void Chunk::loadSection_decodeBlockPalette(ChunkSection * cs, const Tag * palett
     // check vor variants
     BlockInfo const & block = bi.getBlockInfo(hid);
     if (block.hasVariants()) {
-    // test all available properties
-    for (auto key : cs->blockPalette[j].properties.keys()) {
-      QString vname = cs->blockPalette[j].name + ":" + key + ":" + cs->blockPalette[j].properties[key].toString();
-      uint vhid = qHash(vname);
-      if (bi.hasBlockInfo(vhid))
-        hid = vhid; // use this vaiant instead
+      // test all available properties
+      for (auto key : cs->blockPalette[j].properties.keys()) {
+        QString vname = cs->blockPalette[j].name + ":" + key + ":" + cs->blockPalette[j].properties[key].toString();
+        uint vhid = qHash(vname);
+        if (bi.hasBlockInfo(vhid))
+          hid = vhid; // use this vaiant instead
+      }
+      // test all possible combinations of 2 combined properties
+      if (cs->blockPalette[j].properties.keys().length() > 1) {
+        for (auto key1 : cs->blockPalette[j].properties.keys()) {
+          for (auto key2 : cs->blockPalette[j].properties.keys()) {
+            if (key1 == key2) continue;
+            QString vname = cs->blockPalette[j].name + ":" +
+                key1 + ":" + cs->blockPalette[j].properties[key1].toString() + " " +
+                key2 + ":" + cs->blockPalette[j].properties[key2].toString();
+            uint vhid = qHash(vname);
+            if (bi.hasBlockInfo(vhid))
+              hid = vhid; // use this vaiant instead
+          }
+        }
       }
     }
     // store hash of found variant

--- a/identifier/blockidentifier.cpp
+++ b/identifier/blockidentifier.cpp
@@ -176,8 +176,22 @@ void BlockIdentifier::parseDefinition(QJsonObject b, BlockInfo *parent,
   block->enabled = true;
 
   // optional Block State
-  if (b.contains("blockstate"))
-    block->blockstate = b.value("blockstate").toString();
+  if (b.contains("blockstate")) {
+    QJsonValueRef value_ref = b["blockstate"];
+    if (value_ref.isArray()) {
+      // parse complete array of blockstates
+      // !!! this is for the far future, older Minutor would struggle with duplicated Blocks !!!
+      // !!! for now we have to do this task manually in the definition file !!!
+      block->blockstate.clear();
+      int blen = value_ref.toArray().size();
+      for (int b = 0; b < blen; b++) {
+        if (b > 0)
+          block->blockstate.append(" ");
+        block->blockstate.append(value_ref.toArray()[b].toString());
+      }
+    } else  // only single item blockstate
+      block->blockstate = b.value("blockstate").toString();
+  }
 
   if (b.contains("transparent")) {
     // default setting for a transparent Block
@@ -272,8 +286,9 @@ void BlockIdentifier::parseDefinition(QJsonObject b, BlockInfo *parent,
     block->variants = true;
     QJsonArray variants = b.value("variants").toArray();
     int vlen = variants.size();
-    for (int j = 0; j < vlen; j++)
+    for (int j = 0; j < vlen; j++) {
       parseDefinition(variants.at(j).toObject(), block, pack);
+    }
   }
 
   uint hid = qHash(name);


### PR DESCRIPTION
With 1.20 Pitcher Plant,
we have a 2 Block tall flower that should have different color for lower/upper half and for each grow age (0..4)
For lower grow ages the upper half is even invisible.

To get that to work, we have to combine 2 Block properties when defining the Block color.
When searching the correct Block variant from a Palette:
 * up to now, we search only for each single property
 * but we have to search all combinations, not only one property match

In the definition file it would be nice to give these properties as list.
But older Minutor versions would struggle with that.
The code is implemented, but we should not use it for next couple of years.