### PR TITLE
init all members of unknownBiome

### DIFF
--- a/identifier/biomeidentifier.cpp
+++ b/identifier/biomeidentifier.cpp
@@ -190,6 +190,8 @@ QColor BiomeInfo::getBiomeWaterColor( QColor watercolor ) const
 BiomeIdentifier::BiomeIdentifier() {
   unknownBiome.watermodifier.setNamedColor("#3f76e4");
   unknownBiome.enabledwatermodifier = true;
+  for (int c = 0; c < 16; c++)
+    unknownBiome.colors[c] = QColor(0,0,0);
 }
 
 BiomeIdentifier::~BiomeIdentifier() {


### PR DESCRIPTION
the `colors` member variable was not initialized and therefore may contain random content

@Delvin4519 voted for `#000000`, which would be the content for a debug build or cleaned memory.