### PR TITLE
Qt6 compatibility patch 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Makefile.Release
 *.pdb
 *.user
 *.pro.user.*
+
+/.qtcreator/
+/build/

--- a/clamp.h
+++ b/clamp.h
@@ -2,6 +2,8 @@
 #ifndef CLAMP_H_
 #define CLAMP_H_
 
+#if __cplusplus < 201703L
+
 namespace std {
 
 // will be in STD with C++17
@@ -12,4 +14,7 @@ const T& clamp( const T& value, const T& lower, const T& upper )
 }
 
 }
+
+#endif
+
 #endif  // CLAMP_H_

--- a/minutor.cpp
+++ b/minutor.cpp
@@ -1,6 +1,6 @@
 /** Copyright (c) 2013, Sean Kasun */
 #include <QtWidgets/QVBoxLayout>
-#include <QtWidgets/QAction>
+#include <QAction>
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QMenu>

--- a/search/searchtextwidget.cpp
+++ b/search/searchtextwidget.cpp
@@ -1,6 +1,8 @@
 #include "search/searchtextwidget.h"
 #include "ui_searchtextwidget.h"
 
+#include <QRegExp>
+
 SearchTextWidget::SearchTextWidget(const QString &name, QWidget *parent)
   : QWidget(parent)
   , ui(new Ui::SearchTextWidget)

--- a/worldinfo.cpp
+++ b/worldinfo.cpp
@@ -3,9 +3,12 @@
 #include "worldinfo.h"
 
 #include <QtWidgets/QMenu>
+#include <QActionGroup>
 #include <QDirIterator>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QRegExp>
+#include <QStringRef>
 
 #include "nbt/nbt.h"
 #include "zipreader.h"
@@ -210,7 +213,7 @@ bool WorldInfo::parseDatapackNamespace(const QString name_space, const QString p
 
   // test if already there
   if (datapacks.contains(name_space)) {
-    QMap<QString, DatapackInfo>::const_iterator it = datapacks.constFind(name_space);
+    auto it = datapacks.constFind(name_space);
     for (; it != datapacks.constEnd(); ++it) {
       if (it->path == path) return false;
     }


### PR DESCRIPTION
- added missing includes

  some implicit dependencies allowed to build successfully, but with Qt6 these dependencies has changed. also it is a good practice to include what is used.

- don't use Qt module in some includes

  QAction is in QtGui in Qt6, but in QtWidgets in Qt5, just drop module name from include, use raw QAction.

- use `auto` for some iterator due to type mismatch

  looks like there was QMap -> QMultimap change without updating iterator type where it was created, but Qt5 was ok with this (a bit weird, but still). with Qt6 iterator types became incompatible (expected). since C++11 it is possible to use `auto`, and using it for iterator types is a common practice. project uses C++14, so using `auto` here is a good option.

- put C++17 compatibility stuff behind proper define guard

  project uses C++14 and has some stuff implemented that available in C++17. Qt6 requires C++17, so 2 implementations cause build issues. also it is a good practice to include compatibility stuff conditionally.

- adjusted .gitignore to handle modern Qt Creator layout

  Qt Creator creates `.qtcreator` directory to store project- specific information, and `build` for the build products.

these changes don't make build with Qt6 possible, but they don't hurt Qt5 build either, and still move Qt6 migration forward.