### PR TITLE
Fix spawn detection

### DIFF
--- a/worldinfo.cpp
+++ b/worldinfo.cpp
@@ -95,13 +95,17 @@ bool WorldInfo::parseWorldInfo()
   // default
   spawnX = 0;
   spawnZ = 0;
+  spawnDimension = "minecraft:overworld";
   // for old worlds spawn is 2 separated tags
   if (data->has("SpawnX")) { spawnX = data->at("SpawnX")->toInt(); }
   if (data->has("SpawnZ")) { spawnZ = data->at("SpawnZ")->toInt(); }
   // starting with 1.21.9 we have sub tag "spawn"
   if (data->has("spawn")) {
     auto spawn = data->at("spawn");
-    if (spawn->has("pos")) {
+    if (spawn->has("dimension")) {
+      spawnDimension = spawn->at("dimension")->toString();
+    }
+    if ((spawnDimension == "minecraft:overworld") && spawn->has("pos")) {
       auto pos = spawn->at("pos")->toIntArray();
       spawnX = pos[0];
       spawnZ = pos[2];

--- a/worldinfo.h
+++ b/worldinfo.h
@@ -36,12 +36,13 @@ class WorldInfo : public QObject
   bool parseWorldFolder(const QDir &path);
   bool parseWorldInfo();
 
-  QString             getLevelName() const   { return levelName; };
-  unsigned int        getDataVersion() const { return dataVersion; };
-  unsigned long long  getDayTime() const     { return dayTime; };
-  int                 getSpawnX() const      { return spawnX; };
-  int                 getSpawnZ() const      { return spawnZ; };
-  signed long long    getSeed() const        { return seed; };
+  QString             getLevelName() const      { return levelName; };
+  unsigned int        getDataVersion() const    { return dataVersion; };
+  unsigned long long  getDayTime() const        { return dayTime; };
+  int                 getSpawnX() const         { return spawnX; };
+  int                 getSpawnZ() const         { return spawnZ; };
+  const QString &     getSpawnDimension() const { return spawnDimension; };
+  signed long long    getSeed() const           { return seed; };
 
   bool                isDatapackEnabled(const QString name) const;
 
@@ -75,6 +76,7 @@ class WorldInfo : public QObject
   unsigned long long    dayTime;
   int                   spawnX;
   int                   spawnZ;
+  QString               spawnDimension;
   long long             seed;
 
   QList<DimensionInfo>  dimensions;


### PR DESCRIPTION
with 1.21.9 the Tags to store spawn location in level.dat have changed

without this fix we start a new loaded world at 0,0
with this fix we start at Spawn again