### PR TITLE
parse datapacks for their name

### DIFF
--- a/minutor.cpp
+++ b/minutor.cpp
@@ -731,7 +731,7 @@ void Minutor::getWorldList() {
   QDirIterator it(mc);
   while (it.hasNext()) {
     it.next();
-    if (!it.fileInfo().isDir() || !wi.parseFolder(it.filePath())) {
+    if (!it.fileInfo().isDir() || !wi.parseWorldFolder(it.filePath())) {
       continue;
     }
     auto * w = new QAction(this);
@@ -773,8 +773,8 @@ void Minutor::loadWorld(QDir path) {
   currentWorld = path;
 
   WorldInfo & wi(WorldInfo::Instance());
-  wi.parseFolder(path);
-  wi.parseDimensions();
+  wi.parseWorldFolder(path);
+  wi.parseWorldInfo();
 
   // add level name to window title
   setWindowTitle(qApp->applicationName() + " - " + wi.getLevelName());

--- a/worldinfo.h
+++ b/worldinfo.h
@@ -8,6 +8,22 @@
 #include <QMenu>
 
 #include "identifier/dimensionidentifier.h"
+#include "nbt/nbt.h"
+
+
+class DatapackInfo {
+ public:
+  DatapackInfo()
+  : name("")
+  , path("")
+  , enabled(false)
+  , zipped(false) {}
+
+  QString name;
+  QString path;
+  bool enabled;
+  bool zipped;
+};
 
 
 class WorldInfo : public QObject
@@ -19,8 +35,8 @@ class WorldInfo : public QObject
   static WorldInfo &Instance();
 
   void clear();
-  bool parseFolder(const QDir &path);
-  bool parseDimensions();
+  bool parseWorldFolder(const QDir &path);
+  bool parseWorldInfo();
 
   QString             getLevelName() const   { return levelName; };
   unsigned int        getDataVersion() const { return dataVersion; };
@@ -28,6 +44,8 @@ class WorldInfo : public QObject
   int                 getSpawnX() const      { return spawnX; };
   int                 getSpawnZ() const      { return spawnZ; };
   signed long long    getSeed() const        { return seed; };
+
+  bool                isDatapackEnabled(const QString name) const;
 
   const QList<DimensionInfo> & getDimensions() const { return dimensions; };
 
@@ -48,6 +66,9 @@ class WorldInfo : public QObject
   WorldInfo(const WorldInfo &);
   WorldInfo &operator=(const WorldInfo &);
 
+  void parseDatapacks(const Tag * data);
+  bool parsePackMcmeta(const QJsonDocument & json_doc, const QString path, bool enabled, bool zipped);
+  bool parseDimension(const QJsonDocument & json_doc, QString pack_name, QString dim_name);
   bool parseDimensionType(DimensionInfo & dim, const QString & dim_type_id);
 
   QDir                  folder;       // base folder of world
@@ -59,6 +80,7 @@ class WorldInfo : public QObject
   long long             seed;
 
   QList<DimensionInfo>  dimensions;
+  QList<DatapackInfo>   datapacks;
 
   // Dimension view menu
   void addDimensionToMenu(QDir path, QString dir, QString name, QObject *parent);


### PR DESCRIPTION
Parse all enabled datapacks for their real name (not the filename). Put all found datapacks in a list in WorldInfo, support zipped and unzipped storage. Can be used to query whether a specific datapack is used in that world.

Refactored Custom Dimension parsing into the same code.

Example usage:
Just call e.g. `WorldInfo::isDatapackEnabled("Chunklock")` to query if the datapack (in this case "Chunklock") is used.