### PR TITLE
Ignore structures with a zero-sized bounding box

### DIFF
--- a/overlay/generatedstructure.cpp
+++ b/overlay/generatedstructure.cpp
@@ -231,8 +231,12 @@ GeneratedStructure::tryParseFeatures(QVariant &maybeFeatureMap) {
             }
           }
 
-          structure->setBounds( Point(minX, minY, minZ), Point(maxX, maxY, maxZ));
-          ret.append( QSharedPointer<GeneratedStructure>(structure) );
+          // Only add the structure if it has a non-zero bounding box.
+          // This removes Terralith's bogus zpointer nonsense.
+          if (minX != maxX || minY != maxY || minZ != maxZ) {
+            structure->setBounds( Point(minX, minY, minZ), Point(maxX, maxY, maxZ));
+            ret.append( QSharedPointer<GeneratedStructure>(structure) );
+          }
         }
       }
     }


### PR DESCRIPTION
Terralith generates a whole bunch of bogus structures under `terralith:zpointer/blahblah` which luckily happen to have zero-sized bounding boxes and, since those wouldn't show up when overlaid anyway, we can ignore them and avoid polluting the Overlay menu at the same time.