### PR TITLE
Qt6 compatibility patch 3

### DIFF
--- a/minutor.pro
+++ b/minutor.pro
@@ -2,6 +2,7 @@ TEMPLATE = app
 TARGET = minutor
 CONFIG += c++14
 QT += widgets network concurrent
+greaterThan(QT_MAJOR_VERSION, 5) QT += core5compat
 QMAKE_INFO_PLIST = minutor.plist
 unix:LIBS += -lz
 win32:RC_FILE += winicon.rc

--- a/overlay/propertietreecreator.cpp
+++ b/overlay/propertietreecreator.cpp
@@ -38,7 +38,7 @@ QString EvaluateSubExpression(const QString& subexpr, const QVariant& v) {
     int rightbracket = subexpr.indexOf(']');
     if (rightbracket > 0) {
       bool ok = false;
-      int index = subexpr.midRef(1, rightbracket-1).toInt(&ok);
+      int index = subexpr.mid(1, rightbracket-1).toInt(&ok);
       if (ok && (QMetaType::Type)v.type() == QMetaType::QVariantList) {
         return EvaluateSubExpression(subexpr.mid(rightbracket + 1),
                                      v.toList().at(index));


### PR DESCRIPTION
- conditionally depend on core5compat module

  core5compat contains QRegExp and QStringRef classes that are not available in Qt 6 by default.

- replaced QString::midRef() with QString::mid()

  QString::midRef() is not available in Qt 6 due to QStringRef removal. replacing it with QString::mid() is not the best option as this introduces memory allocation, but the easiest one.

  QStringView can't cover all cases as it is limited in Qt 5. but this can be addressed later with full Qt 6 migration.

these changes don't make build with Qt6 possible, but they don't hurt Qt5 build either, and still move Qt6 migration forward.