### PR TITLE
Fix search in top layer

### DIFF
--- a/minutor.pro
+++ b/minutor.pro
@@ -53,6 +53,7 @@ HEADERS += \
     search/searchentityplugin.h \
     search/searchplugininterface.h \
     search/searchrangewidget.h \
+    search/searchresultitem.h \
     search/searchresultwidget.h \
     search/searchtextwidget.h \
     search/statisticdialog.h \

--- a/search/searchblockplugin.cpp
+++ b/search/searchblockplugin.cpp
@@ -76,7 +76,7 @@ SearchPluginI::ResultListT SearchBlockPlugin::searchChunk(const Chunk &chunk)
     return results;
   }
 
-  for (int y = chunk.getLowest(); y < chunk.getHighest() ; y++) {
+  for (int y = chunk.getLowest(); y <= chunk.getHighest() ; y++) {
     int offset = (y & 0x0f) * (16*16);
     const ChunkSection * const section = chunk.getSectionByY(y);
     if (section) {

--- a/search/searchblockplugin.cpp
+++ b/search/searchblockplugin.cpp
@@ -1,5 +1,5 @@
 #include "search/searchblockplugin.h"
-#include "search/searchresultwidget.h"
+#include "search/searchresultitem.h"
 
 #include "chunk.h"
 #include "identifier/blockidentifier.h"
@@ -29,7 +29,7 @@ SearchBlockPlugin::SearchBlockPlugin(QWidget* parent)
     nameList.insert(blockInfo.getName());
   }
 
-  for (auto& name: nameList) {
+  for (const auto& name: nameList) {
     stw_blockName->addSuggestion(name);
   }
 }
@@ -69,7 +69,7 @@ bool SearchBlockPlugin::initSearch()
   return (m_searchForIds.size() > 0);
 }
 
-SearchPluginI::ResultListT SearchBlockPlugin::searchChunk(const Chunk &chunk)
+SearchPluginI::ResultListT SearchBlockPlugin::searchChunk(const Chunk &chunk, const Range<int> &range)
 {
   SearchPluginI::ResultListT results;
 
@@ -77,7 +77,11 @@ SearchPluginI::ResultListT SearchBlockPlugin::searchChunk(const Chunk &chunk)
     return results;
   }
 
-  for (int y = chunk.getLowest(); y <= chunk.getHighest() ; y++) {
+  // determine tight search range
+  int range_start = std::max<int>(chunk.getLowest(), range.begin());
+  int range_stop  = std::min<int>(chunk.getHighest(), range.end());
+
+  for (int y = range_start; y <= range_stop; y++) {
     int offset = (y & 0x0f) * (16*16);
     const ChunkSection * const section = chunk.getSectionByY(y);
     if (section) {

--- a/search/searchblockplugin.cpp
+++ b/search/searchblockplugin.cpp
@@ -22,14 +22,14 @@ SearchBlockPlugin::SearchBlockPlugin(QWidget* parent)
 
   std::set<QString> nameList;   // std::set<> is sorted, QSet<> not
 
-  for (const auto& id: idList) {
+  for (const auto& id: qAsConst(idList)) {
     auto blockInfo = BlockIdentifier::Instance().getBlockInfo(id);
     if (blockInfo.getName() == "minecraft:air") continue;
     if (blockInfo.getName() == "minecraft:cave_air") continue;
     nameList.insert(blockInfo.getName());
   }
 
-  for (auto name: nameList) {
+  for (auto& name: nameList) {
     stw_blockName->addSuggestion(name);
   }
 }
@@ -57,7 +57,8 @@ bool SearchBlockPlugin::initSearch()
   }
 
   if (stw_blockName->active()) {
-    for (const auto hid: BlockIdentifier::Instance().getKnownIds()) {
+    const QList<quint32> &knownIds = BlockIdentifier::Instance().getKnownIds();
+    for (quint32 hid: knownIds) {
       auto blockInfo = BlockIdentifier::Instance().getBlockInfo(hid);
       if (stw_blockName->matches(blockInfo.getName())) {
         m_searchForIds.insert(hid);

--- a/search/searchblockplugin.h
+++ b/search/searchblockplugin.h
@@ -20,7 +20,7 @@ class SearchBlockPlugin : public QWidget, public SearchPluginI
   QWidget &getWidget() override;
 
   bool    initSearch() override;
-  SearchPluginI::ResultListT searchChunk(const Chunk &chunk) override;
+  SearchPluginI::ResultListT searchChunk(const Chunk &chunk, const Range<int> &range) override;
 
  private:
   QLayout* layout;

--- a/search/searchchunksdialog.cpp
+++ b/search/searchchunksdialog.cpp
@@ -148,14 +148,6 @@ QSharedPointer<SearchPluginI::ResultListT> SearchChunksDialog::AsyncSearch::proc
     return QSharedPointer<SearchPluginI::ResultListT>();
   }
 
-  auto results_tmp = strong->searchChunk(*chunk);
-  auto results = QSharedPointer<SearchPluginI::ResultListT>::create();
-
-  for (const auto& result: results_tmp) {
-    if (range_y.isInsideRange(result.pos.y())) {
-      results->push_back(result);
-    }
-  }
-
-  return results;
+  auto results = strong->searchChunk(*chunk, range_y);
+  return QSharedPointer<SearchPluginI::ResultListT>::create(results);
 }

--- a/search/searchentityplugin.cpp
+++ b/search/searchentityplugin.cpp
@@ -17,7 +17,8 @@ SearchEntityPlugin::SearchEntityPlugin()
   layout->addWidget(stw_special  = new SearchTextWidget("special"));
 
   // add suggestions for "entity type"
-  for (const auto& name: EntityIdentifier::Instance().getKnownIds()) {
+  const QList<QString> &knownIds = EntityIdentifier::Instance().getKnownIds();
+  for (const auto& name: knownIds) {
     stw_entity->addSuggestion(name);
   }
 
@@ -27,7 +28,7 @@ SearchEntityPlugin::SearchEntityPlugin()
       << "cartographer" << "cleric" << "farmer" << "fisherman" << "fletcher"
       << "leatherworker" << "librarian" << "mason" << "shepherd"
       << "toolsmith" << "weaponsmith";
-  for (const auto& name: professions) {
+  for (const auto& name: qAsConst(professions)) {
     stw_villager->addSuggestion(name);
   }
 

--- a/search/searchentityplugin.cpp
+++ b/search/searchentityplugin.cpp
@@ -44,19 +44,20 @@ QWidget &SearchEntityPlugin::getWidget()
   return *this;
 }
 
-SearchPluginI::ResultListT SearchEntityPlugin::searchChunk(const Chunk &chunk)
+SearchPluginI::ResultListT SearchEntityPlugin::searchChunk(const Chunk &chunk, const Range<int> &range)
 {
   SearchPluginI::ResultListT results;
 
   const auto& entityMap = chunk.getEntityMap();
 
   for (const auto& entity: entityMap) {
-    EntityEvaluator evaluator(
-      EntityEvaluatorConfig(results,
-                            entity,
-                            std::bind(&SearchEntityPlugin::evaluateEntity, this, std::placeholders::_1)
-                            )
-      );
+    if (range.isInsideRange(entity->midpoint().y))
+      EntityEvaluator evaluator(
+        EntityEvaluatorConfig(results,
+                              entity,
+                              std::bind(&SearchEntityPlugin::evaluateEntity, this, std::placeholders::_1)
+                              )
+        );
   }
 
   return results;

--- a/search/searchentityplugin.h
+++ b/search/searchentityplugin.h
@@ -19,7 +19,7 @@ class SearchEntityPlugin : public QWidget, public SearchPluginI
 
   QWidget &getWidget() override;
 
-  SearchPluginI::ResultListT searchChunk(const Chunk &chunk) override;
+  SearchPluginI::ResultListT searchChunk(const Chunk &chunk, const Range<int> &range) override;
 
  private:
   QLayout* layout;

--- a/search/searchplugininterface.h
+++ b/search/searchplugininterface.h
@@ -1,12 +1,14 @@
 #ifndef SEARCHPLUGININTERFACE_H
 #define SEARCHPLUGININTERFACE_H
 
+#include "search/range.h"
+#include "search/searchresultitem.h"
+#include "chunk.h"
+
 #include <vector>
 
-class Chunk;
 
 class QWidget;
-class SearchResultItem;
 
 class SearchPluginI
 {
@@ -18,7 +20,12 @@ class SearchPluginI
 
   virtual bool initSearch() { return true; }
 
-  virtual ResultListT searchChunk(const Chunk &chunk) = 0;
+  virtual ResultListT searchChunk(const Chunk &chunk, const Range<int> &range) = 0;
+  ResultListT searchChunk(const Chunk &chunk)
+  {
+    Range<int> search_range(chunk.getLowest(), chunk.getHighest());
+    return searchChunk(chunk, search_range);
+  }
 
   virtual ~SearchPluginI() {}
 };

--- a/search/searchresultitem.h
+++ b/search/searchresultitem.h
@@ -1,0 +1,20 @@
+#ifndef SEARCHRESULTITEM_H
+#define SEARCHRESULTITEM_H
+
+#include <QVariant>
+#include <QVector3D>
+#include <QSharedPointer>
+
+class OverlayItem;
+
+class SearchResultItem
+{
+ public:
+  QString   name;
+  QVector3D pos;
+  QString   offers;
+  QVariant  properties;
+  QSharedPointer<OverlayItem> entity;
+};
+
+#endif // SEARCHRESULTITEM_H

--- a/search/searchresultwidget.h
+++ b/search/searchresultwidget.h
@@ -2,9 +2,9 @@
 #define SEARCHRESULTWIDGET_H
 
 #include "overlay/properties.h"
+#include "search/searchresultitem.h"
 
 #include <QWidget>
-#include <QVariant>
 #include <QVector3D>
 #include <QSharedPointer>
 
@@ -14,16 +14,6 @@ class OverlayItem;
 namespace Ui {
 class SearchResultWidget;
 }
-
-class SearchResultItem
-{
- public:
-  QString   name;
-  QVector3D pos;
-  QString   offers;
-  QVariant  properties;
-  QSharedPointer<OverlayItem> entity;
-};
 
 class SearchResultWidget : public QWidget
 {

--- a/search/statisticdialog.cpp
+++ b/search/statisticdialog.cpp
@@ -36,7 +36,7 @@ StatisticDialog::StatisticDialog(QWidget *parent)
     nameList.insert(blockInfo.getName());
   }
 
-  for (auto name: nameList) {
+  for (auto& name: nameList) {
     stw_blockName->addSuggestion(name);
   }
 
@@ -228,25 +228,23 @@ void StatisticDialog::updateResultImage()
       int min_key   = ui->range->getRangeY().end();
       int max_key   = ui->range->getRangeY().begin();
       int max_count = 0;
-      for (auto key: resultMap.keys()) {
-        const StatisticResultItem &result = resultMap.value(key);
-        resultSum += result;
-        if (result.count > 0) {
-          min_key   = std::min<int>(min_key, key);
-          max_key   = std::max<int>(max_key, key);
+      for (auto it = resultMap.begin(); it != resultMap.end(); it++) {
+        resultSum += it.value();
+        if (it->count > 0) {
+          min_key   = std::min<int>(min_key, it.key());
+          max_key   = std::max<int>(max_key, it.key());
         }
-        max_count = std::max<int>(max_count, result.count);
+        max_count = std::max<int>(max_count, it->count);
       }
 
       // prepare image
       int width  = ui->label_graph->width();
       int height = ui->range->getRangeY().end() - ui->range->getRangeY().begin() + 1;
       QImage image = QPixmap(width, height).toImage();
-      for (auto key: resultMap.keys()) {
-        int y = (height-1) - key + ui->range->getRangeY().begin();
-        const StatisticResultItem &result = resultMap.value(key);
-        float scaleR = float(result.count) / float(max_count);                // searched Blocks
-        float scaleA = float(result.total - result.air) / float(max_count);   // non Air Blocks
+      for (auto it = resultMap.begin(); it != resultMap.end(); it++) {
+        int y = (height-1) - it.key() + ui->range->getRangeY().begin();
+        float scaleR = float(it->count) / float(max_count);                // searched Blocks
+        float scaleA = float(it->total - it->air) / float(max_count);   // non Air Blocks
         float scaleW = 1.0 / float(width);
         for (int x = 0; x < width; x++) {
           QColor color;

--- a/search/statisticdialog.cpp
+++ b/search/statisticdialog.cpp
@@ -243,7 +243,7 @@ void StatisticDialog::updateResultImage()
       QImage image = QPixmap(width, height).toImage();
       for (auto it = resultMap.begin(); it != resultMap.end(); it++) {
         int y = (height-1) - it.key() + ui->range->getRangeY().begin();
-        float scaleR = float(it->count) / float(max_count);                // searched Blocks
+        float scaleR = float(it->count) / float(max_count);             // searched Blocks
         float scaleA = float(it->total - it->air) / float(max_count);   // non Air Blocks
         float scaleW = 1.0 / float(width);
         for (int x = 0; x < width; x++) {


### PR DESCRIPTION
There was a bug that we did not search the topmost layer of each Chunk.

While having the search code open:
* I noticed some C++11 warnings, mentioning detach and copy of Qt containers.
  These are solved and we should not unnecessary copy any of the results anymore.
* Found that the search Y-range is not applied during search but the results are filtered afterwards.
  Now the search Y-range is taken into account directly during search.

