### PR TITLE
Qt6 compatibility patch 2

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2026, Nick Korotysh
+#pragma once
+
+/*
+ * This file contains various compatibility stuff
+ * to support builds with both Qt 5 and Qt 6.
+ *
+ * It should be dropped with Qt 5 build support.
+ */
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+#include <QString>
+// QString::SplitBehavior is obsolete since Qt 5.14,
+// and was completely removed in Qt 6.
+namespace Qt {
+// create aliases to emulate required values in old Qt
+constexpr auto SkipEmptyParts = QString::SkipEmptyParts;
+}
+#endif

--- a/identifier/biomeidentifier.cpp
+++ b/identifier/biomeidentifier.cpp
@@ -9,6 +9,7 @@ Copyright (c) 2016, EtlamGit
 
 #include "biomeidentifier.h"
 #include "clamp.h"
+#include "compat.h"
 
 // --------- --------- --------- ---------
 // BiomeInfo
@@ -376,7 +377,7 @@ void BiomeIdentifier::parseBiomeDefinitions2800(QJsonArray data18, int pack) {
       else {
         // construct the name from NID
         QString nid = QString(biome->nid).replace("minecraft:","").replace("_"," ").replace(":",": ");
-        QStringList parts = nid.toLower().split(' ', QString::SkipEmptyParts);
+        QStringList parts = nid.toLower().split(' ', Qt::SkipEmptyParts);
         for (int i = 0; i < parts.size(); i++)
           parts[i].replace(0, 1, parts[i][0].toUpper());
         biome->name = parts.join(" ");

--- a/identifier/dimensionidentifier.cpp
+++ b/identifier/dimensionidentifier.cpp
@@ -4,6 +4,7 @@
 
 #include "dimensionidentifier.h"
 #include "worldinfo.h"
+#include "compat.h"
 
 
 //-------------------------------------------------------------------------------------------------
@@ -73,7 +74,7 @@ int DimensionIdentifier::addDefinitions(QJsonArray defs, int pack) {
       dim->id = dimTag.value("id").toString();
       // construct a default name from ID
       QString nid = QString(dim->id).replace("minecraft:","").replace("_"," ");
-      QStringList parts = nid.toLower().split(' ', QString::SkipEmptyParts);
+      QStringList parts = nid.toLower().split(' ', Qt::SkipEmptyParts);
       for (int i = 0; i < parts.size(); i++)
         parts[i].replace(0, 1, parts[i][0].toUpper());
       dim->name = parts.join(" ");

--- a/overlay/generatedstructure.cpp
+++ b/overlay/generatedstructure.cpp
@@ -1,8 +1,10 @@
 /** Copyright 2014 Rian Shelley */
 #include <QPainter>
+#include <QRegularExpression>
 
 #include "overlay/generatedstructure.h"
 #include "nbt/nbt.h"
+#include "compat.h"
 
 
 // parse structures in *.dat files
@@ -100,7 +102,7 @@ GeneratedStructure::tryParseSpawner(const Tag* tagSpawner) {
     mobType = tagSpawner->at("EntityId")->toString();
     // reformat CamelCase text to flattening
     // split at uppercase characters
-    QStringList tokens = mobType.split(QRegExp("(?<=[a-z])(?=[A-Z])"), QString::SkipEmptyParts);
+    QStringList tokens = mobType.split(QRegularExpression("(?<=[a-z])(?=[A-Z])"), Qt::SkipEmptyParts);
     mobType = tokens.join("_").toLower();
   }
   // after "The Flattening"


### PR DESCRIPTION
this patch resolves compatibility issues with QString::split()

- QRegExp -> QRegularExpression migration (in split() cases only)

  QString::split() accepting QRegExp is not available in Qt 6 (also deprecated in Qt 5), so such cases must be migrated. there was only single such case, and it is 1:1 migration.

- QString::SplitBehavior -> Qt::SplitBehavior migration

  QString::SplitBehavior is obsolete since Qt 5.14, and was completely removed in Qt 6. use new values in the codebase and introduce compatibility layer for the older Qt versions.

these changes don't make build with Qt6 possible, but they don't hurt Qt5 build either, and still move Qt6 migration forward.