### PR TITLE
Sort the Open World sub-menu by world name.

### DIFF
--- a/minutor.h
+++ b/minutor.h
@@ -121,6 +121,9 @@ signals:
   void insertToggleAllAction(QMenu* menu);
   void updateToggleAllState(QMenu* menu);
 
+  /** Populates worldActions with one action for each world encountered in the default Minecraft saves directory.
+  Each action opens the linked world upon triggering.
+  The actions are sorted by world's folder name. */
   void getWorldList();
 
   MapView *mapview;


### PR DESCRIPTION
The "Open World" submenu was not sorted, which could be a big mess with many worlds. Now it is sorted by world name, with the first 9 worlds getting the `Ctrl+<number>` shortcut.