### PR TITLE
Added ChunkLock visualisation.

### DIFF
--- a/chunk.h
+++ b/chunk.h
@@ -65,6 +65,13 @@ class Chunk : public QObject {
   typedef QMultiMap<QString, QSharedPointer<OverlayItem>> EntityMap;
   const EntityMap& getEntityMap() const;
 
+  /** Returns whether the chunk is locked by the ChunkLock resourcepack. */
+  bool getIsChunkLocked() const { return isChunkLocked; }
+
+  /** Returns the name of the item needed for unlocking the ChunkLock.
+  Only valid if getIsChunkLocked() returns true. */
+  const QString & getChunkLockItemName() const { return chunkLockItemName; }
+
  signals:
   void structureFound(QSharedPointer<GeneratedStructure> structure);
 
@@ -89,6 +96,14 @@ class Chunk : public QObject {
   uchar  image[16 * 16 * 4];  // cached render: RGBA for 16*16 Blocks
   short  depth[16 * 16];      // cached depth map to create shadow
   EntityMap entities;
+
+  /** Specifies whether the chunk is locked by the ChunkLock resourcepack. */
+  bool isChunkLocked;
+
+  /** The name of the item needed for unlocking the chunk.
+  Only valid if isChunkLocked is true. */
+  QString chunkLockItemName;
+
   friend class MapView;
   friend class ChunkRenderer;
   friend class ChunkCache;
@@ -101,6 +116,9 @@ class Chunk : public QObject {
   void loadSection_createDummyPalette(ChunkSection * cs);
   void loadSection_loadBlockStates(ChunkSection *cs, const Tag * blockStateTag);
   bool loadSection_decodeBiomePalette(ChunkSection * cs, const Tag * biomesTag);
+
+  /** Checks whether the specified entity NBT is relevant to ChunkLock; if so, updates the ChunkLock-related state. */
+  void loadCheckEntityChunkLock(const Tag * entityNbt);
 };
 
 #endif  // CHUNK_H_

--- a/main.cpp
+++ b/main.cpp
@@ -114,6 +114,10 @@ int main(int argc, char *argv[]) {
       minutor.setViewInhabitedTime(true);
       continue;
     }
+    if (args[i] == "-chl" || args[i] == "--chunklock") {
+      minutor.setViewChunkLock(true);
+      continue;
+    }
   }
 
   minutor.show();

--- a/mapview.cpp
+++ b/mapview.cpp
@@ -515,6 +515,17 @@ void MapView::drawChunk(int x, int z) {
   if (this->zoom < 1.0)
       canvas.setRenderHint(QPainter::SmoothPixmapTransform);
   canvas.drawImage(targetRect, srcImage);
+
+  // Draw the ChunkLock overlay:
+  if (this->flags & flgChunkLock) {
+    if (chunk && chunk->getIsChunkLocked()) {
+      canvas.setPen(QColor::fromRgb(0xff0000));
+      canvas.setBrush(Qt::transparent);
+      double xAdj = (centerx > 0) ? 1 : 2;  // Adjustments are needed for chunks crossing the X or Y axis in viewspace
+      double yAdj = (centery > 0) ? 1 : 2;  // Otherwise their bottom / right edges are missing, most likely due to rounding.
+      canvas.drawRect(centerx, centery, chunksize - xAdj, chunksize - yAdj);
+    }
+  }
 }
 
 void MapView::getToolTip(int x, int z) {
@@ -616,6 +627,9 @@ void MapView::getToolTip(int x, int z) {
   hovertext += " Zoom:" + QString().number(zoomLevel);
 #endif
 
+  if (chunk && chunk->getIsChunkLocked()) {
+    hovertext += QString(" (ChunkLocked, needs %1)").arg(chunk->getChunkLockItemName());
+  }
   emit hoverTextChanged(hovertext);
 }
 

--- a/mapview.h
+++ b/mapview.h
@@ -25,7 +25,8 @@ class MapView : public QWidget {
     flgSeaGround      = 1 << 5,
     flgSingleLayer    = 1 << 6,
     flgSlimeChunks    = 1 << 7,
-    flgInhabitedTime  = 1 << 8
+    flgInhabitedTime  = 1 << 8,
+    flgChunkLock      = 1 << 9,
   };
 
   typedef struct struct_BlockLocation {

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -324,6 +324,11 @@ void Minutor::setViewInhabitedTime(bool value) {
   toggleFlags();
 }
 
+void Minutor::setViewChunkLock(bool value) {
+  m_ui.action_ChunkLock->setChecked(value);
+  toggleFlags();
+}
+
 void Minutor::setDepth(int value) {
   depth->setValue(value);
 }
@@ -340,6 +345,7 @@ void Minutor::toggleFlags() {
   if (m_ui.action_SingleLayer->isChecked())   flags |= MapView::flgSingleLayer;
   if (m_ui.action_SlimeChunks->isChecked())   flags |= MapView::flgSlimeChunks;
   if (m_ui.action_InhabitedTime->isChecked()) flags |= MapView::flgInhabitedTime;
+  if (m_ui.action_ChunkLock->isChecked())     flags |= MapView::flgChunkLock;
   mapview->setFlags(flags);
   mapview->redraw();
 }
@@ -512,6 +518,11 @@ void Minutor::about() {
                      .arg(qApp->organizationName()));
 }
 
+void Minutor::updateDatapackActions()
+{
+  m_ui.action_ChunkLock->setVisible(WorldInfo::Instance().isDatapackEnabled("chunklock"));
+}
+
 void Minutor::updateDimensions() {
   WorldInfo::Instance().getDimensionsInWorld(currentWorld, m_ui.menu_Dimension, this);
 }
@@ -574,6 +585,9 @@ void Minutor::createActions() {
 
   connect(m_ui.action_InhabitedTime, SIGNAL(triggered()),
           this,                      SLOT(toggleFlags()));
+
+  connect(m_ui.action_ChunkLock, SIGNAL(triggered()),
+          this,                  SLOT(toggleFlags()));
 
   // [View->Others]
 //  m_ui.action_Refresh->setStatusTip(tr("Reloads all chunks, "
@@ -779,6 +793,7 @@ void Minutor::loadWorld(QDir path) {
   WorldInfo & wi(WorldInfo::Instance());
   wi.parseWorldFolder(path);
   wi.parseWorldInfo();
+  updateDatapackActions();
 
   // add level name to window title
   setWindowTitle(qApp->applicationName() + " - " + wi.getLevelName());

--- a/minutor.h
+++ b/minutor.h
@@ -61,6 +61,7 @@ class Minutor : public QMainWindow {
   void setViewSingleLayer(bool value);    // set View->Single_Layer
   void setViewSlimeChunks(bool value);    // set View->Slime_Chunks
   void setViewInhabitedTime(bool value);  // set View->Inhabited_Time
+  void setViewChunkLock(bool value);      // set View->ChunkLock
   void setDepth(int value);               // set Depth-Slider
 
   MapView *getMapview() const;
@@ -80,6 +81,9 @@ private slots:
   void toggleOverlays();
 
   void about();
+
+  /** Updates the visibility of datapack-specific actions based on the current world's loaded datapacks. */
+  void updateDatapackActions();
 
   void updateDimensions();
   void rescanWorlds();

--- a/minutor.ui
+++ b/minutor.ui
@@ -66,6 +66,8 @@
     <addaction name="action_SlimeChunks"/>
     <addaction name="action_InhabitedTime"/>
     <addaction name="separator"/>
+    <addaction name="action_ChunkLock"/>
+    <addaction name="separator"/>
     <addaction name="action_Refresh"/>
    </widget>
    <widget class="QMenu" name="menu_Overlay">
@@ -391,6 +393,17 @@ but keeps the same position / dimension</string>
    </property>
    <property name="statusTip">
     <string>Statistic for Block</string>
+   </property>
+  </action>
+  <action name="action_ChunkLock">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>ChunkLock</string>
+   </property>
+   <property name="toolTip">
+    <string>Displays chunks locked by ChunkLock (if installed)</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This adds a new View option, "ChunkLock", which frames in red all chunks that are currently locked by the [ChunkLock resourcepack](https://modrinth.com/datapack/chunklock):
![image](https://github.com/mrkite/minutor/assets/4388386/b1b21a4a-c683-48c1-b756-2a888397123e)

Also adds a note in the status bar, displaying the item needed for unlocking.