### PR TITLE
Add UI setting for zoom follows cursor behavior

### DIFF
--- a/settings.cpp
+++ b/settings.cpp
@@ -58,6 +58,9 @@ Settings::Settings(QWidget *parent) : QDialog(parent) {
   connect(m_ui.radioButton_zoom_alt,   &QRadioButton::toggled,
           this,                        &Settings::toggleModifier4ZoomOut);
 
+  connect(m_ui.checkBox_ZoomFollowsCursor, SIGNAL(toggled(bool)),
+          this, SLOT(toggleZoomFollowsCursor(bool)));
+
   // Load the settings:
   QSettings info;
   auto useDefault = info.value("usedefault", true).toBool();
@@ -79,6 +82,7 @@ Settings::Settings(QWidget *parent) : QDialog(parent) {
   m_ui.checkBox_DefaultLocation->setChecked(useDefault);
   m_ui.checkBox_VerticalDepth->setChecked(verticalDepth);
   m_ui.checkBox_AutoUpdate->setChecked(autoUpdate);
+  m_ui.checkBox_ZoomFollowsCursor->setChecked(zoomFollowsCursor);
   switch (modifier4DepthSlider) {
   case Qt::ControlModifier:
     m_ui.radioButton_depth_ctrl->setChecked(true);
@@ -209,4 +213,10 @@ void Settings::toggleModifier4ZoomOut() {
   }
   QSettings info;
   info.setValue("modifier4ZoomOut", modifier4ZoomOut);
+}
+
+void Settings::toggleZoomFollowsCursor(bool value) {
+  zoomFollowsCursor = value;
+  QSettings info;
+  info.setValue("zoomFollowsCursor", value);
 }

--- a/settings.h
+++ b/settings.h
@@ -35,6 +35,7 @@ class Settings : public QDialog {
   void toggleVerticalDepth(bool on);
   void toggleModifier4DepthSlider();
   void toggleModifier4ZoomOut();
+  void toggleZoomFollowsCursor(bool on);
 
  private:
   Ui::Settings m_ui;

--- a/settings.ui
+++ b/settings.ui
@@ -118,82 +118,96 @@
        <property name="title">
         <string>Mouse Wheel</string>
        </property>
-       <layout class="QHBoxLayout" name="horizontalLayout">
+       <layout class="QVBoxLayout" name="verticalLayout_7">
         <item>
-         <widget class="QGroupBox" name="groupBox_2">
-          <property name="title">
-           <string>Depth Slider</string>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_5">
-           <item>
-            <widget class="QRadioButton" name="radioButton_depth_shift">
-             <property name="text">
-              <string>Shift</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="radioButton_depth_ctrl">
-             <property name="text">
-              <string>Ctrl</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="radioButton_depth_alt">
-             <property name="text">
-              <string>Alt</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QGroupBox" name="groupBox_2">
+            <property name="title">
+             <string>Depth Slider</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_5">
+             <item>
+              <widget class="QRadioButton" name="radioButton_depth_shift">
+               <property name="text">
+                <string>Shift</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="radioButton_depth_ctrl">
+               <property name="text">
+                <string>Ctrl</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="radioButton_depth_alt">
+               <property name="text">
+                <string>Alt</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="groupBox_3">
+            <property name="title">
+             <string>Zoom Out</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_6">
+             <item>
+              <widget class="QRadioButton" name="radioButton_zoom_shift">
+               <property name="text">
+                <string>Shift</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="radioButton_zoom_ctrl">
+               <property name="text">
+                <string>Ctrl</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="radioButton_zoom_alt">
+               <property name="text">
+                <string>Alt</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Without any modifier key, turning the mouse wheel controls zoom IN.</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox_3">
-          <property name="title">
-           <string>Zoom Out</string>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_6">
-           <item>
-            <widget class="QRadioButton" name="radioButton_zoom_shift">
-             <property name="text">
-              <string>Shift</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="radioButton_zoom_ctrl">
-             <property name="text">
-              <string>Ctrl</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="radioButton_zoom_alt">
-             <property name="text">
-              <string>Alt</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="label">
+         <widget class="QCheckBox" name="checkBox_ZoomFollowsCursor">
           <property name="text">
-           <string>Without any modifier key, turning the mouse wheel controls zoom IN.</string>
+           <string>Zoom toward mouse cursor</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-          </property>
-          <property name="wordWrap">
+          <property name="checked">
            <bool>true</bool>
           </property>
          </widget>


### PR DESCRIPTION
## Summary

Minutor already zooms toward the mouse cursor on wheel zoom, but the setting that controls it (`zoomFollowsCursor`) has only ever existed as a hidden `QSettings` value, with no way to change it short of editing settings by hand. The commit that added the behavior, #295 (`36a9d02`), explicitly anticipated this follow-up: "a future commit could expose this setting in the GUI, making it possible to disable the new zoom behavior." This PR adds that checkbox to the Settings dialog.

My use case is comparing the same place in two worlds from different points in time, to spot what changed between them. That comparison works best when the view stays centered on the same spot as you zoom in for a closer look. The cursor-following default instead re-centers on wherever the mouse is, which drifts the framing and pushes the two views out of alignment. Unchecking the box restores center-anchored zoom and holds the framing steady, so the two stay lined up.

## What changed

- A "Zoom toward mouse cursor" checkbox in the Settings dialog, wired to the existing `zoomFollowsCursor` key the same way the other checkboxes are (load, default, save).
- It sits in the existing "Mouse Wheel" group, beside the related "Depth Slider" and "Zoom Out" controls, since the setting only affects wheel zoom, not keyboard zoom.

## Behavior

- Checked (default): wheel zoom keeps the point under the cursor fixed.
- Unchecked: wheel zoom keeps the view center fixed.
- Read live on each wheel event, so it takes effect immediately, with no restart needed.
- The default is unchanged, so existing users see no difference; it only makes the option reachable.

## Screenshot

![Settings dialog with the new checkbox](https://github.com/user-attachments/assets/24934e56-e133-437c-a52f-aff38a42ca54)

## Notes

- No change to the `zoomFollowsCursor` key or its semantics; this only adds the missing UI.
- The slot doesn't emit `settingsUpdated()`: the value is read live at zoom time, so no redraw is needed.
- Builds clean with `qmake && make` (Qt 5).
- The `settings.ui` diff is mostly whitespace. Adding the checkbox below the existing row meant wrapping that row in a vertical layout, which re-indents the surrounding markup. The real change is about 14 lines.